### PR TITLE
chore(git): clean historical CSS and PNG blobs from git history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust build artifacts
 /target/
+crates/tests/target/
 **/*.rs.bk
 *.pdb
 Cargo.lock


### PR DESCRIPTION
## Summary

- Removed stale CSS files from pre-rename crate paths (`burncloud-client-api`, `burncloud-client-models`, `client-api`, `client-models`) that lingered in git history after folder reorganization
- Removed unused `styles.css` from `crates/client/crates/client-api/assets/` — the only code reference in `main.rs` was already commented out
- Removed e2e screenshot artifacts from `crates/tests/target/e2e-screenshots/` and `image.png` — build artifacts should not be in version control
- Added `crates/tests/target/` to `.gitignore` to prevent future inclusion of test build artifacts
- Ran `git filter-repo` to purge orphaned blobs (including a `playwright-report/index.html` 525 KB artifact) from git history

## Impact

- `.git` pack size reduced: ~5.9 MB → ~2.9 MB
- `git clone` will be faster for new contributors
- Git history no longer contains build artifact blobs

## Test plan

- [x] Verify `daisyui.css` and `tailwind.css` (active CSS files) are still present and tracked
- [x] Verify no active code references to removed files
- [x] Verify `.gitignore` correctly excludes `crates/tests/target/`
- [ ] All collaborators should run `git fetch --all && git reset --hard origin/main` after merge (not `git pull`) since all commit hashes changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)