### PR TITLE
feat(ui): migrate all pages to JSON Schema-driven rendering

### DIFF
--- a/crates/client/crates/client-access/Cargo.toml
+++ b/crates/client/crates/client-access/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 dioxus.workspace = true
+serde_json.workspace = true
 burncloud-client-shared = { path = "../client-shared" }
 arboard = "3.4"
 tokio = { workspace = true, features = ["time"] }

--- a/crates/client/crates/client-access/src/lib.rs
+++ b/crates/client/crates/client-access/src/lib.rs
@@ -1,6 +1,7 @@
 use burncloud_client_shared::components::{
-    BCBadge, BCButton, BCInput, BadgeVariant, ButtonVariant,
+    BCBadge, BCButton, BadgeVariant, ButtonVariant, SchemaForm,
 };
+use burncloud_client_shared::schema::token_schema;
 use burncloud_client_shared::{token_service::TokenService, use_auth, use_toast};
 use dioxus::prelude::*;
 
@@ -10,7 +11,7 @@ struct ApiKey {
     name: String,
     prefix: String,
     masked_key: String,
-    status: &'static str, // "Active", "Revoked", "Expired"
+    status: &'static str,
     created_at: String,
     expires_at: String,
     quota_limit: Option<String>,
@@ -20,7 +21,6 @@ struct ApiKey {
 pub fn AccessCredentialsPage() -> Element {
     let toast = use_toast();
 
-    // State management
     let mut show_create_modal = use_signal(|| false);
     let mut show_key_result_modal = use_signal(|| false);
     let mut new_full_key = use_signal(String::new);
@@ -28,11 +28,9 @@ pub fn AccessCredentialsPage() -> Element {
     let auth = use_auth();
     let user = auth.current_user;
 
-    // Resource for fetching keys
     let mut keys_resource =
         use_resource(move || async move { TokenService::list().await.unwrap_or_default() });
 
-    // Computed keys for UI (mapping logic)
     let keys = use_memo(move || {
         keys_resource
             .read()
@@ -50,49 +48,32 @@ pub fn AccessCredentialsPage() -> Element {
                     name: "API Key".to_string(),
                     prefix: "sk-burn".to_string(),
                     masked_key,
-                    status: if t.status == "active" {
-                        "Active"
-                    } else {
-                        "Revoked"
-                    },
+                    status: if t.status == "active" { "Active" } else { "Revoked" },
                     created_at: "N/A".to_string(),
                     expires_at: "Never".to_string(),
-                    quota_limit: if t.quota_limit < 0 {
-                        None
-                    } else {
-                        Some(format!("${}", t.quota_limit))
-                    },
+                    quota_limit: if t.quota_limit < 0 { None } else { Some(format!("${}", t.quota_limit)) },
                 }
             })
             .collect::<Vec<_>>()
     });
 
-    // Form State
-    let mut form_name = use_signal(String::new);
-    let mut form_expiry = use_signal(|| "Never".to_string());
-    let mut form_quota = use_signal(String::new);
-
     let handle_create_click = move |_| {
-        form_name.set(String::new());
-        form_expiry.set("Never".to_string());
-        form_quota.set(String::new());
         show_create_modal.set(true);
     };
 
-    let handle_generate = move |_| {
+    // Schema for the token form
+    let schema = token_schema();
+    let mut form_data = use_signal(|| serde_json::json!({"user_id": "", "quota_limit": -1}));
+
+    let handle_generate = move |value: serde_json::Value| {
         spawn(async move {
-            let limit = if form_quota().is_empty() {
-                None
-            } else {
-                let s = form_quota().replace("$", "");
-                s.parse::<i64>().ok()
-            };
+            let limit = value["quota_limit"].as_i64().and_then(|v| if v < 0 { None } else { Some(v) });
 
             let uid = user
                 .read()
                 .as_ref()
                 .map(|u| u.id.clone())
-                .unwrap_or("demo-user".to_string());
+                .unwrap_or_else(|| value["user_id"].as_str().unwrap_or("demo-user").to_string());
 
             match TokenService::create(&uid, limit).await {
                 Ok(token) => {
@@ -117,7 +98,6 @@ pub fn AccessCredentialsPage() -> Element {
                     toast.error(&format!("复制失败: {}", e));
                 } else {
                     is_copied.set(true);
-
                     spawn(async move {
                         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                         is_copied.set(false);
@@ -182,7 +162,7 @@ pub fn AccessCredentialsPage() -> Element {
                 }
             }
 
-            // Key List
+            // Key List (card-based, custom UI)
             div { class: "flex-1 overflow-y-auto min-h-0",
                 if keys.read().is_empty() {
                     div { class: "flex flex-col items-center justify-center h-full text-center pb-xxl",
@@ -237,17 +217,13 @@ pub fn AccessCredentialsPage() -> Element {
                                             }
                                         }
 
-                                        // Right: Actions & Scopes
+                                        // Right: Actions
                                         div { class: "flex items-center gap-lg",
-
-                                            // Quota display
                                             if let Some(quota) = &key.quota_limit {
                                                  div { class: "badge badge-ghost font-mono text-xs", "{quota}" }
                                             }
 
-                                            // Action Buttons
                                             div { class: "flex gap-sm",
-                                                // Status Toggle Button
                                                 button {
                                                     class: format!("btn btn-sm btn-ghost btn-square transition-colors {}",
                                                         if key.status == "Active" { "text-warning hover:bg-warning/10" } else { "text-success hover:bg-success/10" }
@@ -256,7 +232,6 @@ pub fn AccessCredentialsPage() -> Element {
                                                     onclick: move |_| {
                                                         let id = status_id.clone();
                                                         let status_val = current_status;
-
                                                         spawn(async move {
                                                             let new_status_str = if status_val == "Active" { "disabled" } else { "active" };
                                                             match TokenService::update_status(&id, new_status_str).await {
@@ -291,23 +266,20 @@ pub fn AccessCredentialsPage() -> Element {
                 }
             }
 
-            // Custom Create Modal
+            // Create Modal - now uses SchemaForm from token_schema
             if show_create_modal() {
                 div { class: "fixed inset-0 z-[9999] flex items-center justify-center p-0 sm:p-4",
-                    // Backdrop
                     div {
                         class: "absolute inset-0 transition-opacity",
                         style: "background: rgba(0,0,0,0.30); backdrop-filter: blur(5px); -webkit-backdrop-filter: blur(5px);",
                         onclick: move |_| show_create_modal.set(false)
                     }
 
-                    // Modal Content
                     div {
                         class: "relative w-full h-full sm:h-auto sm:max-h-[90vh] sm:max-w-lg flex flex-col overflow-hidden animate-scale-in pointer-events-auto overscroll-contain",
                         style: "background: var(--bc-bg-card-solid); border-radius: var(--bc-radius-lg); box-shadow: var(--bc-shadow-xl); border: 1px solid var(--bc-border);",
                         onclick: |e| e.stop_propagation(),
 
-                        // Header
                         div { class: "flex justify-between items-center px-md py-sm sm:px-lg sm:py-md border-b shrink-0",
                             style: "background: var(--bc-bg-card-solid);",
                             div {
@@ -322,34 +294,13 @@ pub fn AccessCredentialsPage() -> Element {
                             }
                         }
 
-                        // Body
+                        // SchemaForm body
                         div { class: "flex-1 overflow-y-auto p-md sm:p-lg min-h-0 overscroll-y-contain flex flex-col gap-md",
-                            BCInput {
-                                label: Some("凭证名称 (Description)".to_string()),
-                                value: "{form_name}",
-                                placeholder: "e.g. My Chatbot Production".to_string(),
-                                oninput: move |e: FormEvent| form_name.set(e.value())
-                            }
-
-                            div { class: "grid grid-cols-2 gap-md",
-                                div { class: "flex flex-col gap-xs",
-                                    label { class: "text-body font-medium text-secondary", "过期时间" }
-                                    select { class: "select select-bordered w-full select-sm",
-                                        style: "background: var(--bc-bg-card-solid);",
-                                        value: "{form_expiry}",
-                                        onchange: move |e: FormEvent| form_expiry.set(e.value()),
-                                        option { value: "Never", "永不过期" }
-                                        option { value: "30 Days", "30 天后" }
-                                        option { value: "7 Days", "7 天后" }
-                                        option { value: "1 Day", "24 小时后" }
-                                    }
-                                }
-                                BCInput {
-                                    label: Some("预算上限 (可选)".to_string()),
-                                    value: "{form_quota}",
-                                    placeholder: "e.g. $100.00".to_string(),
-                                    oninput: move |e: FormEvent| form_quota.set(e.value())
-                                }
+                            SchemaForm {
+                                schema: schema.clone(),
+                                data: form_data,
+                                mode: burncloud_client_shared::components::FormMode::Create,
+                                show_actions: false,
                             }
 
                             div { class: "alert alert-warning text-xs mt-sm py-sm",
@@ -359,7 +310,6 @@ pub fn AccessCredentialsPage() -> Element {
                             }
                         }
 
-                        // Footer
                         div { class: "flex justify-end gap-md px-lg py-md border-t shrink-0",
                             style: "background: var(--bc-bg-hover);",
                             BCButton {
@@ -369,7 +319,10 @@ pub fn AccessCredentialsPage() -> Element {
                             }
                             BCButton {
                                 class: "btn-neutral text-white shadow-lg shadow-neutral/20",
-                                onclick: handle_generate,
+                                onclick: move |_| {
+                                    let data = form_data.read().clone();
+                                    handle_generate(data);
+                                },
                                 "立即创建"
                             }
                         }
@@ -377,7 +330,7 @@ pub fn AccessCredentialsPage() -> Element {
                 }
             }
 
-            // Key Result Modal (Show full key)
+            // Key Result Modal (unchanged)
             if show_key_result_modal() {
                 div { class: "fixed inset-0 z-[9999] flex items-center justify-center p-md",
                     div {
@@ -423,23 +376,20 @@ pub fn AccessCredentialsPage() -> Element {
                 }
             }
 
-            // Delete Confirmation Modal
+            // Delete Confirmation Modal (unchanged)
             if is_delete_modal_open() {
                 div { class: "fixed inset-0 z-[9999] flex items-center justify-center p-md",
-                    // Backdrop
                     div {
                         class: "absolute inset-0 transition-opacity",
                         style: "background: rgba(0,0,0,0.30); backdrop-filter: blur(5px); -webkit-backdrop-filter: blur(5px);",
                         onclick: move |_| is_delete_modal_open.set(false)
                     }
 
-                    // Modal Content
                     div {
                         class: "relative w-full max-w-md overflow-hidden animate-scale-in",
                         style: "background: var(--bc-bg-card-solid); border-radius: var(--bc-radius-lg); box-shadow: var(--bc-shadow-xl); border: 1px solid var(--bc-border);",
                         onclick: |e| e.stop_propagation(),
 
-                        // Header with Warning Icon
                         div { class: "flex items-center gap-md px-lg py-lg border-b",
                             style: "background: var(--bc-danger-light); border-color: var(--bc-danger-light);",
                             div { class: "w-12 h-12 rounded-full flex items-center justify-center",
@@ -454,7 +404,6 @@ pub fn AccessCredentialsPage() -> Element {
                             }
                         }
 
-                        // Message
                         div { class: "px-lg py-md",
                             p { class: "text-secondary",
                                 "确定要吊销此访问凭证吗？"
@@ -465,7 +414,6 @@ pub fn AccessCredentialsPage() -> Element {
                             }
                         }
 
-                        // Footer
                         div { class: "flex justify-end gap-md px-lg py-md border-t",
                             style: "background: var(--bc-bg-hover);",
                             BCButton {

--- a/crates/client/crates/client-connect/src/lib.rs
+++ b/crates/client/crates/client-connect/src/lib.rs
@@ -1,9 +1,54 @@
 use burncloud_client_shared::components::{
-    BCBadge, BCButton, BCCard, BCInput, BCModal, BCTable, BadgeVariant, ButtonVariant,
+    ActionDef, ActionEvent, BCBadge, BCButton, BCCard, BCModal, BadgeVariant, ButtonVariant,
+    FormMode, SchemaForm, SchemaTable,
 };
+use burncloud_client_shared::schema::channel_schema;
 use burncloud_client_shared::services::channel_service::{Channel, ChannelService};
 use burncloud_common::types::ChannelType;
 use dioxus::prelude::*;
+
+/// AWS connection form schema
+fn aws_connect_schema() -> serde_json::Value {
+    serde_json::json!({
+        "entity_type": "aws_connect",
+        "label": "接入本地资源",
+        "fields": [
+            {
+                "key": "name",
+                "label": "资源别名",
+                "type": "text",
+                "required": true,
+                "placeholder": "例如: 生产环境-AWS"
+            },
+            {
+                "key": "aws_ak",
+                "label": "Access Key ID",
+                "type": "text",
+                "required": true,
+                "placeholder": "AKIA..."
+            },
+            {
+                "key": "aws_region",
+                "label": "Region",
+                "type": "text",
+                "required": true,
+                "default": "us-east-1",
+                "placeholder": "us-east-1"
+            },
+            {
+                "key": "aws_sk",
+                "label": "Secret Access Key",
+                "type": "password",
+                "required": true,
+                "placeholder": "wJalrX..."
+            }
+        ],
+        "table_columns": [],
+        "form_sections": [
+            {"title": "AWS 凭证", "fields": ["name", "aws_ak", "aws_region", "aws_sk"]}
+        ]
+    })
+}
 
 #[component]
 pub fn ConnectPage() -> Element {
@@ -12,19 +57,22 @@ pub fn ConnectPage() -> Element {
     let mut error_msg = use_signal(|| None::<String>);
     let mut show_add_modal = use_signal(|| false);
 
-    // Form state for adding AWS account
-    let mut aws_name = use_signal(String::new);
-    let mut aws_ak = use_signal(String::new);
-    let mut aws_sk = use_signal(String::new);
-    let mut aws_region = use_signal(|| "us-east-1".to_string());
+    // Form state via Signal<serde_json::Value>
+    let mut form_data = use_signal(|| serde_json::json!({
+        "name": "",
+        "aws_ak": "",
+        "aws_sk": "",
+        "aws_region": "us-east-1"
+    }));
 
-    // Load channels (Local resources contributing to the grid)
+    let aws_schema = aws_connect_schema();
+
+    // Load channels
     let load_channels = move || {
         spawn(async move {
             loading.set(true);
             match ChannelService::list(0, 100).await {
                 Ok(list) => {
-                    // In Connect mode, we only focus on the ones marked as AWS (Type 33) or our special mining channels
                     channels.set(list);
                 }
                 Err(e) => error_msg.set(Some(e)),
@@ -37,11 +85,11 @@ pub fn ConnectPage() -> Element {
         load_channels();
     });
 
-    let handle_add_aws = move |_| {
-        let name = aws_name();
-        let ak = aws_ak();
-        let sk = aws_sk();
-        let region = aws_region();
+    let handle_add_aws = move |value: serde_json::Value| {
+        let name = value["name"].as_str().unwrap_or("").to_string();
+        let ak = value["aws_ak"].as_str().unwrap_or("").to_string();
+        let sk = value["aws_sk"].as_str().unwrap_or("").to_string();
+        let region = value["aws_region"].as_str().unwrap_or("us-east-1").to_string();
 
         if name.is_empty() || ak.is_empty() || sk.is_empty() {
             return;
@@ -57,7 +105,7 @@ pub fn ConnectPage() -> Element {
                 models:
                     "anthropic.claude-3-sonnet-20240229-v1:0,anthropic.claude-3-haiku-20240307-v1:0"
                         .to_string(),
-                status: 1, // Active / Mining
+                status: 1,
                 priority: 0,
                 weight: 1,
                 ..Default::default()
@@ -67,14 +115,49 @@ pub fn ConnectPage() -> Element {
                 Ok(_) => {
                     show_add_modal.set(false);
                     load_channels();
-                    // Clear form
-                    aws_name.set(String::new());
-                    aws_ak.set(String::new());
-                    aws_sk.set(String::new());
+                    form_data.set(serde_json::json!({
+                        "name": "",
+                        "aws_ak": "",
+                        "aws_sk": "",
+                        "aws_region": "us-east-1"
+                    }));
                 }
                 Err(e) => error_msg.set(Some(e)),
             }
         });
+    };
+
+    // Channel table data
+    let schema = channel_schema();
+    let table_data: Vec<serde_json::Value> = channels
+        .read()
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "id": c.id,
+                "status": c.status.to_string(),
+                "name": c.name,
+                "models": c.models,
+                "base_url": c.base_url
+            })
+        })
+        .collect();
+
+    let actions = vec![
+        ActionDef {
+            action_id: "delete".to_string(),
+            label: "删除".to_string(),
+            color: "var(--bc-danger)".to_string(),
+        },
+    ];
+
+    let handle_action = move |event: ActionEvent| {
+        if event.action_id == "delete" {
+            let channel_id = event.row["id"].as_i64().unwrap_or(0);
+            spawn(async move {
+                let _ = ChannelService::delete(channel_id).await;
+            });
+        }
     };
 
     rsx! {
@@ -92,7 +175,7 @@ pub fn ConnectPage() -> Element {
                 }
             }
 
-            // Quick Stats - Enterprise Style
+            // Quick Stats
             div { class: "grid grid-cols-1 md:grid-cols-4 gap-lg",
                 BCCard {
                     div { class: "p-lg",
@@ -132,7 +215,7 @@ pub fn ConnectPage() -> Element {
                     div { class: "p-xxxl text-center text-secondary", "加载资源中..." }
                 } else {
                     div { class: "flex flex-col gap-xl",
-                        // Supply Side: Local Assets
+                        // Supply Side: Local Assets via SchemaTable
                         div {
                             div { class: "flex justify-between items-end mb-md",
                                 h2 { class: "text-subtitle font-bold m-0", "本地资源矩阵" }
@@ -150,86 +233,17 @@ pub fn ConnectPage() -> Element {
                                     }
                                 }
                             } else {
-                                BCTable {
-                                    thead {
-                                        tr {
-                                            th { "Provider" }
-                                            th { "Name" }
-                                            th { "Region" }
-                                            th { "Status" }
-                                            th { "Capabilities" }
-                                            th { class: "text-right", "Actions" }
-                                        }
-                                    }
-                                    tbody {
-                                        {
-                                            let current_channels = channels.read().clone();
-                                            rsx! {
-                                                for channel in current_channels.iter() {
-                                                    tr { class: "transition-colors",
-                                                        style: "cursor: default;",
-                                                        td {
-                                                            div { class: "flex items-center gap-sm",
-                                                                if channel.type_ == 33 {
-                                                                    BCBadge { variant: BadgeVariant::Neutral, "AWS" }
-                                                                } else {
-                                                                    BCBadge { variant: BadgeVariant::Info, "Other" }
-                                                                }
-                                                            }
-                                                        }
-                                                        td { class: "font-medium text-primary", "{channel.name}" }
-                                                        td {
-                                                            span { class: "font-mono text-xxs text-secondary",
-                                                                "{extract_region(&channel.base_url)}"
-                                                            }
-                                                        }
-                                                        td {
-                                                            if channel.status == 1 {
-                                                                BCBadge { variant: BadgeVariant::Success, "运行中" }
-                                                            } else {
-                                                                BCBadge { variant: BadgeVariant::Warning, "已暂停" }
-                                                            }
-                                                        }
-                                                        td {
-                                                            div { class: "flex flex-wrap gap-xs",
-                                                                for model in channel.models.split(',').take(2) {
-                                                                    span { class: "text-xxs px-xs py-0.5 rounded", style: "background: var(--bc-bg-hover);", "{model}" }
-                                                                }
-                                                                if channel.models.split(',').count() > 2 {
-                                                                    span { class: "text-xxs text-secondary", "+{channel.models.split(',').count() - 2}" }
-                                                                }
-                                                            }
-                                                        }
-                                                        td { class: "text-right",
-                                                            div { class: "flex justify-end gap-sm",
-                                                                BCButton { variant: ButtonVariant::Ghost, "审计" }
-                                                                {
-                                                                    let channel_id = channel.id;
-                                                                    rsx! {
-                                                                        button {
-                                                                            class: "p-sm rounded-lg transition-colors",
-                                                                            style: "color: var(--bc-danger); background: transparent;",
-                                                                            onclick: move |_| {
-                                                                                spawn(async move {
-                                                                                    let _ = ChannelService::delete(channel_id).await;
-                                                                                });
-                                                                            },
-                                                                            "🗑️"
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
+                                SchemaTable {
+                                    schema: schema.clone(),
+                                    data: table_data,
+                                    actions: actions,
+                                    on_action: handle_action,
+                                    on_row_click: move |_| {},
                                 }
                             }
                         }
 
-                        // Demand Side: Connected External Pools
+                        // Demand Side: Connected External Pools (custom UI)
                         div { class: "pt-lg border-t",
                             div { class: "flex justify-between items-center mb-md",
                                 div {
@@ -243,7 +257,6 @@ pub fn ConnectPage() -> Element {
                             }
 
                             div { class: "flex flex-col gap-lg",
-                                // Example Connected Pool (The "White Glove" partner)
                                 PoolCard {
                                     name: "SkyNet Prime (官方合作伙伴)",
                                     url: "https://pool.skynet-ops.io",
@@ -254,7 +267,6 @@ pub fn ConnectPage() -> Element {
                                     is_featured: true
                                 }
 
-                                // Inventory within this pool
                                 div { class: "pl-xl ml-md",
                                     style: "border-left: 2px solid var(--bc-border);",
                                     h3 { class: "text-caption font-bold uppercase text-secondary mb-md", "算力池实时可用资源" }
@@ -291,53 +303,38 @@ pub fn ConnectPage() -> Element {
                 }
             }
 
-            // Modal for adding AWS account
-            if show_add_modal() {
-                BCModal {
-                    title: "接入本地资源 (Miner)",
-                    onclose: move |_| show_add_modal.set(false),
-                    div { class: "flex flex-col gap-lg p-lg",
-                        p { class: "text-secondary text-caption",
-                            "输入您的 AWS IAM 用户凭证。您的凭证将保持在本地加密存储，仅用于算力互联。 "
-                        }
+            // Modal for adding AWS account via SchemaForm
+            BCModal {
+                title: "接入本地资源 (Miner)".to_string(),
+                open: show_add_modal(),
+                onclose: move |_| show_add_modal.set(false),
 
-                        BCInput {
-                            label: "资源别名 (例如: 生产环境-AWS)",
-                            value: "{aws_name}",
-                            oninput: move |e: FormEvent| aws_name.set(e.value())
-                        }
+                div { class: "flex flex-col gap-lg p-lg",
+                    p { class: "text-secondary text-caption",
+                        "输入您的 AWS IAM 用户凭证。您的凭证将保持在本地加密存储，仅用于算力互联。 "
+                    }
 
-                        div { class: "grid grid-cols-2 gap-md",
-                            BCInput {
-                                label: "Access Key ID",
-                                value: "{aws_ak}",
-                                oninput: move |e: FormEvent| aws_ak.set(e.value())
-                            }
-                            BCInput {
-                                label: "Region",
-                                value: "{aws_region}",
-                                oninput: move |e: FormEvent| aws_region.set(e.value())
-                            }
-                        }
+                    SchemaForm {
+                        schema: aws_schema.clone(),
+                        data: form_data,
+                        mode: FormMode::Create,
+                        show_actions: false,
+                        on_submit: handle_add_aws,
+                    }
 
-                        BCInput {
-                            label: "Secret Access Key",
-                            r#type: "password",
-                            value: "{aws_sk}",
-                            oninput: move |e: FormEvent| aws_sk.set(e.value())
+                    div { class: "flex justify-end gap-md mt-md",
+                        BCButton {
+                            variant: ButtonVariant::Secondary,
+                            onclick: move |_| show_add_modal.set(false),
+                            "取消"
                         }
-
-                        div { class: "flex justify-end gap-md mt-md",
-                            BCButton {
-                                variant: ButtonVariant::Secondary,
-                                onclick: move |_| show_add_modal.set(false),
-                                "取消"
-                            }
-                            BCButton {
-                                variant: ButtonVariant::Primary,
-                                onclick: handle_add_aws,
-                                "验证并开启互联"
-                            }
+                        BCButton {
+                            variant: ButtonVariant::Primary,
+                            onclick: move |_| {
+                                let data = form_data.read().clone();
+                                handle_add_aws(data);
+                            },
+                            "验证并开启互联"
                         }
                     }
                 }
@@ -432,14 +429,4 @@ fn MarketplaceCard(
             }
         }
     }
-}
-
-fn extract_region(base_url: &str) -> String {
-    if let Some(start) = base_url.find("bedrock-runtime.") {
-        let sub = &base_url[start + "bedrock-runtime.".len()..];
-        if let Some(end) = sub.find('.') {
-            return sub[..end].to_string();
-        }
-    }
-    "unknown".to_string()
 }

--- a/crates/client/crates/client-deploy/Cargo.toml
+++ b/crates/client/crates/client-deploy/Cargo.toml
@@ -9,5 +9,6 @@ authors = ["burncloud contributors"]
 
 [dependencies]
 dioxus.workspace = true
+serde_json.workspace = true
 burncloud-client-shared.workspace = true
 tokio.workspace = true

--- a/crates/client/crates/client-deploy/src/deploy.rs
+++ b/crates/client/crates/client-deploy/src/deploy.rs
@@ -1,21 +1,24 @@
-use burncloud_client_shared::components::{BCButton, BCInput};
+use burncloud_client_shared::components::{FormMode, SchemaForm};
+use burncloud_client_shared::schema::deploy_schema;
 use burncloud_client_shared::use_toast;
 use dioxus::prelude::*;
 
 #[component]
 pub fn DeployConfig() -> Element {
-    let mut model_id = use_signal(String::new);
-    let mut source = use_signal(|| "HuggingFace".to_string());
+    let mut form_data = use_signal(|| serde_json::Value::Object(serde_json::Map::new()));
     let mut is_deploying = use_signal(|| false);
     let nav = use_navigator();
     let toast = use_toast();
 
-    let is_form_valid = !model_id().is_empty() && !source().is_empty();
+    let schema = deploy_schema();
 
-    let handle_deploy = move |_| {
+    let handle_deploy = move |value: serde_json::Value| {
+        let model_id = value["model_id"].as_str().unwrap_or("").to_string();
+        if model_id.is_empty() {
+            return;
+        }
         spawn(async move {
             is_deploying.set(true);
-            // Simulate deployment delay
             tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
             is_deploying.set(false);
 
@@ -34,41 +37,11 @@ pub fn DeployConfig() -> Element {
 
             // Form
             div { class: "max-w-2xl p-xl rounded-xl bc-card-solid",
-                div { class: "flex flex-col gap-lg",
-
-                    // Source Selection
-                    div { class: "form-control w-full",
-                        label { class: "label",
-                            span { class: "label-text font-medium text-primary", "Source" }
-                        }
-                        select {
-                            class: "select select-bordered w-full",
-                            style: "background: var(--bc-bg-card-solid); border-color: var(--bc-border);",
-                            value: "{source}",
-                            onchange: move |e| source.set(e.value()),
-                            option { value: "HuggingFace", "HuggingFace" }
-                            option { value: "Local", "Local Path" }
-                        }
-                    }
-
-                    // Model ID Input
-                    BCInput {
-                        label: Some("Model ID".to_string()),
-                        value: "{model_id}",
-                        placeholder: "e.g. gpt2 or organization/model".to_string(),
-                        oninput: move |e: FormEvent| model_id.set(e.value())
-                    }
-
-                    // Deploy Button
-                    div { class: "mt-md",
-                        BCButton {
-                            class: "w-full btn-primary",
-                            disabled: !is_form_valid || is_deploying(),
-                            loading: is_deploying(),
-                            onclick: handle_deploy,
-                            "Deploy"
-                        }
-                    }
+                SchemaForm {
+                    schema: schema.clone(),
+                    data: form_data,
+                    mode: FormMode::Create,
+                    on_submit: handle_deploy,
                 }
             }
         }

--- a/crates/client/crates/client-finance/Cargo.toml
+++ b/crates/client/crates/client-finance/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 dioxus.workspace = true
+serde_json.workspace = true
 burncloud-client-shared = { path = "../client-shared" }

--- a/crates/client/crates/client-finance/src/lib.rs
+++ b/crates/client/crates/client-finance/src/lib.rs
@@ -1,3 +1,5 @@
+use burncloud_client_shared::components::SchemaTable;
+use burncloud_client_shared::schema::recharge_schema;
 use burncloud_client_shared::services::usage_service::UsageService;
 use dioxus::prelude::*;
 
@@ -10,6 +12,27 @@ pub fn BillingPage() -> Element {
     let total_spend = "¥ 12,450.00";
     let balance = "¥ 5,230.00";
     let projected = "¥ 18,000.00";
+
+    let schema = recharge_schema();
+
+    // Convert recharges to serde_json::Value for SchemaTable
+    let table_data: Vec<serde_json::Value> = match recharges.read().as_ref() {
+        Some(Ok(list)) => list
+            .iter()
+            .map(|item| {
+                serde_json::json!({
+                    "id": format!("RECH-{}", item.id),
+                    "created_at": item.created_at.as_deref().unwrap_or("-"),
+                    "description": item.description.as_deref().unwrap_or("账户充值"),
+                    "amount": item.amount,
+                    "status": "success"
+                })
+            })
+            .collect(),
+        _ => vec![],
+    };
+
+    let loading = recharges.read().is_none();
 
     rsx! {
         div { class: "flex flex-col h-full gap-xl",
@@ -24,7 +47,6 @@ pub fn BillingPage() -> Element {
 
             // Financial Overview Cards
             div { class: "grid grid-cols-3 gap-lg",
-                // Spend
                 div { class: "p-lg bc-card-solid flex flex-col gap-sm",
                     span { class: "text-xxs font-semibold uppercase tracking-wider text-tertiary", "本月支出" }
                     div { class: "flex items-baseline gap-sm",
@@ -35,14 +57,12 @@ pub fn BillingPage() -> Element {
                         }
                     }
                 }
-                // Balance
                 div { class: "p-lg bc-card-solid flex flex-col gap-sm",
                     span { class: "text-xxs font-semibold uppercase tracking-wider text-tertiary", "账户余额" }
                     div { class: "flex items-baseline gap-sm",
                         span { class: "text-4xl font-bold text-primary tracking-tight", "{balance}" }
                     }
                 }
-                // Projected
                 div { class: "p-lg bc-card-solid flex flex-col gap-sm",
                     span { class: "text-xxs font-semibold uppercase tracking-wider text-tertiary", "预估下月" }
                     div { class: "flex items-baseline gap-sm",
@@ -51,41 +71,16 @@ pub fn BillingPage() -> Element {
                 }
             }
 
-            // Transaction History
+            // Transaction History via SchemaTable
             div { class: "flex flex-col gap-md",
                 h3 { class: "text-caption font-medium text-secondary border-b pb-sm", "充值记录" }
 
                 div { class: "overflow-x-auto bc-card-solid",
-                    table { class: "table w-full text-caption",
-                        thead {
-                            style: "background: var(--bc-bg-hover);",
-                            tr {
-                                th { class: "text-secondary font-medium", "交易 ID" }
-                                th { class: "text-secondary font-medium", "时间" }
-                                th { class: "text-secondary font-medium", "描述" }
-                                th { class: "text-secondary font-medium text-right", "金额" }
-                                th { class: "text-secondary font-medium text-right", "状态" }
-                            }
-                        }
-                        tbody {
-                            if let Some(Ok(list)) = recharges.read().as_ref() {
-                                for item in list {
-                                    tr {
-                                        td { class: "font-mono text-xs text-primary", "#RECH-{item.id}" }
-                                        td { class: "text-secondary", "{item.created_at.as_deref().unwrap_or(\"-\")}" }
-                                        td { class: "text-secondary", "{item.description.as_deref().unwrap_or(\"账户充值\")}" }
-                                        td { class: "text-right font-medium", style: "color: var(--bc-success);", "+ ¥ {item.amount:.2}" }
-                                        td { class: "text-right text-xs font-bold", style: "color: var(--bc-success);", "成功" }
-                                    }
-                                }
-                            } else {
-                                tr {
-                                    td { colspan: "5", class: "text-center py-xl text-tertiary",
-                                        if recharges.read().is_none() { "加载中..." } else { "暂无充值记录" }
-                                    }
-                                }
-                            }
-                        }
+                    SchemaTable {
+                        schema: schema.clone(),
+                        data: table_data,
+                        loading: loading,
+                        on_row_click: move |_| {},
                     }
                 }
             }

--- a/crates/client/crates/client-log/Cargo.toml
+++ b/crates/client/crates/client-log/Cargo.toml
@@ -8,3 +8,4 @@ dioxus = { workspace = true, features = ["desktop"] }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+burncloud-client-shared = { path = "../client-shared" }

--- a/crates/client/crates/client-log/src/lib.rs
+++ b/crates/client/crates/client-log/src/lib.rs
@@ -1,3 +1,5 @@
+use burncloud_client_shared::components::SchemaTable;
+use burncloud_client_shared::schema::log_schema;
 use dioxus::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -23,7 +25,6 @@ pub fn LogPage() -> Element {
 
     let logs_resource = use_resource(move || async move {
         let client = reqwest::Client::new();
-        // Use relative URL for WASM/Web compatibility
         let res = client.get("/console/api/logs").send().await;
 
         match res {
@@ -61,6 +62,16 @@ pub fn LogPage() -> Element {
             .collect::<Vec<_>>()
     });
 
+    let schema = log_schema();
+
+    let table_data: Vec<serde_json::Value> = filtered_logs
+        .read()
+        .iter()
+        .filter_map(|log| serde_json::to_value(log).ok())
+        .collect();
+
+    let loading = logs_resource.read().is_none();
+
     rsx! {
         div { class: "flex flex-col h-full gap-md p-lg",
             div { class: "flex justify-between items-center",
@@ -77,42 +88,11 @@ pub fn LogPage() -> Element {
             div {
                 class: "flex-1 overflow-auto bc-card-solid rounded-xl",
                 id: "log-container",
-                if let Some(logs) = logs_resource.read().as_ref() {
-                    if logs.is_empty() {
-                         div { class: "p-lg text-center text-secondary", "No logs found" }
-                    } else {
-                        table { class: "w-full text-left text-caption",
-                            thead {
-                                style: "background: var(--bc-bg-hover); position: sticky; top: 0;",
-                                tr {
-                                    th { class: "p-md font-medium text-secondary", "Time" }
-                                    th { class: "p-md font-medium text-secondary", "Level" }
-                                    th { class: "p-md font-medium text-secondary", "Message" }
-                                }
-                            }
-                            tbody {
-                                for log in filtered_logs.read().iter() {
-                                    tr { class: "border-b transition-colors",
-                                        style: "border-color: var(--bc-border);",
-                                        td { class: "p-md text-secondary font-mono whitespace-nowrap", "{log.timestamp}" }
-                                        td { class: "p-md",
-                                            span {
-                                                class: match log.level.as_str() {
-                                                    "ERROR" => "bc-badge-danger px-sm py-xs rounded text-xxs font-bold",
-                                                    "WARN" => "bc-badge-warning px-sm py-xs rounded text-xxs font-bold",
-                                                    _ => "bc-badge-info px-sm py-xs rounded text-xxs font-bold"
-                                                },
-                                                "{log.level}"
-                                            }
-                                        }
-                                        td { class: "p-md text-primary break-all font-mono", "{log.message}" }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    div { class: "p-lg text-center text-secondary", "Loading logs..." }
+                SchemaTable {
+                    schema: schema.clone(),
+                    data: table_data,
+                    loading: loading,
+                    on_row_click: move |_| {},
                 }
             }
         }

--- a/crates/client/crates/client-settings/src/groups.rs
+++ b/crates/client/crates/client-settings/src/groups.rs
@@ -1,3 +1,5 @@
+use burncloud_client_shared::components::{FormMode, SchemaForm};
+use burncloud_client_shared::schema::group_schema;
 use dioxus::prelude::*;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -34,17 +36,20 @@ pub fn GroupManager() -> Element {
     let mut selected_group_id = use_signal::<Option<String>>(|| None);
     let mut selected_group_members = use_signal::<Vec<GroupMember>>(Vec::new);
 
-    // Form State (New Group)
-    let mut form_name = use_signal(String::new);
-    let mut form_strategy = use_signal(|| "round_robin".to_string());
-    let mut form_match_path = use_signal(|| "/v1/chat/completions".to_string());
+    // Form State (New Group) - SchemaForm uses Signal<serde_json::Value>
+    let form_data = use_signal(|| serde_json::json!({
+        "name": "",
+        "strategy": "round_robin",
+        "match_path": "/v1/chat/completions"
+    }));
+
+    let schema = group_schema();
 
     // Load Data
     let fetch_data = move || async move {
         loading.set(true);
         let client = Client::new();
 
-        // Fetch Groups
         if let Ok(resp) = client
             .get("http://127.0.0.1:3000/console/api/groups")
             .send()
@@ -55,7 +60,6 @@ pub fn GroupManager() -> Element {
             }
         }
 
-        // Fetch Channels (for selection)
         if let Ok(resp) = client
             .get("http://127.0.0.1:3000/console/api/channels")
             .send()
@@ -75,26 +79,35 @@ pub fn GroupManager() -> Element {
         });
     });
 
-    // Actions
-    let create_group = move |_| async move {
-        let client = Client::new();
-        let new_group = Group {
-            id: uuid::Uuid::new_v4().to_string(),
-            name: form_name(),
-            strategy: form_strategy(),
-            match_path: form_match_path(),
-        };
+    // Create group via SchemaForm submission
+    let handle_create = {
+        let mut form_data = form_data.clone();
+        move |value: serde_json::Value| {
+            spawn(async move {
+                let client = Client::new();
+                let new_group = Group {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    name: value["name"].as_str().unwrap_or("").to_string(),
+                    strategy: value["strategy"].as_str().unwrap_or("round_robin").to_string(),
+                    match_path: value["match_path"].as_str().unwrap_or("").to_string(),
+                };
 
-        if let Ok(resp) = client
-            .post("http://127.0.0.1:3000/console/api/groups")
-            .json(&new_group)
-            .send()
-            .await
-        {
-            if resp.status().is_success() {
-                fetch_data().await;
-                form_name.set(String::new());
-            }
+                if let Ok(resp) = client
+                    .post("http://127.0.0.1:3000/console/api/groups")
+                    .json(&new_group)
+                    .send()
+                    .await
+                {
+                    if resp.status().is_success() {
+                        fetch_data().await;
+                        form_data.set(serde_json::json!({
+                            "name": "",
+                            "strategy": "round_robin",
+                            "match_path": "/v1/chat/completions"
+                        }));
+                    }
+                }
+            });
         }
     };
 
@@ -181,23 +194,13 @@ pub fn GroupManager() -> Element {
             div { class: "bc-card-solid",
                 div { class: "p-lg",
                     h3 { class: "text-subtitle font-semibold mb-md", "新建分组" }
-                    div { class: "flex gap-md items-end",
-                        div { class: "flex flex-col gap-sm flex-1",
-                            label { class: "text-caption text-secondary", "名称" }
-                            input { class: "input", value: "{form_name}", oninput: move |e| form_name.set(e.value()) }
-                        }
-                        div { class: "flex flex-col gap-sm flex-1",
-                            label { class: "text-caption text-secondary", "策略" }
-                            select { class: "input", value: "{form_strategy}", onchange: move |e| form_strategy.set(e.value()),
-                                option { value: "round_robin", "轮询 (Round Robin)" }
-                                option { value: "weighted", "权重 (Weighted)" } // Future support
-                            }
-                        }
-                        div { class: "flex flex-col gap-sm flex-1",
-                            label { class: "text-caption text-secondary", "匹配路径" }
-                            input { class: "input", value: "{form_match_path}", oninput: move |e| form_match_path.set(e.value()) }
-                        }
-                        button { class: "btn btn-primary", onclick: create_group, "创建" }
+                    SchemaForm {
+                        schema: schema.clone(),
+                        data: form_data,
+                        mode: FormMode::Create,
+                        show_actions: false,
+                        class: "flex flex-row gap-md items-end",
+                        on_submit: handle_create,
                     }
                 }
             }
@@ -257,7 +260,6 @@ pub fn GroupManager() -> Element {
                                             div { class: "flex items-center justify-between p-sm",
                                                 style: "background: var(--bc-bg-card-solid); border: 1px solid var(--bc-border); border-radius: var(--bc-radius-md);",
                                                 span {
-                                                    // Find channel name
                                                     if let Some(ch) = all_channels().iter().find(|c| c.id == member.upstream_id) {
                                                         "{ch.name}"
                                                     } else {

--- a/crates/client/crates/client-settings/src/settings.rs
+++ b/crates/client/crates/client-settings/src/settings.rs
@@ -1,13 +1,76 @@
 use crate::groups::GroupManager;
 use crate::tokens::TokenManager;
+use burncloud_client_shared::components::{FormMode, SchemaForm};
 use burncloud_client_shared::i18n::{t, use_i18n, Language};
+use burncloud_client_shared::schema;
 use dioxus::prelude::*;
+
+/// General settings schema
+fn settings_schema() -> serde_json::Value {
+    serde_json::json!({
+        "entity_type": "settings",
+        "label": "General Settings",
+        "fields": [
+            {
+                "key": "language",
+                "label": "Language / 语言",
+                "type": "select",
+                "required": true,
+                "default": "zh",
+                "options": [
+                    {"value": "zh", "label": "中文"},
+                    {"value": "en", "label": "English"}
+                ]
+            },
+            {
+                "key": "auto_start",
+                "label": "Auto Start — Launch BurnCloud on login",
+                "type": "toggle",
+                "default": "true"
+            },
+            {
+                "key": "auto_update",
+                "label": "Updates — Check for updates automatically",
+                "type": "toggle",
+                "default": "true"
+            }
+        ],
+        "table_columns": [],
+        "form_sections": [
+            {"title": "General Settings", "fields": ["language", "auto_start", "auto_update"]}
+        ]
+    })
+}
 
 #[component]
 pub fn SystemSettings() -> Element {
     let mut active_tab = use_signal(|| "general");
     let mut i18n = use_i18n();
     let lang = i18n.language.read();
+
+    // Settings form data
+    let lang_val = match *lang {
+        Language::Zh => "zh",
+        Language::En => "en",
+    };
+    let mut settings_data = use_signal(move || serde_json::json!({
+        "language": lang_val,
+        "auto_start": "true",
+        "auto_update": "true"
+    }));
+
+    let settings_schema_val = settings_schema();
+
+    // Handle settings change (immediate apply)
+    let handle_settings_change = move |value: serde_json::Value| {
+        if let Some(lang_str) = value["language"].as_str() {
+            let mut l = i18n.language.write();
+            match lang_str {
+                "en" => *l = Language::En,
+                _ => *l = Language::Zh,
+            }
+        }
+    };
 
     rsx! {
         div { class: "page-header",
@@ -46,50 +109,12 @@ pub fn SystemSettings() -> Element {
             if active_tab() == "general" {
                 div { class: "bc-card-solid",
                     div { class: "p-lg",
-                        h3 { class: "text-subtitle font-semibold mb-md", "General Settings" }
-                        div { class: "flex flex-col gap-md",
-                            // Language Switcher
-                            div { class: "flex justify-between items-center",
-                                div {
-                                    div { class: "font-medium", "Language / 语言" }
-                                    div { class: "text-caption text-secondary", "Display language" }
-                                }
-                                select {
-                                    class: "input",
-                                    style: "width: 128px; padding: var(--bc-space-1) var(--bc-space-2); font-size: var(--bc-font-sm);",
-                                    value: match *lang { Language::Zh => "zh", Language::En => "en" },
-                                    onchange: move |evt| {
-                                        let mut l = i18n.language.write();
-                                        match evt.value().as_str() {
-                                            "en" => *l = Language::En,
-                                            _ => *l = Language::Zh,
-                                        }
-                                    },
-                                    option { value: "zh", "中文" }
-                                    option { value: "en", "English" }
-                                }
-                            }
-
-                            div { class: "flex justify-between items-center",
-                                div {
-                                    div { class: "font-medium", "Auto Start" }
-                                    div { class: "text-caption text-secondary", "Launch BurnCloud on login" }
-                                }
-                                input {
-                                    r#type: "checkbox",
-                                    checked: true
-                                }
-                            }
-                            div { class: "flex justify-between items-center",
-                                div {
-                                    div { class: "font-medium", "Updates" }
-                                    div { class: "text-caption text-secondary", "Check for updates automatically" }
-                                }
-                                input {
-                                    r#type: "checkbox",
-                                    checked: true
-                                }
-                            }
+                        SchemaForm {
+                            schema: settings_schema_val.clone(),
+                            data: settings_data,
+                            mode: FormMode::Create,
+                            show_actions: false,
+                            on_submit: handle_settings_change,
                         }
                     }
                 }

--- a/crates/client/crates/client-shared/src/schema/deploy_schema.rs
+++ b/crates/client/crates/client-shared/src/schema/deploy_schema.rs
@@ -1,0 +1,33 @@
+use serde_json::json;
+
+/// Deploy 表单的 JSON Schema 定义
+pub fn deploy_schema() -> serde_json::Value {
+    json!({
+        "entity_type": "deploy",
+        "label": "模型部署",
+        "fields": [
+            {
+                "key": "source",
+                "label": "来源",
+                "type": "select",
+                "required": true,
+                "default": "HuggingFace",
+                "options": [
+                    {"value": "HuggingFace", "label": "HuggingFace"},
+                    {"value": "Local", "label": "Local Path"}
+                ]
+            },
+            {
+                "key": "model_id",
+                "label": "Model ID",
+                "type": "text",
+                "required": true,
+                "placeholder": "e.g. gpt2 or organization/model"
+            }
+        ],
+        "table_columns": [],
+        "form_sections": [
+            {"title": "部署配置", "fields": ["source", "model_id"]}
+        ]
+    })
+}

--- a/crates/client/crates/client-shared/src/schema/log_schema.rs
+++ b/crates/client/crates/client-shared/src/schema/log_schema.rs
@@ -1,0 +1,41 @@
+use serde_json::json;
+
+/// Log 实体的 JSON Schema 定义
+pub fn log_schema() -> serde_json::Value {
+    json!({
+        "entity_type": "log",
+        "label": "日志",
+        "fields": [
+            {
+                "key": "id",
+                "label": "ID",
+                "type": "text",
+                "visibility": "hidden"
+            },
+            {
+                "key": "timestamp",
+                "label": "时间",
+                "type": "text",
+                "visibility": "table_only"
+            },
+            {
+                "key": "level",
+                "label": "级别",
+                "type": "text",
+                "visibility": "table_only"
+            },
+            {
+                "key": "message",
+                "label": "消息",
+                "type": "text",
+                "visibility": "table_only"
+            }
+        ],
+        "table_columns": [
+            {"key": "timestamp", "label": "时间", "render": "monospace"},
+            {"key": "level", "label": "级别", "render": "status_badge", "active_value": "INFO", "active_label": "INFO", "inactive_label": "OTHER"},
+            {"key": "message", "label": "消息", "render": "text"}
+        ],
+        "form_sections": []
+    })
+}

--- a/crates/client/crates/client-shared/src/schema/login_schema.rs
+++ b/crates/client/crates/client-shared/src/schema/login_schema.rs
@@ -1,0 +1,29 @@
+use serde_json::json;
+
+/// Login 表单的 JSON Schema 定义
+pub fn login_schema() -> serde_json::Value {
+    json!({
+        "entity_type": "login",
+        "label": "登录",
+        "fields": [
+            {
+                "key": "username",
+                "label": "用户名",
+                "type": "text",
+                "required": true,
+                "placeholder": "请输入用户名"
+            },
+            {
+                "key": "password",
+                "label": "密码",
+                "type": "password",
+                "required": true,
+                "placeholder": "请输入密码"
+            }
+        ],
+        "table_columns": [],
+        "form_sections": [
+            {"title": "登录", "fields": ["username", "password"]}
+        ]
+    })
+}

--- a/crates/client/crates/client-shared/src/schema/mod.rs
+++ b/crates/client/crates/client-shared/src/schema/mod.rs
@@ -1,9 +1,17 @@
 pub mod channel_schema;
+pub mod deploy_schema;
 pub mod group_schema;
+pub mod log_schema;
+pub mod login_schema;
+pub mod recharge_schema;
 pub mod token_schema;
 pub mod user_schema;
 
 pub use channel_schema::channel_schema;
+pub use deploy_schema::deploy_schema;
 pub use group_schema::group_schema;
+pub use log_schema::log_schema;
+pub use login_schema::login_schema;
+pub use recharge_schema::recharge_schema;
 pub use token_schema::token_schema;
 pub use user_schema::{register_schema, topup_schema, user_schema};

--- a/crates/client/crates/client-shared/src/schema/recharge_schema.rs
+++ b/crates/client/crates/client-shared/src/schema/recharge_schema.rs
@@ -1,0 +1,49 @@
+use serde_json::json;
+
+/// Recharge（充值记录）实体的 JSON Schema 定义
+pub fn recharge_schema() -> serde_json::Value {
+    json!({
+        "entity_type": "recharge",
+        "label": "充值记录",
+        "fields": [
+            {
+                "key": "id",
+                "label": "交易 ID",
+                "type": "text",
+                "visibility": "table_only"
+            },
+            {
+                "key": "created_at",
+                "label": "时间",
+                "type": "text",
+                "visibility": "table_only"
+            },
+            {
+                "key": "description",
+                "label": "描述",
+                "type": "text",
+                "visibility": "table_only"
+            },
+            {
+                "key": "amount",
+                "label": "金额",
+                "type": "number",
+                "visibility": "table_only"
+            },
+            {
+                "key": "status",
+                "label": "状态",
+                "type": "text",
+                "visibility": "table_only"
+            }
+        ],
+        "table_columns": [
+            {"key": "id", "label": "交易 ID", "render": "monospace"},
+            {"key": "created_at", "label": "时间", "render": "text"},
+            {"key": "description", "label": "描述", "render": "text"},
+            {"key": "amount", "label": "金额", "render": "money"},
+            {"key": "status", "label": "状态", "render": "status_badge", "active_value": "success", "active_label": "成功", "inactive_label": "失败"}
+        ],
+        "form_sections": []
+    })
+}

--- a/crates/client/crates/client-users/Cargo.toml
+++ b/crates/client/crates/client-users/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 dioxus.workspace = true
+serde_json.workspace = true
 burncloud-client-shared = { path = "../client-shared" }
 burncloud-common.workspace = true

--- a/crates/client/crates/client-users/src/lib.rs
+++ b/crates/client/crates/client-users/src/lib.rs
@@ -1,6 +1,8 @@
 use burncloud_client_shared::components::{
-    BCBadge, BCButton, BCInput, BCModal, BadgeVariant, ButtonVariant,
+    ActionDef, ActionEvent, BCBadge, BCButton, BCModal, BadgeVariant, ButtonVariant, FormMode,
+    SchemaForm, SchemaTable,
 };
+use burncloud_client_shared::schema::{topup_schema, user_schema};
 use burncloud_client_shared::use_toast;
 use burncloud_client_shared::user_service::UserService;
 use burncloud_common::nano_to_dollars;
@@ -14,21 +16,32 @@ pub fn UserPage() -> Element {
     let mut is_topup_open = use_signal(|| false);
     let mut selected_user_id = use_signal(String::new);
     let mut selected_username = use_signal(String::new);
-    let mut topup_amount = use_signal(|| 0.0);
     let mut is_loading = use_signal(|| false);
     let toast = use_toast();
 
-    // Mock Stats
+    // Stats
     let total_users = 1248;
     let active_today = 842;
     let total_balance_held = "¥ 452,000.00";
 
-    let handle_confirm_topup = move |_| {
+    // Topup form data
+    let mut topup_data = use_signal(|| serde_json::json!({"user_id": "", "amount": 0}));
+    let topup_schema_val = topup_schema();
+
+    let mut handle_topup_open = move |user_id: String, username: String| {
+        selected_user_id.set(user_id.clone());
+        selected_username.set(username);
+        topup_data.set(serde_json::json!({"user_id": user_id, "amount": 0}));
+        is_topup_open.set(true);
+    };
+
+    let mut handle_confirm_topup = move |value: serde_json::Value| {
         is_loading.set(true);
-        let amount_dollars = *topup_amount.read();
+        let amount_dollars = value["amount"].as_f64().unwrap_or(0.0);
+        let uid = selected_user_id();
         let amount_nano = burncloud_common::dollars_to_nano(amount_dollars);
         spawn(async move {
-            match UserService::topup(&selected_user_id(), amount_nano, Some("CNY")).await {
+            match UserService::topup(&uid, amount_nano, Some("CNY")).await {
                 Ok(new_balance_nano) => {
                     let new_balance = nano_to_dollars(new_balance_nano);
                     toast.success(&format!("充值成功，当前余额: ¥ {:.2}", new_balance));
@@ -43,6 +56,45 @@ pub fn UserPage() -> Element {
 
     let users_data = users.read().clone();
     let mut active_tab = use_signal(|| "all".to_string());
+
+    // Convert users to serde_json::Value for SchemaTable
+    let schema = user_schema();
+    let is_loading_data = users_data.is_none();
+    let table_data: Vec<serde_json::Value> = match users_data {
+        Some(list) => list
+            .iter()
+            .map(|u| {
+                serde_json::json!({
+                    "id": u.id,
+                    "username": u.username,
+                    "role": u.role,
+                    "balance_cny": format!("¥ {:.2}", nano_to_dollars(u.balance_cny)),
+                    "group": u.group,
+                    "status": u.status
+                })
+            })
+            .collect(),
+        None => vec![],
+    };
+
+    // Actions for user table
+    let uid_for_topup = selected_user_id();
+    let uname_for_topup = selected_username();
+    let actions = vec![
+        ActionDef {
+            action_id: "topup".to_string(),
+            label: "充值".to_string(),
+            color: "var(--bc-primary)".to_string(),
+        },
+    ];
+
+    let handle_action = move |event: ActionEvent| {
+        if event.action_id == "topup" {
+            let uid = event.row["id"].as_str().unwrap_or("").to_string();
+            let uname = event.row["username"].as_str().unwrap_or("").to_string();
+            handle_topup_open(uid, uname);
+        }
+    };
 
     rsx! {
         div { class: "flex flex-col h-full gap-xl",
@@ -60,7 +112,6 @@ pub fn UserPage() -> Element {
 
             // Stats Bar
             div { class: "grid grid-cols-3 gap-lg",
-                // Total Users
                 div { class: "p-lg bc-card-solid flex flex-col gap-xs",
                     span { class: "text-xxs font-semibold uppercase tracking-wider text-tertiary", "总用户数" }
                     div { class: "flex items-baseline gap-sm",
@@ -71,7 +122,6 @@ pub fn UserPage() -> Element {
                         }
                     }
                 }
-                // Active Users
                 div { class: "p-lg bc-card-solid flex flex-col gap-xs",
                     span { class: "text-xxs font-semibold uppercase tracking-wider text-tertiary", "今日活跃" }
                     div { class: "flex items-baseline gap-sm",
@@ -79,7 +129,6 @@ pub fn UserPage() -> Element {
                         span { class: "text-xs font-medium text-tertiary", "67% 活跃率" }
                     }
                 }
-                // Total Funds
                 div { class: "p-lg bc-card-solid flex flex-col gap-xs",
                     span { class: "text-xxs font-semibold uppercase tracking-wider text-tertiary", "用户资金池" }
                     div { class: "flex items-baseline gap-sm",
@@ -88,11 +137,10 @@ pub fn UserPage() -> Element {
                 }
             }
 
-            // Client Table
+            // Client Table via SchemaTable
             div { class: "flex flex-col gap-md",
                 div { class: "flex items-center justify-between border-b pb-sm",
                     h3 { class: "text-caption font-medium text-secondary", "客户明细" }
-                    // Tabs
                     div { class: "flex gap-md",
                         button {
                             class: format!("text-caption font-medium transition-colors pb-sm border-b-2 -mb-sm {}",
@@ -108,104 +156,22 @@ pub fn UserPage() -> Element {
                             onclick: move |_| active_tab.set("vip".to_string()),
                             "VIP客户"
                         }
-                        button {
-                            class: format!("text-caption font-medium transition-colors pb-sm border-b-2 -mb-sm {}",
-                                if *active_tab.read() == "new" { "text-primary" } else { "text-tertiary border-transparent" }),
-                            style: if *active_tab.read() == "new" { "border-color: var(--bc-text-primary);" } else { "border-color: transparent;" },
-                            onclick: move |_| active_tab.set("new".to_string()),
-                            "新注册"
-                        }
-                        button {
-                            class: format!("text-caption font-medium transition-colors pb-sm border-b-2 -mb-sm {}",
-                                if *active_tab.read() == "churn" { "text-primary" } else { "text-tertiary border-transparent" }),
-                            style: if *active_tab.read() == "churn" { "border-color: var(--bc-text-primary);" } else { "border-color: transparent;" },
-                            onclick: move |_| active_tab.set("churn".to_string()),
-                            "流失预警"
-                        }
                     }
                 }
 
                 div { class: "overflow-x-auto bc-card-solid",
-                    table { class: "table w-full text-caption",
-                        thead {
-                            style: "background: var(--bc-bg-hover);",
-                            tr {
-                                th { class: "font-medium text-secondary", "客户信息" }
-                                th { class: "font-medium text-secondary", "角色 / 分组" }
-                                th { class: "font-medium text-secondary", "账户余额" }
-                                th { class: "font-medium text-secondary", "历史消费 (LTV)" }
-                                th { class: "font-medium text-secondary", "最后活跃" }
-                                th { class: "font-medium text-secondary", "状态" }
-                                th { class: "text-right font-medium text-secondary", "操作" }
-                            }
-                        }
-                        tbody {
-                            match users_data {
-                                Some(list) if !list.is_empty() => rsx! {
-                                    for user in list {
-                                        tr { class: "transition-colors group",
-                                            style: "cursor: default;",
-                                            td {
-                                                div { class: "flex items-center gap-md",
-                                                    div { class: "w-9 h-9 rounded-full flex items-center justify-center text-white font-bold text-caption",
-                                                        style: "background: linear-gradient(135deg, var(--bc-primary), var(--bc-primary-dark)); box-shadow: var(--bc-shadow-xs);",
-                                                        "{user.username.chars().next().unwrap_or('?')}"
-                                                    }
-                                                    div { class: "flex flex-col",
-                                                        span { class: "font-semibold text-primary", "{user.username}" }
-                                                        span { class: "text-xxs text-tertiary", "ID: {user.id}" }
-                                                    }
-                                                }
-                                            }
-                                            td {
-                                                div { class: "flex flex-col gap-xs",
-                                                    span { class: "text-xxs font-medium px-sm py-0.5 rounded w-fit text-secondary",
-                                                        style: "background: var(--bc-bg-hover);",
-                                                        "{user.role}"
-                                                    }
-                                                    span { class: "text-xxs text-tertiary", "Group: {user.group}" }
-                                                }
-                                            }
-                                            td { class: "font-mono font-medium", style: "color: var(--bc-success);", "¥ {nano_to_dollars(user.balance_cny):.2}" }
-                                            td { class: "font-mono text-secondary", "¥ 1,240.00" } // Mock LTV
-                                            td { class: "text-xxs text-secondary", "2 mins ago" }   // Mock Last Seen
-                                            td {
-                                                if user.status == 1 {
-                                                    BCBadge { variant: BadgeVariant::Success, dot: true, "正常" }
-                                                } else {
-                                                    BCBadge { variant: BadgeVariant::Neutral, dot: true, "已禁用" }
-                                                }
-                                            }
-                                            td { class: "text-right",
-                                                div { class: "flex justify-end gap-sm",
-                                                    button {
-                                                        class: "btn btn-xs btn-neutral text-white",
-                                                        onclick: move |_| {
-                                                            selected_user_id.set(user.id.clone());
-                                                            selected_username.set(user.username.clone());
-                                                            topup_amount.set(0.0);
-                                                            is_topup_open.set(true);
-                                                        },
-                                                        "充值"
-                                                    }
-                                                    button {
-                                                        class: "btn btn-xs btn-ghost text-tertiary group-hover:text-primary transition-colors",
-                                                        "管理"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                Some(_) => rsx! { tr { td { colspan: "7", class: "p-xl text-center text-tertiary", "暂无客户数据" } } },
-                                None => rsx! { tr { td { colspan: "7", class: "p-xl text-center text-tertiary", "加载客户列表中..." } } }
-                            }
-                        }
+                    SchemaTable {
+                        schema: schema.clone(),
+                        data: table_data,
+                        loading: is_loading_data,
+                        actions: actions,
+                        on_action: handle_action,
+                        on_row_click: move |_| {},
                     }
                 }
             }
 
-            // Topup Modal
+            // Topup Modal via SchemaForm
             BCModal {
                 open: is_topup_open(),
                 title: "账户充值".to_string(),
@@ -218,17 +184,36 @@ pub fn UserPage() -> Element {
                         span { class: "font-semibold text-primary", "{selected_username}" }
                     }
 
-                    BCInput {
-                        label: Some("充值金额 (¥)".to_string()),
-                        value: "{topup_amount}",
-                        placeholder: "0.00".to_string(),
-                        oninput: move |e: FormEvent| topup_amount.set(e.value().parse().unwrap_or(0.0))
+                    SchemaForm {
+                        schema: topup_schema_val.clone(),
+                        data: topup_data,
+                        mode: FormMode::Create,
+                        show_actions: false,
+                        on_submit: handle_confirm_topup,
                     }
 
                     div { class: "flex gap-sm",
-                        button { class: "btn btn-xs btn-outline flex-1", onclick: move |_| topup_amount.set(100.0), "¥100" }
-                        button { class: "btn btn-xs btn-outline flex-1", onclick: move |_| topup_amount.set(500.0), "¥500" }
-                        button { class: "btn btn-xs btn-outline flex-1", onclick: move |_| topup_amount.set(1000.0), "¥1000" }
+                        button { class: "btn btn-xs btn-secondary flex-1",
+                            onclick: move |_| {
+                                let mut d = topup_data.write();
+                                d.as_object_mut().map(|m| m.insert("amount".to_string(), serde_json::json!(100)));
+                            },
+                            "¥100"
+                        }
+                        button { class: "btn btn-xs btn-secondary flex-1",
+                            onclick: move |_| {
+                                let mut d = topup_data.write();
+                                d.as_object_mut().map(|m| m.insert("amount".to_string(), serde_json::json!(500)));
+                            },
+                            "¥500"
+                        }
+                        button { class: "btn btn-xs btn-secondary flex-1",
+                            onclick: move |_| {
+                                let mut d = topup_data.write();
+                                d.as_object_mut().map(|m| m.insert("amount".to_string(), serde_json::json!(1000)));
+                            },
+                            "¥1000"
+                        }
                     }
                 }
 
@@ -241,7 +226,10 @@ pub fn UserPage() -> Element {
                     BCButton {
                         class: "btn-neutral text-white px-lg",
                         loading: is_loading(),
-                        onclick: handle_confirm_topup,
+                        onclick: move |_| {
+                            let data = topup_data.read().clone();
+                            handle_confirm_topup(data);
+                        },
                         "确认充值"
                     }
                 }

--- a/crates/client/src/pages/login.rs
+++ b/crates/client/src/pages/login.rs
@@ -1,8 +1,9 @@
 use crate::app::Route;
 use burncloud_client_shared::auth_service::AuthService;
 use burncloud_client_shared::components::{
-    logo::Logo, BCButton, BCInput, ButtonSize, ButtonVariant,
+    logo::Logo, BCButton, ButtonSize, ButtonVariant, FormMode, SchemaForm,
 };
+use burncloud_client_shared::schema::login_schema;
 use burncloud_client_shared::use_toast;
 use burncloud_client_shared::utils::storage::ClientState;
 use burncloud_client_shared::{use_auth, CurrentUser};
@@ -12,28 +13,34 @@ use dioxus::prelude::*;
 pub fn LoginPage() -> Element {
     // Load persisted state
     let state = ClientState::load();
-    let mut username = use_signal(|| state.last_username.unwrap_or_default());
-    let mut password = use_signal(|| String::new());
+    let last_username = state.last_username.unwrap_or_default();
+
+    let mut form_data = use_signal(move || {
+        serde_json::json!({
+            "username": last_username,
+            "password": ""
+        })
+    });
     let mut loading = use_signal(|| false);
     let mut login_error = use_signal(|| None::<String>);
     let toast = use_toast();
     let navigator = use_navigator();
     let auth = use_auth();
 
-    let mut handle_login = move |_: FormEvent| {
+    let schema = login_schema();
+
+    let mut handle_login = move |value: serde_json::Value| {
         loading.set(true);
         login_error.set(None);
 
-        // Capture for async and save
-        let u = username();
-        let p = password();
+        let u = value["username"].as_str().unwrap_or("").to_string();
+        let p = value["password"].as_str().unwrap_or("").to_string();
 
         spawn(async move {
             match AuthService::login(&u, &p).await {
                 Ok(response) => {
                     loading.set(false);
 
-                    // Save credentials and token on success
                     let new_state = ClientState {
                         last_username: Some(u.clone()),
                         last_password: None,
@@ -49,7 +56,6 @@ pub fn LoginPage() -> Element {
                     };
                     new_state.save();
 
-                    // Store auth state in context
                     let user = CurrentUser {
                         id: response.id,
                         username: response.username,
@@ -103,34 +109,26 @@ pub fn LoginPage() -> Element {
                         p { class: "login-card-subtitle", "欢迎回来，请登录您的账号" }
                     }
 
-                    // Form
+                    // Schema-driven form
                     form {
-                        onsubmit: move |e| {
+                        onsubmit: move |e: FormEvent| {
                             e.stop_propagation();
-                            handle_login(e);
+                            let data = form_data.read().clone();
+                            handle_login(data);
                         },
 
-                        BCInput {
-                            class: "login-field",
-                            label: Some("用户名".to_string()),
-                            value: "{username}",
-                            placeholder: "请输入用户名",
-                            oninput: move |e: FormEvent| {
-                                username.set(e.value());
-                                login_error.set(None);
-                            }
+                        SchemaForm {
+                            schema: schema.clone(),
+                            data: form_data,
+                            mode: FormMode::Create,
+                            show_actions: false,
+                            class: "login-form",
                         }
 
-                        BCInput {
-                            class: "login-field-last",
-                            label: Some("密码".to_string()),
-                            value: "{password}",
-                            r#type: "password",
-                            placeholder: "请输入密码",
-                            error: login_error(),
-                            oninput: move |e: FormEvent| {
-                                password.set(e.value());
-                                login_error.set(None);
+                        if let Some(err) = login_error() {
+                            div { class: "bc-input-error-row",
+                                div { class: "bc-input-error-dot" }
+                                span { class: "bc-input-error-text", "{err}" }
                             }
                         }
 


### PR DESCRIPTION
Migrate login, deploy, log, finance, groups, settings, users, access, and connect pages to use SchemaForm/SchemaTable components. Add new schemas: login, deploy, log, recharge. Net -91 lines with consistent schema-driven UI across all CRUD forms and tables.