### PR TITLE
feat: implement issue #168 - [router] 已实现未接入功能清单 — 调度器管线接线缺口

### DIFF
--- a/crates/router/src/channel_state.rs
+++ b/crates/router/src/channel_state.rs
@@ -350,7 +350,7 @@ impl ChannelStateTracker {
                     model_state.failure_count += 1;
                 }
             }
-            FailureType::ServerError | FailureType::Timeout => {
+            FailureType::ServerError | FailureType::Timeout | FailureType::ConnectionError => {
                 // These are transient errors, just update the model state if available
                 if let Some(model_name) = model {
                     let model_state = channel_state.get_or_create_model(model_name, channel_id);
@@ -365,21 +365,15 @@ impl ChannelStateTracker {
 
     /// Record a successful request for a specific channel and model.
     ///
-    /// This updates success counts and average latency metrics.
-    /// If the model was previously in a degraded state, this may restore it to available.
-    ///
-    /// # Arguments
-    /// * `channel_id` - The channel ID where the success occurred
-    /// * `model` - Optional model name if the success is model-specific
-    /// * `latency_ms` - The latency of the successful request in milliseconds
-    /// * `upstream_limit` - Optional rate limit learned from upstream response headers
+    /// Returns the AIMD learned limit if it changed after this success
+    /// (used for BudgetUpdate feedback to InMemoryBudget).
     pub fn record_success(
         &self,
         channel_id: i32,
         model: Option<&str>,
         latency_ms: u64,
         upstream_limit: Option<u32>,
-    ) {
+    ) -> Option<u32> {
         // Get or create channel state
         let mut channel_state = self
             .channel_states
@@ -387,10 +381,7 @@ impl ChannelStateTracker {
             .or_insert_with(|| ChannelState::new(channel_id));
 
         // If no model specified, nothing more to do
-        let model_name = match model {
-            Some(m) => m,
-            None => return,
-        };
+        let model_name = model?;
 
         // Update model state
         let model_state = channel_state.get_or_create_model(model_name, channel_id);
@@ -421,7 +412,15 @@ impl ChannelStateTracker {
         }
 
         // Update adaptive rate limiter with learned upstream limit
+        let prev_learned = model_state.adaptive_limit.get_learned_limit();
         model_state.adaptive_limit.on_success(upstream_limit);
+        let new_learned = model_state.adaptive_limit.get_learned_limit();
+        // Return learned limit if it changed (for BudgetUpdate feedback)
+        if new_learned != prev_learned {
+            new_learned
+        } else {
+            None
+        }
     }
 
     /// Filter a list of candidate channels to return only available ones.

--- a/crates/router/src/circuit_breaker.rs
+++ b/crates/router/src/circuit_breaker.rs
@@ -40,6 +40,8 @@ pub enum FailureType {
     ServerError,
     /// Request timed out
     Timeout,
+    /// Connection failed (DNS, TCP refused, TLS handshake)
+    ConnectionError,
 }
 
 #[derive(Debug)]
@@ -139,12 +141,12 @@ impl CircuitBreaker {
 
         match failure_type {
             FailureType::AuthFailed | FailureType::PaymentRequired => {
-                // Auth and payment failures immediately trip the circuit
-                entry
-                    .failure_count
-                    .store(self.failure_threshold, Ordering::Relaxed);
+                // Auth/payment failures are permanent (bad key, exhausted quota),
+                // not transient — do NOT trip the circuit. The failure type is
+                // already recorded above; leave the failure count unchanged so
+                // transient-traffic CB semantics are preserved.
                 tracing::warn!(
-                    "Circuit Breaker: Upstream {} immediately tripped due to {:?}",
+                    "Circuit Breaker: Upstream {} auth/payment failure ({:?}) — recorded but NOT tripping circuit (permanent failure ≠ transient fault)",
                     upstream_id, failure_type
                 );
             }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -5,12 +5,12 @@ mod aimd_limiter;
 mod adaptor;
 pub mod affinity;
 mod balancer;
-mod channel_state;
+pub mod channel_state;
 mod circuit_breaker;
 mod config;
 pub mod exchange_rate;
 mod limiter;
-mod model_router;
+pub mod model_router;
 pub mod order_type;
 pub mod passthrough;
 pub mod price_sync;
@@ -125,6 +125,7 @@ fn record_upstream_failure(
     model_name: Option<&str>,
     failure_type: FailureType,
     error_msg: &str,
+    session_id: &str,
 ) {
     let channel_id: i32 = upstream.id.parse().unwrap_or(0);
     state
@@ -133,6 +134,46 @@ fn record_upstream_failure(
     state
         .channel_state_tracker
         .record_error(channel_id, model_name, &failure_type, error_msg);
+    // Evict affinity entry when CB trips (audit decision D8 — only on CB
+    // trip, not on every failure, to avoid affinity storms).
+    if !state.circuit_breaker.allow_request(&upstream.id) {
+        if let Some(model) = model_name {
+            state.affinity_cache.evict(session_id, model);
+            tracing::debug!(
+                session_id, model, channel_id,
+                "Affinity evicted — CB tripped for upstream {}",
+                upstream.name
+            );
+        }
+    }
+}
+
+/// Classify an upstream HTTP error into a [`FailureType`] for circuit breaker
+/// and channel state tracking. Shared by passthrough and converted paths
+/// (audit decision D12 — DRY).
+fn classify_upstream_error(
+    status: StatusCode,
+    headers: &HeaderMap,
+    error_info: &response_parser::ErrorInfo,
+) -> FailureType {
+    match status {
+        StatusCode::UNAUTHORIZED => FailureType::AuthFailed,
+        StatusCode::PAYMENT_REQUIRED => FailureType::PaymentRequired,
+        StatusCode::TOO_MANY_REQUESTS => {
+            let retry_after = headers
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok());
+            let scope = error_info
+                .scope
+                .clone()
+                .unwrap_or(circuit_breaker::RateLimitScope::Unknown);
+            FailureType::RateLimited { scope, retry_after }
+        }
+        StatusCode::NOT_FOUND => FailureType::ModelNotFound,
+        _ if status.is_server_error() => FailureType::ServerError,
+        _ => FailureType::ServerError,
+    }
 }
 
 /// Helper function to build a response safely without panicking.
@@ -333,6 +374,7 @@ pub async fn create_router_app(
     db: Arc<Database>,
 ) -> anyhow::Result<(
     Router,
+    Router,
     mpsc::Sender<tokio::sync::oneshot::Sender<price_sync::SyncResult>>,
 )> {
     let config = load_router_config(&db).await?;
@@ -385,6 +427,35 @@ pub async fn create_router_app(
     // Counter for fail-open admissions (unconfigured channels). Surfaced
     // via /router/status so admins notice silently-permissive channels.
     let fail_open_count = Arc::new(AtomicU64::new(0));
+
+    // AIMD → InMemoryBudget feedback channel (capacity=1, latest-wins debounce).
+    // When the adaptive limiter learns a new RPM limit, it sends an update here;
+    // a background task reconfigures the budget bucket (audit decision D6/D10).
+    let (budget_update_tx, mut budget_update_rx) =
+        mpsc::channel::<state::BudgetUpdate>(1);
+    {
+        let rate_budget = rate_budget.clone();
+        tokio::spawn(async move {
+            tracing::info!("AIMD budget-update task started");
+            while let Some(update) = budget_update_rx.recv().await {
+                // Reconfigure the channel's RPM cap to the learned limit.
+                // TPM cap stays unchanged (AIMD only learns RPM).
+                if let Some(snapshot) = rate_budget.snapshot(update.channel_id) {
+                    rate_budget.configure(
+                        update.channel_id,
+                        update.learned_limit,
+                        snapshot.tpm_cap,
+                        rate_budget::ChannelReservation::default(),
+                    );
+                    tracing::debug!(
+                        channel_id = update.channel_id,
+                        learned_rpm = update.learned_limit,
+                        "AIMD feedback: reconfigured budget RPM cap"
+                    );
+                }
+            }
+        });
+    }
 
     // Start background price sync task (every 24 hours)
     // Prices pulled from pricing_data repo (GitHub/Gitee fallback).
@@ -440,6 +511,7 @@ pub async fn create_router_app(
         affinity_cache,
         rate_budget,
         fail_open_count,
+        budget_update_tx,
     };
 
     use burncloud_common::constants::INTERNAL_PREFIX;
@@ -449,10 +521,17 @@ pub async fn create_router_app(
     let reload_path = format!("{}/reload", INTERNAL_PREFIX);
     let health_path = format!("{}/health", INTERNAL_PREFIX);
     let price_sync_path = format!("{}/prices/sync", INTERNAL_PREFIX);
-    let app = Router::new()
+
+    // Internal routes that must be registered BEFORE LiveView's catch-all
+    // `/console/{*path}` in the server layer, otherwise LiveView intercepts
+    // them and returns HTML instead of JSON.
+    let internal_app = Router::new()
         .route(&reload_path, post(reload_handler))
         .route(&health_path, axum::routing::get(health_status_handler))
         .route(&price_sync_path, post(price_sync_handler))
+        .with_state(state.clone());
+
+    let app = Router::new()
         .route("/v1/models", axum::routing::get(models_handler))
         .route("/api/v1/usage", axum::routing::get(usage_handler))
         .route(
@@ -463,7 +542,7 @@ pub async fn create_router_app(
         .layer(CorsLayer::permissive())
         .with_state(state);
 
-    Ok((app, force_sync_tx))
+    Ok((app, internal_app, force_sync_tx))
 }
 
 // ...
@@ -1369,6 +1448,13 @@ async fn proxy_logic(
     // the L1 Classifier (issue #150) resolves a real color from the user.
     let mut shaper_color: TrafficColor = TrafficColor::Yellow;
 
+    // Extract session_id from conversation_id in request body (P0 affinity wiring).
+    // Falls back to user_id so affinity still works when no conversation_id is set.
+    let session_id: String = serde_json::from_slice::<serde_json::Value>(&body_bytes)
+        .ok()
+        .and_then(|v| v.get("conversation_id").and_then(|c| c.as_str()).map(|s| s.to_string()))
+        .unwrap_or_else(|| user_id.to_string());
+
     // Try to extract model from Gemini native path first
     let gemini_path_model = passthrough::extract_model_from_gemini_path(path);
 
@@ -1409,7 +1495,7 @@ async fn proxy_logic(
                 user_id: Some(user_id.to_string()),
                 color,
                 order_type,
-                session_id: None,
+                session_id: Some(session_id.clone()),
             };
 
             tracing::debug!(
@@ -1802,6 +1888,7 @@ async fn proxy_logic(
                         last_error = format!("Upstream returned {status}");
                         record_upstream_failure(
                             state, upstream, model_name, FailureType::ServerError, &last_error,
+                            &session_id,
                         );
                         continue;
                     }
@@ -1819,7 +1906,12 @@ async fn proxy_logic(
                             model_name,
                             latency_ms,
                             rate_limit_info.request_limit,
-                        );
+                        )
+                        .inspect(|&learned| {
+                            let _ = state.budget_update_tx.try_send(
+                                state::BudgetUpdate { channel_id, learned_limit: learned }
+                            );
+                        });
 
                         // Handle streaming vs non-streaming passthrough
                         if is_stream {
@@ -1901,9 +1993,14 @@ async fn proxy_logic(
                                 token_counter.set_from_usage(&resp_usage);
                             }
 
-                            // L2 Shaper success — see streaming branch above.
+                            // L2 Shaper success — non-streaming passthrough.
+                            // Use actual_tpm from parsed usage (audit decision D9 —
+                            // non-streaming paths have complete usage data).
+                            // Fall back to est_tpm when usage parsing yields 0.
+                            let actual_tpm = token_counter.get_usage().total_tokens() as u64;
+                            let commit_tpm = if actual_tpm > 0 { actual_tpm } else { shaper_ctx.est_tpm };
                             if let Some(g) = budget_guard.take() {
-                                g.commit(shaper_ctx.est_tpm);
+                                g.commit(commit_tpm);
                             }
                             return ProxyResult {
                                 response: build_response_with_header(
@@ -1925,7 +2022,8 @@ async fn proxy_logic(
                             };
                         }
                     } else {
-                        // Non-success status (4xx)
+                        // Non-success status (4xx) — capture headers before consuming body.
+                        let resp_headers = resp.headers().clone();
                         let body_bytes = match resp.bytes().await {
                             Ok(b) => b,
                             Err(e) => {
@@ -1949,15 +2047,26 @@ async fn proxy_logic(
                             }
                         };
 
-                        // Record rate limit errors
+                        // Classify all 4xx errors (not just 429) for circuit breaker
+                        // and channel state tracking (P1 — passthrough error mapping).
+                        let body_str = String::from_utf8_lossy(&body_bytes);
+                        let error_info = parse_error_response(&body_str, &upstream.protocol);
+                        let error_message = error_info.message.as_deref().unwrap_or("Unknown error");
+                        let failure_type = classify_upstream_error(status, &resp_headers, &error_info);
+                        // Auth/payment failures affect entire channel (model_name=None)
+                        let error_model = match status {
+                            StatusCode::UNAUTHORIZED | StatusCode::PAYMENT_REQUIRED => None,
+                            _ => model_name,
+                        };
+                        record_upstream_failure(
+                            state, upstream, error_model, failure_type, error_message,
+                            &session_id,
+                        );
+                        // 429: try next ranked candidate
                         if status == StatusCode::TOO_MANY_REQUESTS {
-                            record_upstream_failure(
-                                state, upstream, model_name,
-                                FailureType::RateLimited {
-                                    scope: circuit_breaker::RateLimitScope::Unknown,
-                                    retry_after: None,
-                                },
-                                "Rate limited",
+                            tracing::warn!(
+                                "Passthrough: {} rate limited, trying next candidate",
+                                upstream.name
                             );
                             continue;
                         }
@@ -1986,8 +2095,14 @@ async fn proxy_logic(
                 }
                 Err(e) => {
                     last_error = format!("Network Error: {e}");
+                    let failure_type = if e.is_timeout() {
+                        FailureType::Timeout
+                    } else {
+                        FailureType::ConnectionError
+                    };
                     record_upstream_failure(
-                        state, upstream, model_name, FailureType::Timeout, &last_error,
+                        state, upstream, model_name, failure_type, &last_error,
+                        &session_id,
                     );
                     tracing::warn!(
                         "Failover: {} network error: {}, trying next...",
@@ -2101,6 +2216,7 @@ async fn proxy_logic(
                     last_error = format!("Upstream returned {status}");
                     record_upstream_failure(
                         state, upstream, model_name, FailureType::ServerError, &last_error,
+                        &session_id,
                     );
                     continue;
                 }
@@ -2124,7 +2240,12 @@ async fn proxy_logic(
                         model_name,
                         latency_ms,
                         rate_limit_info.request_limit,
-                    );
+                    )
+                    .inspect(|&learned| {
+                        let _ = state.budget_update_tx.try_send(
+                            state::BudgetUpdate { channel_id, learned_limit: learned }
+                        );
+                    });
 
                     // Log rate limit info for debugging/monitoring
                     if rate_limit_info.request_limit.is_some()
@@ -2172,9 +2293,11 @@ async fn proxy_logic(
                                 );
                                 token_counter.set_from_usage(&resp_usage);
                             }
-                            // L2 Shaper success — see Gemini stream branch above.
+                            // L2 Shaper success — video-gen non-streaming (actual_tpm available).
+                            let actual_tpm = token_counter.get_usage().total_tokens() as u64;
+                            let commit_tpm = if actual_tpm > 0 { actual_tpm } else { shaper_ctx.est_tpm };
                             if let Some(g) = budget_guard.take() {
-                                g.commit(shaper_ctx.est_tpm);
+                                g.commit(commit_tpm);
                             }
                             return ProxyResult {
                                 response: build_response_with_header(
@@ -2195,7 +2318,8 @@ async fn proxy_logic(
                                 sched_request_color: shaper_color,
                             };
                         }
-                        // L2 Shaper success: OpenAI default success path.
+                        // L2 Shaper success: OpenAI streaming path — keep est_tpm
+                        // (actual_tpm not yet available during stream, audit decision D9).
                         if let Some(g) = budget_guard.take() {
                             g.commit(shaper_ctx.est_tpm);
                         }
@@ -2252,7 +2376,8 @@ async fn proxy_logic(
                         });
                         let final_stream = stream.chain(done);
 
-                        // L2 Shaper success — non-OpenAI streaming.
+                        // L2 Shaper success — non-OpenAI streaming path — keep est_tpm
+                        // (actual_tpm not yet available during stream, audit decision D9).
                         if let Some(g) = budget_guard.take() {
                             g.commit(shaper_ctx.est_tpm);
                         }
@@ -2320,9 +2445,11 @@ async fn proxy_logic(
                         serde_json::to_string(&resp_json).unwrap_or_else(|_| "{}".to_string())
                     };
 
-                    // L2 Shaper success — non-OpenAI non-streaming.
+                    // L2 Shaper success — non-OpenAI non-streaming (actual_tpm available).
+                    let actual_tpm = token_counter.get_usage().total_tokens() as u64;
+                    let commit_tpm = if actual_tpm > 0 { actual_tpm } else { shaper_ctx.est_tpm };
                     if let Some(g) = budget_guard.take() {
-                        g.commit(shaper_ctx.est_tpm);
+                        g.commit(commit_tpm);
                     }
                     return ProxyResult {
                         response: build_response_with_header(
@@ -2373,23 +2500,8 @@ async fn proxy_logic(
                     let error_info = parse_error_response(&body_str, &upstream.protocol);
                     let error_message = error_info.message.as_deref().unwrap_or("Unknown error");
 
-                    // Determine failure type based on status code
-                    let failure_type = match status {
-                        StatusCode::UNAUTHORIZED => FailureType::AuthFailed,
-                        StatusCode::PAYMENT_REQUIRED => FailureType::PaymentRequired,
-                        StatusCode::TOO_MANY_REQUESTS => {
-                            let retry_after = resp_headers
-                                .get("retry-after")
-                                .and_then(|v| v.to_str().ok())
-                                .and_then(|v| v.parse::<u64>().ok());
-                            let scope = error_info
-                                .scope
-                                .unwrap_or(crate::circuit_breaker::RateLimitScope::Unknown);
-                            FailureType::RateLimited { scope, retry_after }
-                        }
-                        StatusCode::NOT_FOUND => FailureType::ModelNotFound,
-                        _ => FailureType::ServerError,
-                    };
+                    // Determine failure type using shared classifier (D12)
+                    let failure_type = classify_upstream_error(status, &resp_headers, &error_info);
 
                     // Auth/payment failures affect entire channel (model_name=None)
                     let error_model = match status {
@@ -2399,6 +2511,7 @@ async fn proxy_logic(
 
                     record_upstream_failure(
                         state, upstream, error_model, failure_type, error_message,
+                        &session_id,
                     );
 
                     // 429: try next ranked candidate (scheduler provides alternatives)
@@ -2473,8 +2586,14 @@ async fn proxy_logic(
             }
             Err(e) => {
                 last_error = format!("Network Error: {e}");
+                let failure_type = if e.is_timeout() {
+                    FailureType::Timeout
+                } else {
+                    FailureType::ConnectionError
+                };
                 record_upstream_failure(
-                    state, upstream, model_name, FailureType::Timeout, &last_error,
+                    state, upstream, model_name, failure_type, &last_error,
+                    &session_id,
                 );
                 tracing::warn!(
                     "Failover: {} failed with {}, trying next...",

--- a/crates/router/src/state.rs
+++ b/crates/router/src/state.rs
@@ -20,6 +20,15 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, RwLock};
 
+/// AIMD → InMemoryBudget feedback message. When the adaptive limiter learns a
+/// new limit, this update is sent via a capacity-1 mpsc channel so the budget
+/// can be reconfigured asynchronously (audit decision D6/D10 — no lock
+/// contention, natural debounce).
+pub struct BudgetUpdate {
+    pub channel_id: i32,
+    pub learned_limit: u32,
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub client: Client,
@@ -50,4 +59,6 @@ pub struct AppState {
     /// Exposed via `/router/status` so admins can spot silently-permissive
     /// channels (audit FM2 — fail-open silent failure).
     pub fail_open_count: Arc<AtomicU64>,
+    /// AIMD → InMemoryBudget feedback channel (capacity=1, latest-wins debounce).
+    pub budget_update_tx: mpsc::Sender<BudgetUpdate>,
 }

--- a/crates/router/tests/common.rs
+++ b/crates/router/tests/common.rs
@@ -226,9 +226,13 @@ pub async fn start_test_server(port: u16, db_url: &str) {
         .unwrap_or_else(|e| panic!("Failed to open DB: {e}"));
     let db_arc = Arc::new(db);
 
-    let (app, _force_sync_tx) = burncloud_router::create_router_app(db_arc)
+    let (app, internal_app, _force_sync_tx) = burncloud_router::create_router_app(db_arc)
         .await
         .unwrap_or_else(|e| panic!("Failed to create app: {e}"));
+
+    // Merge internal_app before the main app so internal routes
+    // (e.g. /console/internal/health) are reachable in tests.
+    let app = internal_app.merge(app);
 
     tokio::spawn(async move {
         let listener = TcpListener::bind(format!("0.0.0.0:{}", port))

--- a/crates/server/src/api/log.rs
+++ b/crates/server/src/api/log.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Json, Response},
-    routing::{get, post},
+    routing::get,
     Router,
 };
 use burncloud_service_router_log::{BillingService, RouterLogService};
@@ -41,15 +41,6 @@ struct ApiError {
     error: String,
 }
 
-#[derive(Serialize)]
-struct PriceSyncResult {
-    models_synced: usize,
-    currencies_synced: usize,
-    tiers_synced: usize,
-    errors: usize,
-    source: String,
-}
-
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/console/api/logs", get(list_logs))
@@ -58,7 +49,6 @@ pub fn routes() -> Router<AppState> {
             "/console/internal/billing/summary",
             get(billing_summary_handler),
         )
-        .route("/console/internal/prices/sync", post(price_sync_handler))
 }
 
 async fn list_logs(
@@ -115,43 +105,6 @@ async fn billing_summary_handler(
         std::env::var("BURNCLOUD_INTERNAL_SECRET").ok().as_deref(),
     )
     .await
-}
-
-async fn price_sync_handler(State(state): State<AppState>) -> Response {
-    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-    if state.force_sync_tx.send(reply_tx).await.is_err() {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(ApiError {
-                error: "Price sync task is not running".to_string(),
-            }),
-        )
-            .into_response();
-    }
-    match tokio::time::timeout(std::time::Duration::from_secs(60), reply_rx).await {
-        Ok(Ok(result)) => Json(PriceSyncResult {
-            models_synced: result.models_synced,
-            currencies_synced: result.currencies_synced,
-            tiers_synced: result.tiered_pricing_synced,
-            errors: result.errors,
-            source: result.source,
-        })
-        .into_response(),
-        Ok(Err(_)) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError {
-                error: "Sync task dropped the reply channel".to_string(),
-            }),
-        )
-            .into_response(),
-        Err(_) => (
-            StatusCode::GATEWAY_TIMEOUT,
-            Json(ApiError {
-                error: "Price sync timed out after 60s".to_string(),
-            }),
-        )
-            .into_response(),
-    }
 }
 
 async fn billing_summary_inner(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -30,7 +30,7 @@ pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Res
     let _ = monitor.start_auto_update().await;
 
     // 3. Data Plane Router (Fallback) — must be created first to get force_sync_tx
-    let (router_app, force_sync_tx) = create_router_app(db.clone()).await?;
+    let (router_app, internal_app, force_sync_tx) = create_router_app(db.clone()).await?;
 
     let state = AppState {
         db: db.clone(),
@@ -45,9 +45,13 @@ pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Res
     // Top-level liveness probe (unauthenticated, used by deploy validators and
     // external uptime monitors). The richer report lives at
     // `/console/internal/health`.
+    // Internal routes (health, reload, price-sync) must be registered BEFORE
+    // LiveView's catch-all `/console/{*path}` so they return JSON instead of
+    // the SPA HTML shell.
     let mut app = Router::new()
         .route("/health", get(|| async { "ok" }))
-        .merge(api_router);
+        .merge(api_router)
+        .merge(internal_app);
 
     if enable_liveview {
         // 2. LiveView Router

--- a/crates/server/tests/log_api_tests.rs
+++ b/crates/server/tests/log_api_tests.rs
@@ -5,17 +5,32 @@
     clippy::disallowed_types
 )]
 
-use burncloud_database::create_default_database;
+use burncloud_database::create_database_with_url;
 use burncloud_database_router::{RouterDatabase, RouterLog};
+use burncloud_database_user::UserDatabase;
 use reqwest::Client;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 
 #[tokio::test]
 async fn test_log_api_endpoints() -> anyhow::Result<()> {
     // 1. Setup DB and Insert Dummy Data
-    let db = create_default_database().await?;
-    RouterDatabase::init(&db).await?; // Ensure tables exist
+    if std::env::var("MASTER_KEY").is_err() {
+        std::env::set_var(
+            "MASTER_KEY",
+            "a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8",
+        );
+    }
+
+    let tmp = tempfile::NamedTempFile::new()?;
+    let path = tmp.path().to_string_lossy().to_string();
+    std::mem::forget(tmp);
+    let url = format!("sqlite:{}", path);
+
+    let db = create_database_with_url(&url).await?;
+    RouterDatabase::init(&db).await?;
+    UserDatabase::init(&db).await?;
 
     let log_entry = RouterLog {
         id: 0,
@@ -54,12 +69,18 @@ async fn test_log_api_endpoints() -> anyhow::Result<()> {
 
     RouterDatabase::insert_log(&db, &log_entry).await?;
 
-    // 2. Start Server
-    let port = 4002;
+    // 2. Start Server using create_app with the test DB
+    let db_arc = Arc::new(db);
+    let app = burncloud_server::create_app(db_arc, false).await?;
+
+    let port = 4002_u16;
     tokio::spawn(async move {
-        if let Err(_e) = burncloud_server::start_server("127.0.0.1", port, false).await {
-            // Ignore bind errors if already running
-        }
+        let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}"))
+            .await
+            .expect("Failed to bind test port");
+        axum::serve(listener, app)
+            .await
+            .expect("Server error");
     });
     sleep(Duration::from_secs(2)).await;
 

--- a/crates/server/tests/management_tests.rs
+++ b/crates/server/tests/management_tests.rs
@@ -5,8 +5,11 @@
     clippy::disallowed_types
 )]
 
-use burncloud_database_router::{RouterToken, RouterUpstream};
+use burncloud_database::create_database_with_url;
+use burncloud_database_router::{RouterDatabase, RouterToken, RouterUpstream};
+use burncloud_database_user::UserDatabase;
 use reqwest::Client;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -122,11 +125,33 @@ async fn test_channel_management_lifecycle() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_token_management_lifecycle() -> anyhow::Result<()> {
-    let port = 4006;
+    if std::env::var("MASTER_KEY").is_err() {
+        std::env::set_var(
+            "MASTER_KEY",
+            "a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8",
+        );
+    }
+
+    let tmp = tempfile::NamedTempFile::new()?;
+    let path = tmp.path().to_string_lossy().to_string();
+    std::mem::forget(tmp);
+    let url = format!("sqlite:{}", path);
+
+    let db = create_database_with_url(&url).await?;
+    RouterDatabase::init(&db).await?;
+    UserDatabase::init(&db).await?;
+
+    let db_arc = Arc::new(db);
+    let app = burncloud_server::create_app(db_arc, false).await?;
+
+    let port = 4006_u16;
     tokio::spawn(async move {
-        if let Err(_e) = burncloud_server::start_server("127.0.0.1", port, false).await {
-            // Ignore
-        }
+        let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}"))
+            .await
+            .expect("Failed to bind test port");
+        axum::serve(listener, app)
+            .await
+            .expect("Server error");
     });
     sleep(Duration::from_secs(2)).await;
 

--- a/crates/service/crates/billing/src/types.rs
+++ b/crates/service/crates/billing/src/types.rs
@@ -32,6 +32,20 @@ impl UnifiedUsage {
         *self == Self::default()
     }
 
+    /// Sum of all token counts (for budget commit actual-TPM).
+    pub fn total_tokens(&self) -> i64 {
+        self.input_tokens
+            .saturating_add(self.output_tokens)
+            .saturating_add(self.cache_read_tokens)
+            .saturating_add(self.cache_write_tokens)
+            .saturating_add(self.audio_input_tokens)
+            .saturating_add(self.audio_output_tokens)
+            .saturating_add(self.image_tokens)
+            .saturating_add(self.video_tokens)
+            .saturating_add(self.reasoning_tokens)
+            .saturating_add(self.embedding_tokens)
+    }
+
     /// Accumulate another usage into self using saturating add.
     /// Overflow is capped at i64::MAX and a warning should be logged by the caller.
     pub fn saturating_add(&mut self, other: &UnifiedUsage) {

--- a/crates/service/crates/user/Cargo.toml
+++ b/crates/service/crates/user/Cargo.toml
@@ -10,6 +10,7 @@ burncloud-common.workspace = true
 burncloud-database-user.workspace = true
 burncloud-database.workspace = true
 bcrypt.workspace = true
+dashmap.workspace = true
 uuid.workspace = true
 jsonwebtoken.workspace = true
 serde.workspace = true

--- a/crates/service/crates/user/src/lib.rs
+++ b/crates/service/crates/user/src/lib.rs
@@ -6,6 +6,7 @@ use bcrypt::{hash, verify, DEFAULT_COST};
 use burncloud_common::TrafficColor;
 use burncloud_database::Database;
 use burncloud_database_user::UserDatabase;
+use dashmap::DashMap;
 
 // Re-export domain types so server can depend on service-user instead of database-user
 pub use burncloud_database_user::{UserAccount, UserRecharge};
@@ -124,25 +125,46 @@ impl UserService {
     /// `SchedulingRequest` — the router crate stays color-agnostic (audit
     /// decision E-D3).
     ///
-    /// **Associated function (no `&self`)** — follows CLAUDE.md "Service 模式 B
-    /// (stateless, pure operation wrapper)" so the hot path can invoke it as
-    /// `UserService::resolve_traffic_class(&db, &user_id).await` without
-    /// constructing a `UserService`. This avoids `UserService::new()` reading
-    /// `JWT_SECRET` (irrelevant to color resolution) and panicking on every
-    /// request in release builds when that env var is missing.
-    ///
-    /// **MVP behavior** (audit decision D10): every user maps to `Yellow`
-    /// (Assured tier). Trader Class differentiation is deferred until customer
-    /// segmentation data is available — see
-    /// `docs/design/channel-scheduler-hqos.md` § Strategic Vision.
-    ///
-    /// `_db` and `_user_id` are placeholders for the future implementation
-    /// that will read user role / billing tier / customer agreement.
+    /// Uses a TTL cache (5 min, audit decision D13) to avoid per-request DB
+    /// queries. Falls back to Yellow on cache miss + DB failure.
     pub async fn resolve_traffic_class(
-        _db: &Database,
-        _user_id: &str,
+        db: &Database,
+        user_id: &str,
     ) -> Result<TrafficColor> {
-        Ok(TrafficColor::Yellow)
+        use std::sync::OnceLock;
+        static CACHE: OnceLock<DashMap<String, (TrafficColor, std::time::Instant)>> = OnceLock::new();
+        let cache = CACHE.get_or_init(DashMap::new);
+        const TTL: std::time::Duration = std::time::Duration::from_secs(300);
+
+        // Check cache
+        if let Some(entry) = cache.get(user_id) {
+            if entry.1.elapsed() < TTL {
+                return Ok(entry.0);
+            }
+            drop(entry);
+            cache.remove(user_id);
+        }
+
+        // Cache miss — query DB for user roles
+        let color = match UserDatabase::get_user_roles(db, user_id).await {
+            Ok(roles) => {
+                if roles.iter().any(|r| r == "admin" || r == "enterprise") {
+                    TrafficColor::Green
+                } else {
+                    TrafficColor::Yellow
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    user_id, error = %e,
+                    "DB error resolving traffic class, defaulting to Yellow"
+                );
+                TrafficColor::Yellow
+            }
+        };
+
+        cache.insert(user_id.to_string(), (color, std::time::Instant::now()));
+        Ok(color)
     }
 
     /// Register a new user


### PR DESCRIPTION
## Summary

Implements #168

Closes #168

## Summary by Sourcery

Wire router scheduler pipeline with affinity, adaptive rate feedback, and internal health/price-sync endpoints, while improving user traffic classification and test/server wiring.

New Features:
- Expose router channel_state and model_router modules for reuse by other crates.
- Add session-based affinity eviction on circuit breaker trips using conversation or user identifiers.
- Introduce classification of upstream HTTP and network errors into detailed failure types shared between passthrough and converted paths.
- Add AIMD-to-budget feedback channel so learned rate limits dynamically reconfigure in-memory rate budgets.
- Introduce internal router app with health, reload, and price sync routes, merged into the main server router before LiveView routes.
- Add TTL-cached user traffic class resolution backed by database roles for differentiating Green vs Yellow traffic tiers.

Bug Fixes:
- Ensure non-streaming paths commit actual token usage to budgets when available, falling back to estimates only when necessary.
- Prevent auth and payment failures from tripping the circuit breaker, treating them as permanent configuration errors instead of transient faults.
- Handle connection-level errors separately from timeouts in channel state tracking and circuit breaker logic.
- Fix internal health and price sync endpoints being shadowed by LiveView catch-all routes by registering them earlier and wiring them through router tests and server startup.
- Adjust price sync API wiring so it is served from router internal routes instead of the console log API.

Enhancements:
- Extend channel state tracking to include connection errors and return AIMD learned limits on success for downstream consumers.
- Refine router failure recording to include session IDs and centralize HTTP error mapping, improving observability and consistency.
- Optimize server tests to create apps with temporary SQLite databases and explicit listeners instead of relying on global default databases and start_server.
- Add total_tokens helper on UnifiedUsage to support budget commits based on unified token accounting.
- Update log and management tests to use explicit database URLs and initialize user and router schemas consistently.

Tests:
- Refactor server log and management tests to spin up isolated apps with temporary SQLite databases and properly initialized router and user schemas, ensuring internal APIs remain testable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic rate limit adjustment based on learned upstream capacity limits.
  * Session-based request affinity with automatic cleanup when limits are exceeded.
  * Improved token usage tracking using actual parsed token counts instead of estimates.
  * Traffic class resolution now cached with user role-based prioritization.

* **Bug Fixes**
  * Authentication and payment failures no longer incorrectly trigger circuit breaker restrictions.
  * Enhanced error classification for more accurate failure handling.

* **Chores**
  * Removed internal price synchronization endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->