### PR TITLE
feat: implement issue #198 - 全局迁移到 tracing + tracing-subscriber 结构化日志

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ disallowed_types = "deny"
 
 [workspace.dependencies]
 anyhow = "1.0"
-env_logger = "0.11"
 dotenvy = "0.15"
 log = "0.4"
 semver = "1.0"
@@ -96,7 +95,7 @@ rand = "0.8"
 # HTTP
 reqwest = { version = "0.12", features = ["json", "stream"] }
 axum = { version = "0.8.7", features = ["macros", "ws"] }
-tower-http = { version = "0.6", features = ["trace", "cors"] }
+tower-http = { version = "0.6", features = ["trace", "cors", "request-id"] }
 http-body-util = "0.1"
 http = "1.0"
 
@@ -222,7 +221,7 @@ burncloud-installer.workspace = true
 bcrypt.workspace = true
 uuid.workspace = true
 clap.workspace = true
-log.workspace = true
+tracing.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/auto-update/Cargo.toml
+++ b/crates/auto-update/Cargo.toml
@@ -14,11 +14,12 @@ categories = ["development-tools"]
 
 [dependencies]
 anyhow.workspace = true
-log.workspace = true
+tracing.workspace = true
 self_update.workspace = true
 semver.workspace = true
 
 [dev-dependencies]
-env_logger.workspace = true
+tracing-subscriber.workspace = true
+
 [lints]
 workspace = true

--- a/crates/auto-update/examples/update_example.rs
+++ b/crates/auto-update/examples/update_example.rs
@@ -8,8 +8,7 @@
 use burncloud_auto_update::{AutoUpdater, UpdateConfig};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize logger
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     // Create updater with custom config
     let config = UpdateConfig {

--- a/crates/auto-update/src/updater.rs
+++ b/crates/auto-update/src/updater.rs
@@ -1,7 +1,7 @@
 //! 自动更新器核心实现
 
 use crate::{UpdateConfig, UpdateError, UpdateResult};
-use log::{error, info};
+use tracing::{error, info};
 use self_update::backends::github;
 use semver;
 

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -20,7 +20,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 chrono.workspace = true
 dirs.workspace = true
-log.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/database/crates/user/Cargo.toml
+++ b/crates/database/crates/user/Cargo.toml
@@ -10,7 +10,6 @@ burncloud-database.workspace = true
 burncloud-common.workspace = true
 sqlx.workspace = true
 serde.workspace = true
-log.workspace = true
 tracing.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
 

--- a/crates/installer/Cargo.toml
+++ b/crates/installer/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 anyhow.workspace = true
-log.workspace = true
+tracing.workspace = true
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -27,14 +27,6 @@ sha2 = "0.10"
 
 [target.'cfg(windows)'.dependencies]
 winapi.workspace = true
-
-[dev-dependencies]
-env_logger.workspace = true
-
-[package.metadata.cargo-machete]
-# winapi is under [target.'cfg(windows)'.dependencies] — machete doesn't detect cfg-gated deps
-# env_logger is in [dev-dependencies] — machete limitation
-ignored = ["winapi", "env_logger"]
 
 [lints]
 workspace = true

--- a/crates/installer/src/bundle.rs
+++ b/crates/installer/src/bundle.rs
@@ -1,7 +1,7 @@
 //! Bundle creation and verification for offline installation
 
 use chrono::Utc;
-use log::{info, warn};
+use tracing::{info, warn};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/crates/installer/src/installer.rs
+++ b/crates/installer/src/installer.rs
@@ -1,6 +1,6 @@
 //! Core installer implementation
 
-use log::{info, warn};
+use tracing::{info, warn};
 use regex::Regex;
 use reqwest::Client;
 use std::collections::HashMap;

--- a/crates/installer/src/npm.rs
+++ b/crates/installer/src/npm.rs
@@ -1,6 +1,6 @@
 //! npm package installation support
 
-use log::info;
+use tracing::info;
 use std::path::Path;
 use std::process::Command;
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["web-programming"]
 [dependencies]
 tokio.workspace = true
 anyhow.workspace = true
-log.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
@@ -22,7 +21,7 @@ tracing-log.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
-tower-http = { workspace = true, features = ["cors", "trace"] }
+tower-http = { workspace = true, features = ["cors", "trace", "request-id"] }
 burncloud-database = { workspace = true }
 burncloud-database-router = { workspace = true }
 burncloud-database-user = { workspace = true }

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -65,6 +65,7 @@ pub fn routes() -> Router<AppState> {
         .route("/api/auth/login", post(login))
 }
 
+#[tracing::instrument(skip(state, payload), fields(username = %payload.username))]
 async fn create_user(
     State(state): State<AppState>,
     Json(payload): Json<RegisterDto>,
@@ -110,6 +111,7 @@ async fn create_user(
     }
 }
 
+#[tracing::instrument(skip(state, payload), fields(username = %payload.username))]
 async fn login(State(state): State<AppState>, Json(payload): Json<LoginDto>) -> impl IntoResponse {
     match state
         .user_service
@@ -140,6 +142,7 @@ async fn login(State(state): State<AppState>, Json(payload): Json<LoginDto>) -> 
     }
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn auth_middleware(mut req: Request<Body>, next: Next) -> Result<Response, StatusCode> {
     let auth_header = req
         .headers()

--- a/crates/server/src/api/channel.rs
+++ b/crates/server/src/api/channel.rs
@@ -21,7 +21,7 @@ fn default_limit() -> i32 {
     20
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ChannelDto {
     pub id: Option<i32>,
     #[serde(rename = "type")]
@@ -131,6 +131,7 @@ async fn list_channels(
     }
 }
 
+#[tracing::instrument(skip(state), fields(name = %payload.name))]
 async fn create_channel(
     State(state): State<AppState>,
     axum::extract::Json(payload): axum::extract::Json<ChannelDto>,
@@ -142,6 +143,7 @@ async fn create_channel(
     }
 }
 
+#[tracing::instrument(skip(state, payload), fields(name = %payload.name))]
 async fn update_channel(
     State(state): State<AppState>,
     axum::extract::Json(payload): axum::extract::Json<ChannelDto>,
@@ -156,6 +158,7 @@ async fn update_channel(
     }
 }
 
+#[tracing::instrument(skip(state))]
 async fn delete_channel(State(state): State<AppState>, Path(id): Path<i32>) -> impl IntoResponse {
     match ChannelService::delete(&state.db, id).await {
         Ok(_) => ok(()).into_response(),

--- a/crates/server/src/api/group.rs
+++ b/crates/server/src/api/group.rs
@@ -8,7 +8,7 @@ use axum::{
 use burncloud_service_group::{GroupMemberService, GroupService, RouterGroup, RouterGroupMember};
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct GroupDto {
     pub id: String,
     pub name: String,
@@ -63,6 +63,7 @@ pub fn routes() -> Router<AppState> {
         .route("/groups/{id}/members", get(get_members).put(set_members))
 }
 
+#[tracing::instrument(skip_all)]
 async fn list_groups(State(state): State<AppState>) -> impl IntoResponse {
     match GroupService::get_all(&state.db).await {
         Ok(groups) => Json(groups).into_response(),
@@ -70,6 +71,7 @@ async fn list_groups(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
+#[tracing::instrument(skip(state), fields(name = %payload.name))]
 async fn create_group(
     State(state): State<AppState>,
     Json(payload): Json<GroupDto>,
@@ -94,6 +96,7 @@ async fn get_group(State(state): State<AppState>, Path(id): Path<String>) -> imp
     }
 }
 
+#[tracing::instrument(skip(state))]
 async fn delete_group(State(state): State<AppState>, Path(id): Path<String>) -> impl IntoResponse {
     let name = match GroupService::get(&state.db, &id).await {
         Ok(Some(g)) => g.name,

--- a/crates/server/src/api/security.rs
+++ b/crates/server/src/api/security.rs
@@ -72,12 +72,12 @@ impl From<FilterConfig> for FilterConfigResponse {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct EmergencyBreakRequest {
     reason: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct EventQueryParams {
     page: Option<i32>,
     page_size: Option<i32>,
@@ -266,6 +266,7 @@ fn log_to_risk_event(log: &RouterLog) -> RiskEvent {
 ///
 /// Aggregate security summary: score based on 4xx/5xx ratio in router_logs,
 /// blocked count, threat source count, and a 7-day sparkline.
+#[tracing::instrument(skip_all)]
 async fn security_summary(State(state): State<AppState>) -> impl IntoResponse {
     match RouterLogService::get(&state.db, 1000, 0).await {
         Ok(logs) => {
@@ -290,6 +291,7 @@ async fn security_summary(State(state): State<AppState>) -> impl IntoResponse {
 /// GET /console/api/monitor/security/events
 ///
 /// Paginated list of risk events derived from 4xx/5xx router logs.
+#[tracing::instrument(skip(state))]
 async fn security_events(
     State(state): State<AppState>,
     Query(params): Query<EventQueryParams>,
@@ -393,6 +395,7 @@ async fn security_filters_put(
 /// POST /console/api/monitor/security/emergency-circuit-break
 ///
 /// Proxy to router's internal trip-all endpoint. Requires a reason.
+#[tracing::instrument(skip(_state), fields(reason = %body.reason))]
 async fn security_emergency_circuit_break(
     State(_state): State<AppState>,
     Json(body): Json<EmergencyBreakRequest>,
@@ -401,7 +404,7 @@ async fn security_emergency_circuit_break(
         return err("Reason is required for emergency circuit break").into_response();
     }
 
-    log::warn!(
+    tracing::warn!(
         "SECURITY: Emergency circuit break triggered — reason: \"{}\"",
         body.reason
     );
@@ -428,6 +431,7 @@ async fn security_emergency_circuit_break(
 /// GET /console/api/monitor/security/circuit-breaker-status
 ///
 /// Proxy to router's internal health endpoint to get circuit breaker states.
+#[tracing::instrument(skip_all)]
 async fn security_circuit_breaker_status(
     State(_state): State<AppState>,
 ) -> impl IntoResponse {

--- a/crates/server/src/api/token.rs
+++ b/crates/server/src/api/token.rs
@@ -9,7 +9,7 @@ use burncloud_service_token::{RouterToken, TokenService};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CreateTokenRequest {
     pub user_id: String,
     pub quota_limit: Option<i64>,
@@ -46,6 +46,7 @@ pub fn routes() -> Router<AppState> {
         )
 }
 
+#[tracing::instrument(skip_all)]
 async fn list_tokens(State(state): State<AppState>) -> impl IntoResponse {
     tracing::info!("[API] list_tokens request received");
     match TokenService::list(&state.db).await {
@@ -60,6 +61,7 @@ async fn list_tokens(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
+#[tracing::instrument(skip(state), fields(user_id = %payload.user_id))]
 async fn create_token(
     State(state): State<AppState>,
     Json(payload): Json<CreateTokenRequest>,
@@ -98,6 +100,7 @@ async fn create_token(
     }
 }
 
+#[tracing::instrument(skip(state, payload), fields(status = %payload.status))]
 async fn update_token(
     State(state): State<AppState>,
     Path(token): Path<String>,
@@ -124,6 +127,7 @@ async fn update_token(
     }
 }
 
+#[tracing::instrument(skip(state))]
 async fn delete_token(
     State(state): State<AppState>,
     Path(token): Path<String>,

--- a/crates/server/src/api/user.rs
+++ b/crates/server/src/api/user.rs
@@ -79,6 +79,7 @@ pub fn routes() -> Router<AppState> {
         .merge(authenticated)
 }
 
+#[tracing::instrument(skip(state, payload), fields(user_id = %payload.user_id))]
 async fn topup(State(state): State<AppState>, Json(payload): Json<TopupDto>) -> impl IntoResponse {
     let currency = payload.currency.unwrap_or_else(|| "USD".to_string());
     match state
@@ -91,6 +92,7 @@ async fn topup(State(state): State<AppState>, Json(payload): Json<TopupDto>) -> 
     }
 }
 
+#[tracing::instrument(skip(state, payload), fields(username = %payload.username))]
 async fn register(
     State(state): State<AppState>,
     Json(payload): Json<RegisterDto>,
@@ -153,6 +155,7 @@ async fn check_username(
     }
 }
 
+#[tracing::instrument(skip(state, payload), fields(username = %payload.username))]
 async fn login(State(state): State<AppState>, Json(payload): Json<LoginDto>) -> impl IntoResponse {
     match state
         .user_service
@@ -212,6 +215,7 @@ fn persist_client_state(username: &str, token: &str) {
     }
 }
 
+#[tracing::instrument(skip_all)]
 async fn list_users(State(state): State<AppState>) -> impl IntoResponse {
     match state.user_service.list_users(&state.db).await {
         Ok(users) => {
@@ -245,6 +249,7 @@ async fn list_users(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
+#[tracing::instrument(skip_all)]
 async fn list_recharges(
     State(state): State<AppState>,
     Extension(claims): Extension<Claims>,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod logging;
 pub use api::auth::{auth_middleware, Claims};
 
+use axum::http::HeaderName;
 use axum::{routing::get, Router};
 use burncloud_database::{create_default_database, Database};
 use burncloud_database_router::RouterDatabase;
@@ -14,6 +15,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tower_http::cors::CorsLayer;
+use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
 use tower_http::trace::TraceLayer;
 
 #[derive(Clone)]
@@ -24,6 +26,7 @@ pub struct AppState {
     pub force_sync_tx: mpsc::Sender<oneshot::Sender<SyncResult>>,
 }
 
+#[tracing::instrument(skip(db))]
 pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Result<Router> {
     let monitor = Arc::new(SystemMonitorService::new());
     // Start auto collection in background
@@ -62,14 +65,22 @@ pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Res
     // Note: If LiveView is disabled, "/" requests will hit the fallback (router_app)
     // which usually returns 404 for unknown paths, or handles LLM requests.
 
+    let x_request_id = HeaderName::from_static("x-request-id");
+
     let app = app
         .fallback_service(router_app)
+        .layer(SetRequestIdLayer::new(
+            x_request_id.clone(),
+            MakeRequestUuid,
+        ))
+        .layer(PropagateRequestIdLayer::new(x_request_id.clone()))
         .layer(TraceLayer::new_for_http())
         .layer(CorsLayer::permissive());
 
     Ok(app)
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn start_server(host: &str, port: u16, enable_liveview: bool) -> anyhow::Result<()> {
     let db = create_default_database().await?;
     RouterDatabase::init(&db).await?;

--- a/crates/service/crates/inference/Cargo.toml
+++ b/crates/service/crates/inference/Cargo.toml
@@ -13,7 +13,6 @@ reqwest = { workspace = true }
 burncloud-database = { workspace = true }
 burncloud-database-router = { workspace = true }
 tracing = { workspace = true }
-log = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use burncloud_auto_update::AutoUpdater;
 use burncloud_database::Database;
 use clap::{Arg, Command};
-use log::{error, info};
+use tracing::{error, info};
 
 use super::bundle::handle_bundle_command;
 use super::channel::handle_channel_command;

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use burncloud_database_sys::InstallerDB;
 use burncloud_installer::{Installer, InstallerConfig};
 use clap::ArgMatches;
-use log::error;
+use tracing::error;
 use std::path::PathBuf;
 
 /// Handle install subcommand


### PR DESCRIPTION
## Summary

Implements #198

Closes #198

## Summary by Sourcery

Migrate logging across the workspace toward structured tracing-based logging and enrich server APIs with tracing instrumentation and request correlation.

New Features:
- Add HTTP request ID generation and propagation to the server using tower-http request-id support.

Enhancements:
- Replace legacy log/env_logger usage with tracing and tracing-subscriber in workspace crates, including installer and auto-update.
- Annotate key server HTTP handlers and auth/user/group/token/security endpoints with tracing instrumentation and contextual fields for better observability.
- Derive Debug on various API DTOs to improve log output and debugging of request payloads.

Build:
- Update workspace and crate Cargo.toml files to depend on tracing instead of log and enable tower-http request-id feature where needed.