### PR TITLE
feat: implement issue #213 - 在 CLAUDE.md 中明确 Upstream Policy：禁止接入第三方中转 API

### DIFF
--- a/crates/service/crates/user/src/lib.rs
+++ b/crates/service/crates/user/src/lib.rs
@@ -458,11 +458,25 @@ impl Default for UserService {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use burncloud_database::create_default_database;
+    use burncloud_database::create_database_with_url;
+
+    async fn test_db() -> burncloud_database::Result<Database> {
+        let path = format!("/tmp/burncloud_test_{}.db", uuid::Uuid::new_v4());
+        let url = format!("sqlite:///{}?mode=rwc", path);
+        let db = create_database_with_url(&url).await?;
+        // Clean up temp file when db is dropped
+        let path_clone = path.clone();
+        tokio::spawn(async move {
+            let _ = std::fs::remove_file(&path_clone);
+            let _ = std::fs::remove_file(format!("{}-shm", &path_clone));
+            let _ = std::fs::remove_file(format!("{}-wal", &path_clone));
+        });
+        Ok(db)
+    }
 
     #[tokio::test]
     async fn test_register_user() -> anyhow::Result<()> {
-        let db = create_default_database().await?;
+        let db = test_db().await?;
         UserDatabase::init(&db).await?;
 
         let service = UserService::new();
@@ -493,7 +507,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_duplicate_user() -> anyhow::Result<()> {
-        let db = create_default_database().await?;
+        let db = test_db().await?;
         UserDatabase::init(&db).await?;
 
         let service = UserService::new();
@@ -519,7 +533,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_login_user_success() -> anyhow::Result<()> {
-        let db = create_default_database().await?;
+        let db = test_db().await?;
         UserDatabase::init(&db).await?;
 
         let service = UserService::new();
@@ -543,7 +557,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_login_user_wrong_password() -> anyhow::Result<()> {
-        let db = create_default_database().await?;
+        let db = test_db().await?;
         UserDatabase::init(&db).await?;
 
         let service = UserService::new();
@@ -567,7 +581,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_login_user_not_found() -> anyhow::Result<()> {
-        let db = create_default_database().await?;
+        let db = test_db().await?;
         UserDatabase::init(&db).await?;
 
         let service = UserService::new();

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -37,6 +37,29 @@ Client (Dioxus) → Server (axum) → Router (data plane)
 | 日志 | `log::info!` / `log::warn!` / `log::error!` | `eprintln!` / `println!` |
 | 错误类型 | `thiserror::Error` derive | 裸 `String` / `Box<dyn Error>` |
 
+## Upstream Policy（上游接入硬规则）
+
+BurnCloud 仅接入**可溯源的信誉平台**，禁止匿名/不可溯源的第三方中转。
+
+**准入标准**：客户能明确知道资源来路 + 平台有公开品牌和运营主体。
+
+| 类别 | 平台 | ChannelType | Base URL |
+|------|------|-------------|----------|
+| 官方直连 | Anthropic | 14 | `https://api.anthropic.com` |
+| 官方直连 | OpenAI | 1 | `https://api.openai.com` |
+| 官方直连 | 智谱AI (Zhipu) | 16 | `https://open.bigmodel.cn` |
+| 官方直连 | DeepSeek | 43 | `https://api.deepseek.com` |
+| 官方直连 | 阿里云百炼 (Ali) | 17 | `https://dashscope.aliyuncs.com` |
+| 官方直连 | 月之暗面 (Moonshot) | 25 | `https://api.moonshot.cn` |
+| 信誉聚合 | OpenRouter | 20 | `https://openrouter.ai/api/v1` |
+| 信誉聚合 | SiliconFlow | 40 | `https://api.siliconflow.cn/v1` |
+
+**禁止接入**：one-api、new-api 等自建匿名中转。代码中 `ChannelType::NewApi(58)` 为历史遗留，禁止新增此类渠道。
+
+**适用范围**：源代码、配置文件、环境变量示例、文档示例、测试用例、CI 脚本。
+
+新平台接入需满足准入标准并经 PR 评审。
+
 ---
 
 ## Service 两种模式


### PR DESCRIPTION
## Summary

Implements #213

Closes #213

## Summary by Sourcery

Document upstream integration policy restricting connections to reputable, traceable providers and adjust user service tests to use isolated temporary SQLite databases.

Documentation:
- Add an upstream policy section defining allowed official and reputable aggregation providers and explicitly banning anonymous relay APIs across code, config, docs, tests, and CI.

Tests:
- Update user service tests to create and use per-test temporary SQLite databases instead of the default shared database.