### PR TITLE
fix: CLI bugs round 2 — 7 fixes across 14 files

### DIFF
--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -349,9 +349,15 @@ pub struct Ability {
     pub group: String,
     pub model: String,
     pub channel_id: i32,
-    pub enabled: bool,
+    pub enabled: i32,
     pub priority: i64,
     pub weight: i32,
+}
+
+impl Ability {
+    pub fn enabled_bool(&self) -> bool {
+        self.enabled != 0
+    }
 }
 
 /// Spec-aligned alias: `channel_abilities` row type.
@@ -418,7 +424,7 @@ pub struct ProtocolConfig {
     /// API version string (e.g., "2024-02-01", "v1")
     pub api_version: String,
     /// Whether this is the default config for the channel type
-    pub is_default: bool,
+    pub is_default: i32,
     /// Chat completions endpoint (supports placeholders like {deployment_id})
     pub chat_endpoint: Option<String>,
     /// Embeddings endpoint
@@ -443,7 +449,7 @@ impl Default for ProtocolConfig {
             id: 0,
             channel_type: 1, // OpenAI
             api_version: "default".to_string(),
-            is_default: true,
+            is_default: 1,
             chat_endpoint: Some("/v1/chat/completions".to_string()),
             embed_endpoint: Some("/v1/embeddings".to_string()),
             models_endpoint: Some("/v1/models".to_string()),

--- a/crates/database/crates/billing/src/billing_price.rs
+++ b/crates/database/crates/billing/src/billing_price.rs
@@ -206,6 +206,7 @@ impl BillingPriceModel {
     }
 
     /// Get all prices for a model across all currencies
+    /// `region = None` is normalized to `""` to match rows stored by `upsert()`.
     pub async fn get_all_currencies(
         db: &Database,
         model: &str,
@@ -213,6 +214,8 @@ impl BillingPriceModel {
     ) -> Result<Vec<Price>> {
         let conn = db.get_connection()?;
         let is_postgres = db.kind() == "postgres";
+        // upsert() normalises None → ""; queries must use the same convention.
+        let region_key = region.unwrap_or("");
 
         let sql = if is_postgres {
             r#"SELECT id, model, currency, input_price, output_price,
@@ -227,7 +230,7 @@ impl BillingPriceModel {
                       supports_vision, supports_function_calling,
                       voices_pricing, video_pricing, asr_pricing, realtime_pricing, model_type,
                       synced_at, created_at, updated_at
-               FROM billing_prices WHERE model = $1 AND region IS NOT DISTINCT FROM $2
+               FROM billing_prices WHERE model = $1 AND region = $2
                ORDER BY currency"#
         } else {
             r#"SELECT id, model, currency, input_price, output_price,
@@ -242,21 +245,20 @@ impl BillingPriceModel {
                       supports_vision, supports_function_calling,
                       voices_pricing, video_pricing, asr_pricing, realtime_pricing, model_type,
                       synced_at, created_at, updated_at
-               FROM billing_prices WHERE model = ? AND (region = ? OR (region IS NULL AND ? IS NULL))
+               FROM billing_prices WHERE model = ? AND region = ?
                ORDER BY currency"#
         };
 
         let prices = if is_postgres {
             sqlx::query_as(sql)
                 .bind(model)
-                .bind(region)
+                .bind(region_key)
                 .fetch_all(conn.pool())
                 .await?
         } else {
             sqlx::query_as(sql)
                 .bind(model)
-                .bind(region)
-                .bind(region)
+                .bind(region_key)
                 .fetch_all(conn.pool())
                 .await?
         };
@@ -265,6 +267,7 @@ impl BillingPriceModel {
     }
 
     /// List all prices with pagination
+    /// `region = None` is normalized to `""` to match rows stored by `upsert()`.
     pub async fn list(
         db: &Database,
         limit: i32,
@@ -274,6 +277,8 @@ impl BillingPriceModel {
     ) -> Result<Vec<Price>> {
         let conn = db.get_connection()?;
         let is_postgres = db.kind() == "postgres";
+        // upsert() normalises None → ""; queries must use the same convention.
+        let region_key = region.unwrap_or("");
 
         let base_select = r#"SELECT id, model, currency, input_price, output_price,
                               cache_read_input_price, cache_creation_input_price,
@@ -288,17 +293,17 @@ impl BillingPriceModel {
                               synced_at, created_at, updated_at"#;
 
         let prices = match (currency, region) {
-            (Some(curr), Some(reg)) => {
+            (Some(curr), Some(_)) => {
                 // Filter by both currency and region
                 let sql = if is_postgres {
                     &format!(
-                        r#"{} FROM billing_prices WHERE currency = $1 AND region IS NOT DISTINCT FROM $2
+                        r#"{} FROM billing_prices WHERE currency = $1 AND region = $2
                        ORDER BY model LIMIT $3 OFFSET $4"#,
                         base_select
                     )
                 } else {
                     &format!(
-                        r#"{} FROM billing_prices WHERE currency = ? AND (region = ? OR (region IS NULL AND ? IS NULL))
+                        r#"{} FROM billing_prices WHERE currency = ? AND region = ?
                        ORDER BY model LIMIT ? OFFSET ?"#,
                         base_select
                     )
@@ -306,7 +311,7 @@ impl BillingPriceModel {
                 if is_postgres {
                     sqlx::query_as(sql)
                         .bind(curr)
-                        .bind(reg)
+                        .bind(region_key)
                         .bind(limit)
                         .bind(offset)
                         .fetch_all(conn.pool())
@@ -314,8 +319,7 @@ impl BillingPriceModel {
                 } else {
                     sqlx::query_as(sql)
                         .bind(curr)
-                        .bind(reg)
-                        .bind(reg)
+                        .bind(region_key)
                         .bind(limit)
                         .bind(offset)
                         .fetch_all(conn.pool())
@@ -344,32 +348,31 @@ impl BillingPriceModel {
                     .fetch_all(conn.pool())
                     .await?
             }
-            (None, Some(reg)) => {
+            (None, Some(_)) => {
                 // Filter by region only
                 let sql = if is_postgres {
                     &format!(
-                        r#"{} FROM billing_prices WHERE region IS NOT DISTINCT FROM $1
+                        r#"{} FROM billing_prices WHERE region = $1
                        ORDER BY model, currency LIMIT $2 OFFSET $3"#,
                         base_select
                     )
                 } else {
                     &format!(
-                        r#"{} FROM billing_prices WHERE (region = ? OR (region IS NULL AND ? IS NULL))
+                        r#"{} FROM billing_prices WHERE region = ?
                        ORDER BY model, currency LIMIT ? OFFSET ?"#,
                         base_select
                     )
                 };
                 if is_postgres {
                     sqlx::query_as(sql)
-                        .bind(reg)
+                        .bind(region_key)
                         .bind(limit)
                         .bind(offset)
                         .fetch_all(conn.pool())
                         .await?
                 } else {
                     sqlx::query_as(sql)
-                        .bind(reg)
-                        .bind(reg)
+                        .bind(region_key)
                         .bind(limit)
                         .bind(offset)
                         .fetch_all(conn.pool())
@@ -804,13 +807,14 @@ impl BillingPriceModel {
             }
             None => {
                 let sql = if is_postgres {
-                    "DELETE FROM billing_prices WHERE model = $1 AND currency = $2 AND region IS NULL"
+                    "DELETE FROM billing_prices WHERE model = $1 AND currency = $2 AND region = $3"
                 } else {
-                    "DELETE FROM billing_prices WHERE model = ? AND currency = ? AND region IS NULL"
+                    "DELETE FROM billing_prices WHERE model = ? AND currency = ? AND region = ?"
                 };
                 sqlx::query(sql)
                     .bind(model)
                     .bind(currency)
+                    .bind("")
                     .execute(conn.pool())
                     .await?
             }

--- a/crates/database/crates/channel/src/channel_protocol_config.rs
+++ b/crates/database/crates/channel/src/channel_protocol_config.rs
@@ -8,7 +8,7 @@ pub struct ChannelProtocolConfig {
     pub id: i32,
     pub channel_type: i32,
     pub api_version: String,
-    pub is_default: bool,
+    pub is_default: i32,
     pub chat_endpoint: Option<String>,
     pub embed_endpoint: Option<String>,
     pub models_endpoint: Option<String>,
@@ -17,6 +17,12 @@ pub struct ChannelProtocolConfig {
     pub detection_rules: Option<String>,
     pub created_at: Option<i64>,
     pub updated_at: Option<i64>,
+}
+
+impl ChannelProtocolConfig {
+    pub fn is_default_bool(&self) -> bool {
+        self.is_default != 0
+    }
 }
 
 /// Input for creating/updating a channel protocol config

--- a/crates/database/crates/user/src/lib.rs
+++ b/crates/database/crates/user/src/lib.rs
@@ -469,9 +469,11 @@ impl UserDatabase {
                     .bind(currency)
                     .bind(&recharge.description)
                     .execute(conn.pool())
-                    .await?
-                    .last_insert_id()
-                    .unwrap_or(0) as i32
+                    .await?;
+                let id: i32 = sqlx::query_scalar("SELECT last_insert_rowid()")
+                    .fetch_one(conn.pool())
+                    .await?;
+                id
             }
             "postgres" => {
                 sqlx::query("INSERT INTO user_recharges (user_id, amount, currency, description) VALUES ($1, $2, $3, $4) RETURNING id")

--- a/crates/database/migrations/sqlite/0013_fix_bool_columns.sql
+++ b/crates/database/migrations/sqlite/0013_fix_bool_columns.sql
@@ -1,0 +1,41 @@
+-- Fix SQLite bool columns: BOOLEAN → INTEGER
+-- The sqlx Any driver cannot decode SQLite BOOLEAN into Rust bool.
+-- These columns store 0/1 integers anyway, so just change the declared type.
+
+-- channel_protocol_configs.is_default
+CREATE TABLE channel_protocol_configs_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    channel_type INTEGER NOT NULL,
+    api_version TEXT NOT NULL,
+    is_default INTEGER NOT NULL DEFAULT 0,
+    chat_endpoint TEXT,
+    embed_endpoint TEXT,
+    models_endpoint TEXT,
+    request_mapping TEXT,
+    response_mapping TEXT,
+    detection_rules TEXT,
+    created_at INTEGER,
+    updated_at INTEGER
+);
+
+INSERT INTO channel_protocol_configs_new SELECT * FROM channel_protocol_configs;
+DROP TABLE channel_protocol_configs;
+ALTER TABLE channel_protocol_configs_new RENAME TO channel_protocol_configs;
+
+-- channel_abilities.enabled
+CREATE TABLE channel_abilities_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_name TEXT NOT NULL,
+    model TEXT NOT NULL,
+    channel_id INTEGER NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    priority INTEGER NOT NULL DEFAULT 0,
+    weight INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER,
+    updated_at INTEGER,
+    FOREIGN KEY (channel_id) REFERENCES channels(id)
+);
+
+INSERT INTO channel_abilities_new SELECT * FROM channel_abilities;
+DROP TABLE channel_abilities;
+ALTER TABLE channel_abilities_new RENAME TO channel_abilities;

--- a/crates/router/src/exchange_rate.rs
+++ b/crates/router/src/exchange_rate.rs
@@ -66,29 +66,31 @@ impl ExchangeRateService {
     }
 
     /// Convert an amount from one currency to another
-    pub fn convert(&self, amount: f64, from: Currency, to: Currency) -> f64 {
+    pub fn convert(&self, amount: f64, from: Currency, to: Currency) -> anyhow::Result<f64> {
         if from == to {
-            return amount;
+            return Ok(amount);
         }
 
         if let Some(rate) = self.get_rate(from, to) {
-            amount * rate
+            Ok(amount * rate)
         } else {
             // Fallback: try reverse rate
             if let Some(reverse_rate) = self.get_rate(to, from) {
                 if reverse_rate > 0.0 {
-                    amount / reverse_rate
+                    Ok(amount / reverse_rate)
                 } else {
-                    amount
+                    Err(anyhow::anyhow!(
+                        "Invalid reverse exchange rate for {} -> {}",
+                        to,
+                        from
+                    ))
                 }
             } else {
-                // No rate available, return original amount
-                tracing::warn!(
-                    "No exchange rate found for {} -> {}, returning original amount",
+                Err(anyhow::anyhow!(
+                    "No exchange rate found for {} -> {}",
                     from,
                     to
-                );
-                amount
+                ))
             }
         }
     }
@@ -310,7 +312,7 @@ mod tests {
     fn test_convert_same_currency() {
         let service = create_test_service();
 
-        let amount = service.convert(100.0, Currency::USD, Currency::USD);
+        let amount = service.convert(100.0, Currency::USD, Currency::USD).unwrap();
         assert!((amount - 100.0).abs() < 0.001);
     }
 
@@ -333,11 +335,11 @@ mod tests {
 
         service.set_rate(Currency::USD, Currency::CNY, 7.2);
 
-        let amount = service.convert(100.0, Currency::USD, Currency::CNY);
+        let amount = service.convert(100.0, Currency::USD, Currency::CNY).unwrap();
         assert!((amount - 720.0).abs() < 0.001);
 
         // Reverse conversion using reverse rate
-        let amount = service.convert(720.0, Currency::CNY, Currency::USD);
+        let amount = service.convert(720.0, Currency::CNY, Currency::USD).unwrap();
         assert!((amount - 100.0).abs() < 0.001);
     }
 
@@ -345,9 +347,9 @@ mod tests {
     fn test_convert_missing_rate() {
         let service = create_test_service();
 
-        // No rate set, should return original amount
-        let amount = service.convert(100.0, Currency::USD, Currency::EUR);
-        assert!((amount - 100.0).abs() < 0.001);
+        // No rate set, should return error
+        let result = service.convert(100.0, Currency::USD, Currency::EUR);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -397,9 +399,9 @@ mod tests {
         service.set_rate(Currency::EUR, Currency::CNY, 7.75);
 
         // Test each conversion
-        assert!((service.convert(100.0, Currency::USD, Currency::CNY) - 720.0).abs() < 0.001);
-        assert!((service.convert(100.0, Currency::USD, Currency::EUR) - 93.0).abs() < 0.001);
-        assert!((service.convert(100.0, Currency::EUR, Currency::CNY) - 775.0).abs() < 0.001);
+        assert!((service.convert(100.0, Currency::USD, Currency::CNY).unwrap() - 720.0).abs() < 0.001);
+        assert!((service.convert(100.0, Currency::USD, Currency::EUR).unwrap() - 93.0).abs() < 0.001);
+        assert!((service.convert(100.0, Currency::EUR, Currency::CNY).unwrap() - 775.0).abs() < 0.001);
 
         // Verify all rates are stored
         let rates = service.list_rates();
@@ -414,11 +416,11 @@ mod tests {
         service.set_rate(Currency::USD, Currency::CNY, 7.2);
 
         // Forward conversion uses direct rate
-        let forward = service.convert(100.0, Currency::USD, Currency::CNY);
+        let forward = service.convert(100.0, Currency::USD, Currency::CNY).unwrap();
         assert!((forward - 720.0).abs() < 0.001);
 
         // Reverse conversion uses reverse rate calculation
-        let reverse = service.convert(720.0, Currency::CNY, Currency::USD);
+        let reverse = service.convert(720.0, Currency::CNY, Currency::USD).unwrap();
         assert!((reverse - 100.0).abs() < 0.001);
     }
 
@@ -431,16 +433,12 @@ mod tests {
         service.set_rate(Currency::EUR, Currency::USD, 1.08);
 
         // EUR to USD (direct rate exists)
-        let eur_to_usd = service.convert(100.0, Currency::EUR, Currency::USD);
+        let eur_to_usd = service.convert(100.0, Currency::EUR, Currency::USD).unwrap();
         assert!((eur_to_usd - 108.0).abs() < 0.001);
 
-        // EUR to CNY (no direct rate, should return original amount as fallback)
-        // Note: This tests the current behavior where only direct/reverse rates work
+        // EUR to CNY (no direct rate and no reverse rate, should error)
         let eur_to_cny = service.convert(100.0, Currency::EUR, Currency::CNY);
-        // Since there's no direct EUR->CNY rate and we don't do multi-hop,
-        // it returns original amount (current implementation)
-        // In a full implementation, this would be 100 * 1.08 * 7.2 = 777.6
-        assert!((eur_to_cny - 100.0).abs() < 0.001);
+        assert!(eur_to_cny.is_err());
     }
 
     #[test]
@@ -448,7 +446,7 @@ mod tests {
         let service = create_test_service();
         service.set_rate(Currency::USD, Currency::CNY, 7.2);
 
-        let amount = service.convert(0.0, Currency::USD, Currency::CNY);
+        let amount = service.convert(0.0, Currency::USD, Currency::CNY).unwrap();
         assert!((amount - 0.0).abs() < 0.001);
     }
 
@@ -460,13 +458,12 @@ mod tests {
         service.set_rate(Currency::USD, Currency::CNY, -7.2);
 
         // Forward conversion with negative rate should work
-        let amount = service.convert(100.0, Currency::USD, Currency::CNY);
+        let amount = service.convert(100.0, Currency::USD, Currency::CNY).unwrap();
         assert!((amount - (-720.0)).abs() < 0.001);
 
         // Reverse conversion: when reverse_rate is negative (not > 0),
-        // the code returns the original amount as a safety measure
+        // the code returns an error
         let reverse = service.convert(720.0, Currency::CNY, Currency::USD);
-        // Due to safety check (reverse_rate > 0.0), returns original amount
-        assert!((reverse - 720.0).abs() < 0.001);
+        assert!(reverse.is_err());
     }
 }

--- a/crates/router/src/model_router.rs
+++ b/crates/router/src/model_router.rs
@@ -271,12 +271,17 @@ impl ModelRouter {
                 let raw = price.input_price.saturating_add(price.output_price);
                 let nano = match burncloud_common::Currency::from_str(&price.currency) {
                     Ok(curr) if curr != burncloud_common::Currency::USD => {
-                        let usd = exchange_rate.convert(
+                        match exchange_rate.convert(
                             raw as f64,
                             curr,
                             burncloud_common::Currency::USD,
-                        );
-                        usd as i64
+                        ) {
+                            Ok(usd) => usd as i64,
+                            Err(e) => {
+                                tracing::warn!("Currency conversion failed: {e}, using raw amount");
+                                raw
+                            }
+                        }
                     }
                     _ => raw,
                 };

--- a/crates/router/src/scheduler/mod.rs
+++ b/crates/router/src/scheduler/mod.rs
@@ -321,7 +321,13 @@ pub async fn build_context(
                 let raw = price.input_price as f64 + price.output_price as f64;
                 let price_usd = match burncloud_common::Currency::from_str(&price.currency) {
                     Ok(curr) if curr != burncloud_common::Currency::USD => {
-                        exchange_rate.convert(raw, curr, burncloud_common::Currency::USD)
+                        match exchange_rate.convert(raw, curr, burncloud_common::Currency::USD) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                tracing::warn!("Currency conversion failed: {e}, using raw amount");
+                                raw
+                            }
+                        }
                     }
                     _ => raw,
                 };

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -638,6 +638,13 @@ pub async fn handle_command(args: &[String]) -> Result<()> {
                             Arg::new("user-id")
                                 .long("user-id")
                                 .help("Filter by user ID"),
+                        )
+                        .arg(
+                            Arg::new("format")
+                                .long("format")
+                                .default_value("table")
+                                .value_parser(["table", "json"])
+                                .help("Output format (table or json)"),
                         ),
                 )
                 .subcommand(
@@ -975,6 +982,13 @@ pub async fn handle_command(args: &[String]) -> Result<()> {
                                 .long("limit")
                                 .default_value("100")
                                 .help("Maximum number of results"),
+                        )
+                        .arg(
+                            Arg::new("format")
+                                .long("format")
+                                .default_value("table")
+                                .value_parser(["table", "json"])
+                                .help("Output format (table or json)"),
                         ),
                 )
                 .subcommand(

--- a/src/cli/price.rs
+++ b/src/cli/price.rs
@@ -51,22 +51,35 @@ pub async fn handle_price_command(db: &Database, matches: &ArgMatches) -> Result
                 return Ok(());
             }
 
-            println!(
-                "{:<30} {:>8} {:>15} {:>15} {:>10}",
-                "Model", "Currency", "Input ($/1M)", "Output ($/1M)", "Region"
-            );
-            println!("{}", "-".repeat(80));
+            let format = sub_m
+                .get_one::<String>("format")
+                .map(|s| s.as_str())
+                .unwrap_or("table");
 
-            for price in prices {
-                let region = price.region.as_deref().unwrap_or("-");
-                println!(
-                    "{:<30} {:>8} {:>15.4} {:>15.4} {:>10}",
-                    price.model,
-                    price.currency,
-                    from_nano(price.input_price),
-                    from_nano(price.output_price),
-                    region
-                );
+            match format {
+                "json" => {
+                    let json = serde_json::to_string_pretty(&prices)?;
+                    println!("{}", json);
+                }
+                _ => {
+                    println!(
+                        "{:<30} {:>8} {:>15} {:>15} {:>10}",
+                        "Model", "Currency", "Input ($/1M)", "Output ($/1M)", "Region"
+                    );
+                    println!("{}", "-".repeat(80));
+
+                    for price in prices {
+                        let region = price.region.as_deref().unwrap_or("-");
+                        println!(
+                            "{:<30} {:>8} {:>15.4} {:>15.4} {:>10}",
+                            price.model,
+                            price.currency,
+                            from_nano(price.input_price),
+                            from_nano(price.output_price),
+                            region
+                        );
+                    }
+                }
             }
         }
         Some(("set", sub_m)) => {

--- a/src/cli/protocol.rs
+++ b/src/cli/protocol.rs
@@ -30,7 +30,7 @@ pub async fn handle_protocol_command(db: &Database, matches: &ArgMatches) -> Res
 
             for config in configs {
                 let channel_type_name = channel_type_to_name(config.channel_type);
-                let is_default = if config.is_default { "Yes" } else { "No" };
+                let is_default = if config.is_default_bool() { "Yes" } else { "No" };
                 let endpoint = config.chat_endpoint.as_deref().unwrap_or("-");
                 println!(
                     "{:<5} {:<12} {:<18} {:<8} {:<35}",

--- a/src/cli/token.rs
+++ b/src/cli/token.rs
@@ -16,6 +16,10 @@ pub async fn handle_token_command(db: &Database, matches: &ArgMatches) -> Result
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(0);
             let user_id = sub_m.get_one::<String>("user-id").map(|s| s.as_str());
+            let format = sub_m
+                .get_one::<String>("format")
+                .map(|s| s.as_str())
+                .unwrap_or("table");
 
             let tokens = UserApiKeyModel::list(db, limit, offset, user_id).await?;
 
@@ -24,33 +28,41 @@ pub async fn handle_token_command(db: &Database, matches: &ArgMatches) -> Result
                 return Ok(());
             }
 
-            println!(
-                "{:<52} {:<20} {:<12} {:>12} {:<8} {:>12}",
-                "Key", "Name", "User", "Quota", "Status", "Expired"
-            );
-            println!("{}", "-".repeat(120));
+            match format {
+                "json" => {
+                    let json = serde_json::to_string_pretty(&tokens)?;
+                    println!("{}", json);
+                }
+                _ => {
+                    println!(
+                        "{:<52} {:<20} {:<12} {:>12} {:<8} {:>12}",
+                        "Key", "Name", "User", "Quota", "Status", "Expired"
+                    );
+                    println!("{}", "-".repeat(120));
 
-            for token in tokens {
-                let name = token.name.as_deref().unwrap_or("-");
-                let quota = if token.unlimited_quota {
-                    "unlimited".to_string()
-                } else {
-                    token.remain_quota.to_string()
-                };
-                let status = if token.status == 1 {
-                    "active"
-                } else {
-                    "disabled"
-                };
-                let expired = if token.expired_time == -1 {
-                    "never".to_string()
-                } else {
-                    format!("{}", token.expired_time)
-                };
-                println!(
-                    "{:<52} {:<20} {:<12} {:>12} {:<8} {:>12}",
-                    token.key, name, token.user_id, quota, status, expired
-                );
+                    for token in tokens {
+                        let name = token.name.as_deref().unwrap_or("-");
+                        let quota = if token.unlimited_quota {
+                            "unlimited".to_string()
+                        } else {
+                            token.remain_quota.to_string()
+                        };
+                        let status = if token.status == 1 {
+                            "active"
+                        } else {
+                            "disabled"
+                        };
+                        let expired = if token.expired_time == -1 {
+                            "never".to_string()
+                        } else {
+                            format!("{}", token.expired_time)
+                        };
+                        println!(
+                            "{:<52} {:<20} {:<12} {:>12} {:<8} {:>12}",
+                            token.key, name, token.user_id, quota, status, expired
+                        );
+                    }
+                }
             }
         }
         Some(("create", sub_m)) => {

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -235,22 +235,33 @@ pub async fn cmd_user_recharges(db: &Database, matches: &ArgMatches) -> Result<(
         return Ok(());
     }
 
-    // Table format output
-    println!(
-        "{:<10} {:<15} {:<10} {:<40} {:<20}",
-        "ID", "Amount", "Currency", "Description", "CreatedAt"
-    );
-    println!("{}", "-".repeat(100));
-    for recharge in recharges {
-        // Convert nanodollars to display format
-        let amount = recharge.amount as f64 / 1_000_000_000.0;
-        let currency = recharge.currency.as_deref().unwrap_or("USD");
-        let description = recharge.description.as_deref().unwrap_or("N/A");
-        let created_at = recharge.created_at.as_deref().unwrap_or("N/A");
-        println!(
-            "{:<10} ${:<14.2} {:<10} {:<40} {:<20}",
-            recharge.id, amount, currency, description, created_at
-        );
+    let format = matches
+        .get_one::<String>("format")
+        .map(|s| s.as_str())
+        .unwrap_or("table");
+
+    match format {
+        "json" => {
+            let json = serde_json::to_string_pretty(&recharges)?;
+            println!("{}", json);
+        }
+        _ => {
+            println!(
+                "{:<10} {:<15} {:<10} {:<40} {:<20}",
+                "ID", "Amount", "Currency", "Description", "CreatedAt"
+            );
+            println!("{}", "-".repeat(100));
+            for recharge in recharges {
+                let amount = recharge.amount as f64 / 1_000_000_000.0;
+                let currency = recharge.currency.as_deref().unwrap_or("USD");
+                let description = recharge.description.as_deref().unwrap_or("N/A");
+                let created_at = recharge.created_at.as_deref().unwrap_or("N/A");
+                println!(
+                    "{:<10} ${:<14.2} {:<10} {:<40} {:<20}",
+                    recharge.id, amount, currency, description, created_at
+                );
+            }
+        }
     }
 
     Ok(())
@@ -295,6 +306,13 @@ pub async fn cmd_user_topup(db: &Database, matches: &ArgMatches) -> Result<()> {
         ));
     }
 
+    // Verify user exists
+    if UserDatabase::get_user_by_username(db, user_id).await?.is_none()
+        && UserDatabase::get_user_by_id(db, user_id).await?.is_none()
+    {
+        return Err(anyhow::anyhow!("User '{}' not found", user_id));
+    }
+
     // Parse amount (in dollars) and convert to nanodollars
     let amount_dollar: f64 = amount_str
         .parse()
@@ -318,7 +336,7 @@ pub async fn cmd_user_topup(db: &Database, matches: &ArgMatches) -> Result<()> {
 
     let recharge_id = UserDatabase::create_recharge(db, &recharge).await?;
 
-    // Get new balance
+    // Get new balance (create_recharge already updated it)
     let new_balance_nano = UserDatabase::update_balance(db, user_id, 0, Some(&currency)).await?;
 
     // Convert nanodollars to display format

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,16 @@ fn main() -> Result<()> {
     // Auto-generate MASTER_KEY if missing
     ensure_master_key();
 
+    let args: Vec<String> = env::args().collect();
+
+    // For CLI commands (not server/router), suppress INFO logs on stdout
+    let is_server = args.len() >= 2 && matches!(args[1].as_str(), "server" | "router" | "client");
+    if !is_server {
+        env::set_var("RUST_LOG", "error");
+    }
+
     // 初始化日志（tracing-subscriber + 文件输出）
     let _logging_guards = burncloud_server::logging::init_logging();
-
-    let args: Vec<String> = env::args().collect();
 
     match args.as_slice() {
         [_] => {


### PR DESCRIPTION
## Summary

- Fix SQLite BOOLEAN→INTEGER for `is_default` and `enabled` columns (sqlx Any driver can't decode SQLite BOOLEAN into Rust bool) — addresses #217, #219
- Fix `price get/show` returning empty for models without region (normalize `None→""` to match `upsert()` convention) — addresses #218
- Add `--format json` to `token list`, `price list`, `user recharges` subcommands
- Fix `user topup` showing raw FK error instead of "User not found" (validate user exists before insert)
- Fix `user topup` Recharge ID=0 on SQLite (use `SELECT last_insert_rowid()` instead of `unwrap_or(0)`)
- Fix INFO log leak in CLI output (set `RUST_LOG=error` for non-server commands)
- Fix `ExchangeRateService::convert()` silent fallback — now returns `Result<f64>` with proper error when no rate exists, instead of silently returning original amount

## Test plan

- [x] `cargo build` compiles successfully
- [x] `cargo test -p burncloud-router` — 175 tests pass (including updated exchange_rate tests)
- [x] `cargo test -p burncloud-common` — 36 tests pass
- [ ] Manual: `burncloud protocol list` works without SQLite bool error
- [ ] Manual: `burncloud price get <model>` returns results for models without region
- [ ] Manual: `burncloud token list --format json` outputs JSON
- [ ] Manual: `burncloud user topup <invalid-id> 10 USD` shows "User not found" instead of FK error
- [ ] Manual: CLI commands no longer leak INFO log lines to stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix multiple CLI and backend issues around pricing, user topups, logging, SQLite booleans, and exchange-rate error handling.

New Features:
- Add optional JSON output format to the token list, price list, and user recharges CLI commands.

Bug Fixes:
- Normalize price region filtering so models without a region can be queried consistently across databases.
- Validate user existence before creating recharges to surface a clear "User not found" error instead of a foreign key error in the user topup CLI command.
- Correct retrieval of the last inserted recharge ID on SQLite to avoid returning ID 0.
- Prevent INFO-level log lines from leaking into CLI output by tightening default logging for non-server commands.
- Resolve SQLite BOOLEAN decoding issues by switching relevant columns to INTEGER and updating corresponding Rust types.

Enhancements:
- Change the exchange-rate conversion API to return a Result and propagate explicit errors when rates are missing or invalid, updating routing and scheduler logic to log and fall back gracefully.