### PR TITLE
fix: phantom video_tokens billing and doubled request path

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -859,6 +859,30 @@ async fn usage_models_handler(
     }
 }
 
+/// Normalize doubled path prefixes caused by client SDKs that include the
+/// endpoint path in their base_url. For example, when a client sets
+/// base_url = "https://gateway/v1/messages" and the SDK appends "/v1/messages",
+/// the resulting path is "/v1/messages/v1/messages" — this function collapses
+/// it back to "/v1/messages".
+fn normalize_doubled_path(path: &str) -> String {
+    // Known endpoint prefixes that clients may double
+    const PREFIXES: &[&str] = &["/v1/messages", "/v1/chat/completions", "/v1/embeddings"];
+
+    for prefix in PREFIXES {
+        let doubled = format!("{prefix}{prefix}");
+        if path.starts_with(&doubled) {
+            let rest = &path[prefix.len()..];
+            let normalized = format!("{prefix}{rest}");
+            if normalized != path {
+                tracing::debug!(original = %path, normalized = %normalized, "Normalized doubled path prefix");
+            }
+            return normalized;
+        }
+    }
+
+    path.to_string()
+}
+
 /// Inject video_tokens into usage for video models whose responses contain no usage field.
 ///
 /// Used for request-side billing when the upstream response has no token/usage data.
@@ -985,7 +1009,11 @@ async fn proxy_handler(
 ) -> Response {
     let start_time = Instant::now();
     let request_id = Uuid::new_v4().to_string();
-    let path = uri.path().to_string();
+    let raw_path = uri.path().to_string();
+
+    // Normalize doubled path prefixes caused by client SDKs that include
+    // the endpoint path in their base_url (e.g. /v1/messages/v1/messages → /v1/messages).
+    let path = normalize_doubled_path(&raw_path);
 
     // 0. Authenticate User
     // Support "Authorization: Bearer sk-xxx", "x-api-key: sk-xxx" (Anthropic native), and "x-goog-api-key: sk-xxx" (Gemini native)
@@ -1174,6 +1202,8 @@ async fn proxy_handler(
 
     // Extract Seedance / NewApi video generation fields for request-side billing.
     // Seedance's response has no usage field; duration and resolution are in the request body.
+    // Only compute seedance fields for video generation paths — zero them out otherwise
+    // to prevent phantom video_tokens injection on non-video requests.
     let (seedance_duration_secs, seedance_resolution) = if path == "/v1/video/generations" {
         let v = serde_json::from_slice::<serde_json::Value>(&body_bytes).ok();
         let dur = v
@@ -1188,7 +1218,7 @@ async fn proxy_handler(
             .to_string();
         (dur, res)
     } else {
-        (5i64, "720p".to_string())
+        (0i64, "480p".to_string())
     };
 
     // Detect request type for advanced billing


### PR DESCRIPTION
## Summary

- **Fix phantom video_tokens billing**: Seedance defaults (`duration=5, resolution=720p`) were applied to ALL non-video-generation requests, producing `seedance_tokens=10` that got injected as `video_tokens` via `inject_video_tokens_if_empty()`. This caused phantom billing of $0.00003/request on 365 requests, totaling **$0.01095 in leaked charges**. Fixed by zeroing out seedance defaults in the else branch.
- **Fix doubled request path**: Client SDKs that include the endpoint path in `base_url` produce doubled paths like `/v1/messages/v1/messages`. Added `normalize_doubled_path()` to collapse these at the `proxy_handler` entry point.

## Root Cause Analysis

### Bug 1: Phantom video_tokens billing (CRITICAL)

**Code path** (`lib.rs:1190-1192` → `1362-1364`):
```
else branch: seedance_duration_secs = 5, seedance_resolution = "720p"
→ seedance_tokens = 5 × 2 = 10
→ inject_video_tokens_if_empty(status, usage, 10, "seedance")
→ video_tokens = 10 injected when usage is empty
→ video_cost = nano(10, input_price=3_000_000_000) = 30,000 nanodollars = $0.00003
```

**Fix**: else branch now returns `(0, "480p")` → `seedance_tokens = 0 × 1 = 0` → no injection.

### Bug 2: Doubled request path (MEDIUM)

Client SDKs set `base_url = "https://gateway/v1/messages"` and the SDK appends `/v1/messages` again, producing `/v1/messages/v1/messages`. This doubled path was forwarded to upstream and caused incorrect routing decisions.

**Fix**: `normalize_doubled_path()` detects and collapses doubled prefixes for `/v1/message`, `/v1/chat/completions`, and `/v1/embeddings`.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p burncloud-router -p burncloud-service-billing -p burncloud-database-router` — 361 tests pass, 0 failures
- [x] Server restarts successfully with the fix
- [ ] Verify new requests no longer show `video_tokens=10` on non-video paths
- [ ] Verify doubled paths like `/v1/messages/v1/messages` are normalized to `/v1/messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix billing and routing behavior for specific API paths.

Bug Fixes:
- Prevent non-video requests from being billed with default Seedance video_tokens by zeroing Seedance defaults on non-video paths.
- Normalize doubled API path prefixes (e.g., /v1/messages/v1/messages) at the router entrypoint to ensure correct upstream routing.