### PR TITLE
fix: user_roles table dropped on fresh installs

### DIFF
--- a/crates/database/src/schema/rename.rs
+++ b/crates/database/src/schema/rename.rs
@@ -26,6 +26,15 @@
 //! Steps 1–2 free the name `user_roles` before step 2 claims it.
 //! Step 4 (recharges) is placed before step 3's DROP so that in PostgreSQL
 //! the FK `recharges.user_id → users.id` is removed before `users` is dropped.
+//!
+//! ## Fresh install handling
+//!
+//! On fresh installs, `0010_rename_tables.sql` creates tables with canonical names
+//! (e.g., `user_roles` for role definitions). The rename logic must detect this to
+//! avoid dropping newly created tables. The detection works by checking if the
+//! source and destination tables have no shared columns — if so, they are different
+//! table types (e.g., new `user_roles` role table vs `user_role_bindings` binding table),
+//! indicating the source was created by 0010, not a legacy table needing migration.
 
 use crate::Result;
 use sqlx::{AnyPool, Row};
@@ -63,6 +72,10 @@ pub(super) async fn migrate_table_renames(pool: &AnyPool, kind: &str) -> Result<
 /// - `old_table` does not exist (migration already completed or never needed).
 /// - `new_table` already contains rows (copy already ran; skip to avoid
 ///   duplicates, but still drop the old table if it remains).
+/// - **Fresh install detection**: if `old_table` and `new_table` have no shared
+///   columns, they are different table types (e.g., new `user_roles` role table
+///   vs `user_role_bindings` binding table), indicating a fresh install where
+///   `old_table` was created by 0010_rename_tables.sql, not a legacy table.
 ///
 /// ## Column mismatch handling
 ///
@@ -79,6 +92,29 @@ async fn copy_and_drop(pool: &AnyPool, kind: &str, old_table: &str, new_table: &
         return;
     }
 
+    // Get column lists for both tables
+    let old_cols = column_names(pool, kind, old_table).await;
+    let new_cols = column_names(pool, kind, new_table).await;
+
+    // Fresh install detection: if old_table and new_table have no shared columns,
+    // they are different table types. This happens when:
+    // - 0010_rename_tables.sql created a new table with the same name as a legacy table
+    //   but with different purpose (e.g., new user_roles role table vs old user_roles binding table)
+    // - The "old_table" is actually the newly created table, not a legacy table needing migration
+    // In this case, skip the entire operation to avoid dropping the newly created table.
+    let shared: Vec<String> = old_cols
+        .iter()
+        .filter(|c| new_cols.iter().any(|n| n.eq_ignore_ascii_case(c)))
+        .cloned()
+        .collect();
+
+    if shared.is_empty() {
+        tracing::info!(
+            "[Rename] Skipping {old_table} → {new_table}: no shared columns indicates fresh install (table created by 0010, not legacy)"
+        );
+        return;
+    }
+
     // Guard: only copy when the destination is still empty to avoid duplicates.
     let new_count: i64 = sqlx::query_scalar(&format!("SELECT COUNT(*) FROM {new_table}"))
         .fetch_one(pool)
@@ -88,31 +124,15 @@ async fn copy_and_drop(pool: &AnyPool, kind: &str, old_table: &str, new_table: &
     if new_count == 0 {
         tracing::info!("[Rename] Migrating data: {old_table} → {new_table}");
 
-        // Intersect source and destination columns so that adding columns to
-        // the new table in later migrations does not break the copy.
-        let old_cols = column_names(pool, kind, old_table).await;
-        let new_cols = column_names(pool, kind, new_table).await;
-        let shared: Vec<String> = old_cols
+        let col_list = shared
             .iter()
-            .filter(|c| new_cols.iter().any(|n| n.eq_ignore_ascii_case(c)))
-            .cloned()
-            .collect();
-
-        if shared.is_empty() {
-            tracing::warn!(
-                "[Rename] No shared columns between {old_table} and {new_table}; skipping copy"
-            );
-        } else {
-            let col_list = shared
-                .iter()
-                .map(|c| quote_ident(c))
-                .collect::<Vec<_>>()
-                .join(", ");
-            let insert_sql =
-                format!("INSERT INTO {new_table} ({col_list}) SELECT {col_list} FROM {old_table}");
-            if let Err(e) = sqlx::query(&insert_sql).execute(pool).await {
-                tracing::warn!("[Rename] Copy {old_table} → {new_table} failed: {e}");
-            }
+            .map(|c| quote_ident(c))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let insert_sql =
+            format!("INSERT INTO {new_table} ({col_list}) SELECT {col_list} FROM {old_table}");
+        if let Err(e) = sqlx::query(&insert_sql).execute(pool).await {
+            tracing::warn!("[Rename] Copy {old_table} → {new_table} failed: {e}");
         }
     }
 

--- a/crates/database/tests/migration_rename_tests.rs
+++ b/crates/database/tests/migration_rename_tests.rs
@@ -12,12 +12,6 @@
 //!
 //! Strategy: create a fresh SQLite database via `create_database_with_url`, which
 //! runs all migrations (0001–0010) and the `schema/rename.rs` data-copy logic.
-//!
-//! **Known issue**: `user_roles` is dropped by `rename.rs` on fresh installs.
-//! Migration 0010 creates `user_roles` (the new name for the old `roles` table),
-//! but `rename.rs` step 1 treats it as the old `user_roles` binding table, copies
-//! its (empty) rows into `user_role_bindings`, then drops it. Tests for `user_roles`
-//! are therefore omitted until rename.rs is fixed to skip when source == target schema.
 
 use burncloud_database::{create_database_with_url, sqlx};
 use sqlx::any::{AnyConnectOptions, AnyPoolOptions};
@@ -70,7 +64,11 @@ async fn test_new_user_tables_exist() {
         table_exists(&db, "user_accounts").await,
         "user_accounts must exist"
     );
-    // user_roles omitted — see module-level known-issue note
+    // user_roles now exists after fixing rename.rs fresh-install detection
+    assert!(
+        table_exists(&db, "user_roles").await,
+        "user_roles must exist (was dropped by rename.rs bug before fix)"
+    );
     assert!(
         table_exists(&db, "user_role_bindings").await,
         "user_role_bindings must exist"


### PR DESCRIPTION
## Summary

Fixes a bug where the `user_roles` table was incorrectly dropped on fresh installations, causing "no such table: user_roles" errors at runtime.

## Problem

On fresh installations:
1. Migration `0010_rename_tables.sql` creates the `user_roles` table (role definitions)
2. `rename.rs` step 1 treats this newly created table as a legacy `user_roles` binding table
3. Since the new `user_roles` (role table) has different columns than `user_role_bindings` (binding table), the migration logic drops it
4. This causes the server to crash with "no such table: user_roles" error

## Solution

Added fresh-install detection to `copy_and_drop()`:
- If the source and destination tables have **no shared columns**, they are different table types
- This indicates the source was created by `0010_rename_tables.sql`, not a legacy table
- Skip the entire operation to preserve the newly created table

## Test Plan

- [x] All 42 migration_rename_tests pass
- [x] `user_roles` table now exists after fresh install
- [x] Data migration tests still work correctly for upgrade scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix table rename migration logic to avoid dropping the new user_roles table on fresh installs and update tests to assert its presence.

Bug Fixes:
- Prevent fresh installs from dropping the newly created user_roles table by detecting and skipping renames where old and new tables have no shared columns.

Tests:
- Extend migration rename tests to verify that the user_roles table exists after a fresh installation.