### PR TITLE
fix(database): preserve existing data by default, require FRESH_DB=1 to delete

### DIFF
--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -52,14 +52,12 @@ impl Database {
             let default_path = get_default_database_path()?;
             create_directory_if_not_exists(&default_path)?;
 
-            // BURNCLOUD_FRESH_DB=1 (default for local SQLite): delete the
-            // SQLite file so the next connection starts from a blank database.
-            // Used by CI/verification runners to guarantee a clean state for
-            // first-user-is-admin tests.  Defaults to enabled when no explicit
-            // BURNCLOUD_DATABASE_URL is set (dev/verification scenario).
-            // Production deployments set BURNCLOUD_DATABASE_URL (Postgres) and
-            // are unaffected.  Set BURNCLOUD_FRESH_DB=0 to opt out.
-            let fresh_db = std::env::var("BURNCLOUD_FRESH_DB").as_deref() != Ok("0");
+            // BURNCLOUD_FRESH_DB=1: delete the SQLite file so the next connection
+            // starts from a blank database. Used by CI/verification runners to
+            // guarantee a clean state for first-user-is-admin tests.
+            // Default is to preserve existing data. Set BURNCLOUD_FRESH_DB=1 to
+            // explicitly request a fresh database (dev/CI scenario).
+            let fresh_db = std::env::var("BURNCLOUD_FRESH_DB").as_deref() == Ok("1");
             if fresh_db && default_path.exists() {
                 tracing::info!("BURNCLOUD_FRESH_DB: deleting {}", default_path.display());
                 std::fs::remove_file(&default_path).map_err(|e| {


### PR DESCRIPTION
## Summary
- Changed `BURNCLOUD_FRESH_DB` behavior: now defaults to preserving existing data
- Previously: database was deleted unless `BURNCLOUD_FRESH_DB=0` was explicitly set
- Now: database is only deleted when `BURNCLOUD_FRESH_DB=1` is explicitly set

## Problem
The previous logic caused unexpected data loss:
```rust
let fresh_db = std::env::var("BURNCLOUD_FRESH_DB").as_deref() != Ok("0");
```
This meant:
- `BURNCLOUD_FRESH_DB` not set → delete database (dangerous default!)
- `BURNCLOUD_FRESH_DB=0` → preserve database
- `BURNCLOUD_FRESH_DB=1` → delete database

## Solution
```rust
let fresh_db = std::env::var("BURNCLOUD_FRESH_DB").as_deref() == Ok("1");
```
Now:
- `BURNCLOUD_FRESH_DB` not set → preserve database (safe default)
- `BURNCLOUD_FRESH_DB=0` → preserve database
- `BURNCLOUD_FRESH_DB=1` → delete database

## Test plan
- [x] Code compiles successfully
- [ ] Manual test: start server without env var, verify data persists on restart
- [ ] CI tests should pass (they can set `BURNCLOUD_FRESH_DB=1` if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)