### PR TITLE
feat(router): support OpenAI format passthrough for OpenAI channels

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -1929,6 +1929,19 @@ async fn proxy_logic(
                     .header("x-api-key", &upstream.api_key)
                     .header("anthropic-version", "2023-06-01");
                 (req, is_stream, false)
+            } else if channel_type == ChannelType::OpenAI {
+                // OpenAI passthrough: forward to base_url + /chat/completions
+                let base = upstream.base_url.trim_end_matches('/');
+                let url = format!("{base}/chat/completions");
+                let is_stream = body_json
+                    .get("stream")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let req = state
+                    .client
+                    .request(method.clone(), &url)
+                    .header("Authorization", format!("Bearer {}", &upstream.api_key));
+                (req, is_stream, false)
             } else {
                 // Gemini passthrough
                 let passthrough_url =

--- a/crates/router/src/passthrough.rs
+++ b/crates/router/src/passthrough.rs
@@ -60,6 +60,15 @@ pub fn should_passthrough(
         return PassthroughDecision::Convert;
     }
 
+    // OpenAI channels: passthrough for OpenAI format requests
+    if channel_type == ChannelType::OpenAI {
+        // OpenAI native path: /v1/chat/completions
+        if path.starts_with("/v1/chat/completions") || path.starts_with("/chat/completions") {
+            return PassthroughDecision::Passthrough;
+        }
+        return PassthroughDecision::Convert;
+    }
+
     // Only Gemini/Vertex channels support passthrough
     if channel_type != ChannelType::Gemini && channel_type != ChannelType::VertexAi {
         return PassthroughDecision::Convert;


### PR DESCRIPTION
## Summary

- Add passthrough mode for OpenAI-type channels when receiving OpenAI format requests (`/v1/chat/completions`)
- Previously, OpenAI channels were incorrectly using conversion mode, causing empty responses

## Changes

### `crates/router/src/passthrough.rs`
- Add OpenAI channel detection for passthrough mode
- Return `PassthroughDecision::Passthrough` when path matches `/v1/chat/completions`

### `crates/router/src/lib.rs`
- Add OpenAI passthrough URL building: `base_url + /chat/completions`
- Use Bearer token authentication for OpenAI channels

## Test Plan

1. Create an OpenAI-type channel with Xunfei's `/v2` endpoint
2. Send OpenAI format request to `/v1/chat/completions`
3. Verify response contains correct content

```bash
curl -X POST http://localhost:3000/v1/chat/completions \
  -H "Authorization: Bearer sk-xxx" \
  -d '{"model": "astron-code-latest", "messages": [{"role": "user", "content": "Hello"}]}'
```

Expected: Response with non-empty `content` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)