### PR TITLE
feat: OpenTelemetry distributed tracing integration (Issue #244)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,3 +81,11 @@ TEST_OPENAI_API_KEY=sk-1231234567890abcdefgHIJKLMNOPQRSTuvwxYZ
 # z.ai uses Anthropic-compatible API format at /api/anthropic/v1/messages
 # ZAI_API_KEY=your-zai-api-key
 # ZAI_BASE_URL=https://api.z.ai/api/anthropic
+
+# ── OpenTelemetry Distributed Tracing ─────────────────────────────────────────
+# OTLP collector endpoint (e.g., http://localhost:4317 for Jaeger/Tempo)
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# Sampling rate (0.0 to 1.0, default: 0.1 for 10%)
+# OTEL_TRACES_SAMPLER_ARG=0.1
+# Service name for tracing (default: burncloud)
+# OTEL_SERVICE_NAME=burncloud

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,12 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 tracing-log = "0.2"
+# OpenTelemetry for distributed tracing
+opentelemetry = "0.27"
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic"] }
+opentelemetry-semantic-conventions = "0.27"
+tracing-opentelemetry = "0.28"
 
 # Internal crates
 burncloud-auto-update = { path = "crates/auto-update" }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -34,6 +34,7 @@ chrono = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
 tower-http = { workspace = true, features = ["trace", "cors"] }
 tracing.workspace = true
+tracing-opentelemetry.workspace = true
 prometheus.workspace = true
 async-trait.workspace = true
 futures.workspace = true

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -923,6 +923,7 @@ async fn health_status_handler(State(state): State<AppState>) -> Response {
     )
 }
 
+#[tracing::instrument(skip_all, fields(request_id))]
 async fn proxy_handler(
     State(state): State<AppState>,
     method: Method,
@@ -932,6 +933,8 @@ async fn proxy_handler(
 ) -> Response {
     let start_time = Instant::now();
     let request_id = Uuid::new_v4().to_string();
+    // Record request_id in span for OpenTelemetry tracing
+    tracing::Span::current().record("request_id", &request_id);
     let raw_path = uri.path().to_string();
 
     // Normalize doubled path prefixes caused by client SDKs that include
@@ -1528,7 +1531,7 @@ struct ShaperContext {
     /// `X-Rejected-By: shaper` (audit decision D12).
     rejected_count: u32,
 }
-
+#[tracing::instrument(skip_all, fields(model, channel_id, user_id))]
 #[allow(clippy::too_many_arguments)]
 async fn proxy_logic(
     state: &AppState,
@@ -1545,6 +1548,8 @@ async fn proxy_logic(
     model_name: Option<&str>,
     request_start_time: Instant,
 ) -> ProxyResult {
+    // Record user_id in span for OpenTelemetry tracing
+    tracing::Span::current().record("user_id", user_id);
     // Model Routing
     let mut candidates: Vec<Upstream> = Vec::new();
     // L6 Observability: routing decision from route_with_scheduler.
@@ -1587,6 +1592,8 @@ async fn proxy_logic(
         let model_opt = model_ref.or(gemini_path_model.as_deref());
 
         if let Some(model) = model_opt {
+            // Record model in span for OpenTelemetry tracing
+            tracing::Span::current().record("model", model);
             // Use scheduler-based routing for multi-channel failover
             // Clone the policy for this group, then release the lock immediately.
             // This prevents the lock from being held during SQL queries and async
@@ -1845,6 +1852,8 @@ async fn proxy_logic(
             });
         }
         last_upstream_id = Some(upstream.id.clone());
+        // Record channel_id in span for OpenTelemetry tracing
+        tracing::Span::current().record("channel_id", &upstream.id);
 
         // Update pricing_region for billing to match the actual upstream serving
         selected_pricing_region = upstream.pricing_region.clone();

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -18,6 +18,11 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
 tracing-log.workspace = true
+opentelemetry.workspace = true
+opentelemetry_sdk.workspace = true
+opentelemetry-otlp.workspace = true
+tracing-opentelemetry.workspace = true
+opentelemetry-semantic-conventions.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 axum = { workspace = true, features = ["macros"] }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod logging;
+pub mod telemetry;
 pub use api::auth::{auth_middleware, Claims};
 
 use axum::http::HeaderName;

--- a/crates/server/src/logging.rs
+++ b/crates/server/src/logging.rs
@@ -13,6 +13,7 @@ use tracing_subscriber::{
 /// - Daily log rotation with retention via `LOG_MAX_FILES` (default: 7)
 /// - Log directory via `LOG_DIR` env var (default: `./logs`)
 /// - `tracing-log` bridge so existing `log::*!` calls route to tracing
+/// - Optional OpenTelemetry layer for distributed tracing via OTLP
 ///
 /// Returns `WorkerGuard`s that must be held for the program's lifetime.
 pub fn init_logging() -> Vec<WorkerGuard> {
@@ -38,7 +39,11 @@ pub fn init_logging() -> Vec<WorkerGuard> {
     let (router_nb, g) = file_appender(&log_dir, "router", max_files);
     guards.push(g);
 
+    // Try to initialize OpenTelemetry layer (optional)
+    let otlp_layer = crate::telemetry::init_telemetry();
+
     let subscriber = tracing_subscriber::registry()
+        .with(otlp_layer)
         .with(tracing_subscriber::fmt::layer().with_filter(env_filter))
         .with(
             tracing_subscriber::fmt::layer()

--- a/crates/server/src/telemetry.rs
+++ b/crates/server/src/telemetry.rs
@@ -1,0 +1,82 @@
+//! OpenTelemetry distributed tracing initialization.
+//!
+//! This module provides OpenTelemetry integration for distributed tracing,
+//! supporting OTLP protocol export to backends like Jaeger, Zipkin, and Grafana Tempo.
+//!
+//! # Configuration
+//!
+//! Tracing is configured via environment variables:
+//!
+//! - `OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP collector endpoint (e.g., `http://localhost:4317`)
+//! - `OTEL_TRACES_SAMPLER_ARG`: Sampling rate (0.0 to 1.0, default: 0.1 for 10%)
+//! - `OTEL_SERVICE_NAME`: Service name (default: `burncloud`)
+//!
+//! # Example
+//!
+//! ```bash
+//! # Enable tracing with 10% sampling
+//! export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+//! export OTEL_TRACES_SAMPLER_ARG=0.1
+//! ```
+
+use opentelemetry::{trace::TracerProvider, KeyValue};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::trace::Sampler;
+use std::env;
+
+/// Initialize OpenTelemetry tracing layer.
+///
+/// Returns `Some(layer)` if OTLP endpoint is configured, `None` otherwise.
+/// The returned layer should be added to the tracing subscriber.
+pub fn init_telemetry() -> Option<
+    tracing_opentelemetry::OpenTelemetryLayer<
+        tracing_subscriber::Registry,
+        opentelemetry_sdk::trace::Tracer,
+    >,
+> {
+    let endpoint = env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()?;
+
+    let service_name = env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "burncloud".to_string());
+
+    let sample_rate = env::var("OTEL_TRACES_SAMPLER_ARG")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(0.1)
+        .clamp(0.0, 1.0);
+
+    tracing::info!(
+        endpoint = %endpoint,
+        service_name = %service_name,
+        sample_rate = sample_rate,
+        "Initializing OpenTelemetry tracing"
+    );
+
+    let resource = opentelemetry_sdk::Resource::new([KeyValue::new(
+        opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+        service_name,
+    )]);
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(&endpoint)
+        .build()
+        .ok()?;
+
+    let tracer_provider = opentelemetry_sdk::trace::TracerProvider::builder()
+        .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+        .with_resource(resource)
+        .with_sampler(Sampler::TraceIdRatioBased(sample_rate))
+        .build();
+
+    let tracer = tracer_provider.tracer("burncloud");
+
+    Some(tracing_opentelemetry::layer().with_tracer(tracer))
+}
+
+/// Shutdown OpenTelemetry tracer provider.
+///
+/// This should be called when the application shuts down to flush
+/// any remaining spans to the collector.
+pub fn shutdown_telemetry() {
+    opentelemetry::global::shutdown_tracer_provider();
+}


### PR DESCRIPTION
## 功能描述

集成 OpenTelemetry 分布式追踪，支持请求链路分析和性能瓶颈定位。

## 实现内容

### 依赖添加
-  0.27
-  0.27 (with rt-tokio feature)
-  0.27 (with grpc-tonic feature)
-  0.27
-  0.28

### Telemetry 模块
- 创建 `crates/server/src/telemetry.rs` 模块
- OTLP exporter 初始化，支持 gRPC 协议
- 可配置采样率 (默认 10%)
- 服务名称配置 (默认 burncloud)

### Span 插桩
- `proxy_handler`: 记录 request_id
- `proxy_logic`: 记录 model, channel_id, user_id

### 配置方式
通过环境变量配置：
```bash
export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
export OTEL_TRACES_SAMPLER_ARG=0.1
export OTEL_SERVICE_NAME=burncloud
```

### 兼容性
- Jaeger
- Zipkin
- Grafana Tempo

## 测试
- 编译通过: `cargo build -p burncloud-server -p burncloud-router`
- 测试通过: 179 passed (1 个已存在的测试失败与本次更改无关)

Closes #244