### PR TITLE
fix(security): add authentication to Token and User APIs (Issues #281, #282)

### DIFF
--- a/crates/server/src/api/token.rs
+++ b/crates/server/src/api/token.rs
@@ -1,6 +1,7 @@
 use crate::AppState;
 use axum::{
     extract::{Path, State},
+    middleware,
     response::{IntoResponse, Json},
     routing::{get, post},
     Router,
@@ -53,6 +54,7 @@ pub fn routes() -> Router<AppState> {
             "/console/api/tokens/{token}/ip-whitelist",
             post(set_ip_whitelist),
         )
+        .layer(middleware::from_fn(crate::auth_middleware))
 }
 
 #[tracing::instrument(skip_all)]

--- a/crates/server/src/api/user.rs
+++ b/crates/server/src/api/user.rs
@@ -68,6 +68,7 @@ struct UserSummary {
 pub fn routes() -> Router<AppState> {
     let authenticated = Router::new()
         .route("/console/api/user/recharges", get(list_recharges))
+        .route("/console/api/list_users", get(list_users))
         .layer(middleware::from_fn(crate::auth_middleware));
 
     Router::new()
@@ -75,7 +76,6 @@ pub fn routes() -> Router<AppState> {
         .route("/console/api/user/login", post(login))
         .route("/console/api/user/topup", post(topup))
         .route("/console/api/user/check_username", get(check_username))
-        .route("/console/api/list_users", get(list_users))
         .merge(authenticated)
 }
 


### PR DESCRIPTION
## 安全修复

修复了两个安全漏洞：
- **Issue #281**: `/console/api/tokens` 端点无需认证即可访问
- **Issue #282**: `/console/api/list_users` 端点无需认证即可访问

## 修复内容

### Token API (`crates/server/src/api/token.rs`)
- 为所有 `/console/api/tokens` 路由添加认证中间件
- 包括：list_tokens, create_token, get_token, update_token, delete_token, rotate_token 等

### User API (`crates/server/src/api/user.rs`)
- 将 `/console/api/list_users` 路由移入 authenticated Router
- 现在需要有效的 JWT Token 才能访问

## 测试
- 编译检查通过
- 需要验证：无认证访问时返回 401 Unauthorized

Closes #281
Closes #282