### PR TITLE
fix(router): add catch-all for unmatched /console/api/* paths (Issue #289)

### DIFF
--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -1,7 +1,12 @@
 use crate::AppState;
 pub mod security;
 
-use axum::Router;
+use axum::{
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
 
 pub mod auth;
 pub mod billing;
@@ -12,6 +17,12 @@ pub mod openapi;
 pub mod response;
 pub mod token;
 pub mod user;
+
+/// Fallback handler for unmatched /console/api/* requests
+/// Returns 404 instead of being caught by LiveView's catch-all
+async fn api_not_found() -> impl IntoResponse {
+    (StatusCode::NOT_FOUND, "API endpoint not found")
+}
 
 pub fn routes(state: AppState) -> Router {
     Router::new()
@@ -24,5 +35,8 @@ pub fn routes(state: AppState) -> Router {
         .merge(user::routes())
         .merge(security::security_routes())
         .merge(openapi::routes())
+        // Catch-all for any unmatched /console/api/* paths
+        // This prevents LiveView from returning HTML for non-existent API endpoints
+        .route("/console/api/{*path}", get(api_not_found))
         .with_state(state)
 }


### PR DESCRIPTION
## Summary

Fixes security issue where invalid `/console/api/*` paths were caught by LiveView's catch-all route and returned HTML (200 status) instead of being properly handled.

## Problem

When requesting non-existent API endpoints like:
- `GET /console/api/billing` → 200 (HTML page)
- `GET /console/api/api-keys` → 200 (HTML page)

These were caught by LiveView's catch-all `/console/{*path}` route, returning frontend HTML instead of an appropriate error response.

## Solution

Add a catch-all route `/console/api/{*path}` that returns 404 for any unmatched API paths. This ensures:
1. Invalid API endpoints return proper 404 status
2. LiveView's catch-all no longer intercepts API requests
3. Clear error message for debugging

## Changes

- Add `api_not_found` fallback handler in `api/mod.rs`
- Returns 404 with "API endpoint not found" message
- Registered as last route in API router to catch all unmatched paths
- Resolved merge conflict with main branch (Issue #285 cache integration)

## Security Impact

Before: Invalid API paths leaked frontend HTML structure
After: Invalid API paths return proper 404 error

## Testing

- [x] `cargo check --package burncloud-server` passes
- [x] `cargo test --package burncloud-server` passes

## Programming Constraints Checklist

- [x] No cross-layer calls (Handler only calls Service/Database via state)
- [x] Service does not hold Database (no changes)
- [x] SQL uses ph()/phs() (no SQL changes)
- [x] Errors use thiserror (no new error types)
- [x] No `unwrap()`/`expect()` in non-test code
- [x] Uses `tracing::*!` for logging (no changes needed)
- [x] Handler uses `ok()`/`err()` (no changes needed)
- [x] Handler uses `State<AppState>` (no changes needed)
- [x] Files placed correctly

Closes #289