### PR TITLE
fix(ui): 修复首页"开始使用"按钮文字颜色显示为白色的问题

### DIFF
--- a/crates/client/crates/client-shared/src/styles.rs
+++ b/crates/client/crates/client-shared/src/styles.rs
@@ -1503,8 +1503,8 @@ html .overflow-x-scroll:hover::-webkit-scrollbar-thumb:hover {
 
 /* Buttons */
 .landing-btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 10px 18px; border-radius: 9999px; font-size: 14px; font-weight: 600; transition: all 150ms; cursor: pointer; border: 1px solid transparent; }
-.landing-btn-light { background: #FFFFFF; color: #000; }
-.landing-btn-light:hover { background: rgba(255,255,255,0.92); transform: translateY(-1px); }
+.landing-btn-light { background: #FFFFFF; color: #000 !important; }
+.landing-btn-light:hover { background: rgba(255,255,255,0.92); transform: translateY(-1px); color: #000 !important; }
 .landing-btn-ghost { background: transparent; color: #FFFFFF; border-color: rgba(255,255,255,0.2); }
 .landing-btn-ghost:hover { border-color: rgba(255,255,255,0.45); }
 .landing-btn-dark { background: #000; color: #fff; }


### PR DESCRIPTION
## 问题
首页界面的"开始使用"按钮显示为白色文字，在白色背景上无法看清。

## 根本原因
Tailwind CSS 基础样式  使链接元素继承父级颜色。首页  和  区域设置了 （白色），导致  的  被  覆盖。

## 解决方案
在  样式中添加  强制指定黑色文字，确保按钮在白色背景上显示黑色文字。

## 修改文件
- `crates/client/crates/client-shared/src/styles.rs`: 修复  样式

## 测试
- ✅ `cargo check -p burncloud-client-shared` 编译通过

Closes #307