### PR TITLE
fix(router): failover on auth errors (401/402) and add xunfei channel type

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -2292,16 +2292,22 @@ async fn proxy_logic(
                             error_message,
                             &session_id,
                         );
-                        // 429: try next ranked candidate
-                        if status == StatusCode::TOO_MANY_REQUESTS {
+                        // 429 (rate limit), 401 (auth failed), 402 (payment required):
+                        // try next ranked candidate — other channels may have valid credentials.
+                        if status == StatusCode::TOO_MANY_REQUESTS
+                            || status == StatusCode::UNAUTHORIZED
+                            || status == StatusCode::PAYMENT_REQUIRED
+                        {
                             tracing::warn!(
-                                "Passthrough: {} rate limited, trying next candidate",
-                                upstream.name
+                                "Passthrough: {} returned {}, trying next candidate",
+                                upstream.name,
+                                status.as_u16()
                             );
+                            last_error = error_message.to_string();
                             continue;
                         }
 
-                        // 4xx response: actual usage = 0. budget_guard drops
+                        // Other 4xx response: actual usage = 0. budget_guard drops
                         // on return → full est_tpm refund (no commit).
                         let et = match failure_type {
                             FailureType::AuthFailed => "auth_failed",

--- a/src/cli/channel.rs
+++ b/src/cli/channel.rs
@@ -16,7 +16,7 @@ use std::io::{self, Write};
 
 /// Parse channel type from string
 ///
-/// Supports: openai, azure, anthropic, gemini, aws, vertexai, deepseek
+/// Supports: openai, azure, anthropic, gemini, aws, vertexai, deepseek, xunfei
 pub fn parse_channel_type(s: &str) -> Result<ChannelType> {
     match s.to_lowercase().as_str() {
         "openai" => Ok(ChannelType::OpenAI),
@@ -29,8 +29,9 @@ pub fn parse_channel_type(s: &str) -> Result<ChannelType> {
         "newapi" | "new-api" => Ok(ChannelType::NewApi),
         "volcengine" | "volc" => Ok(ChannelType::VolcEngine),
         "doubaovideo" | "doubao-video" | "seedance" => Ok(ChannelType::DoubaoVideo),
+        "xunfei" | "xfyun" => Ok(ChannelType::Xunfei),
         _ => Err(anyhow!(
-            "Unsupported channel type: '{}'. Supported types: openai, azure, anthropic, gemini, aws, vertexai, deepseek, newapi, volcengine, seedance",
+            "Unsupported channel type: '{}'. Supported types: openai, azure, anthropic, gemini, aws, vertexai, deepseek, newapi, volcengine, seedance, xunfei",
             s
         )),
     }
@@ -48,6 +49,7 @@ pub fn get_default_models(channel_type: ChannelType) -> Vec<&'static str> {
         ChannelType::DeepSeek => vec!["deepseek-chat", "deepseek-coder"],
         ChannelType::NewApi => vec![],
         ChannelType::VolcEngine => vec![],
+        ChannelType::Xunfei => vec!["spark-lite", "spark-v2.0", "spark-v3.0", "spark-v3.5", "spark-v4.0"],
         ChannelType::DoubaoVideo => vec![
             "doubao-seedance-2-0-260128",
             "doubao-seedance-2-0-fast-260128",
@@ -86,6 +88,7 @@ pub fn get_channel_type_name(channel_type: ChannelType) -> &'static str {
         ChannelType::DeepSeek => "DeepSeek",
         ChannelType::NewApi => "NewApi",
         ChannelType::VolcEngine => "VolcEngine",
+        ChannelType::Xunfei => "Xunfei",
         ChannelType::DoubaoVideo => "DoubaoVideo",
         _ => "Unknown",
     }


### PR DESCRIPTION
## 问题

当渠道返回 401 (Unauthorized) 或 402 (Payment Required) 错误时，请求直接返回错误给客户端，不会尝试 failover 到其他渠道。这导致即使有其他渠道配置了正确的 API key，请求仍然失败。

## 修复

1. **Failover 逻辑改进**: 将 401 和 402 错误加入 failover 触发条件
   - 之前：只有 429 (rate limit) 触发 failover
   - 现在：429、401、402 都会触发 failover 到下一个候选渠道

2. **CLI 支持 xunfei 渠道类型**: 添加讯飞星火渠道类型支持
   - 支持 `xunfei` 和 `xfyun` 作为渠道类型
   - 默认模型: spark-lite, spark-v2.0, spark-v3.0, spark-v3.5, spark-v4.0

## 测试

{"error":{"message":"Invalid Token","type":"invalid_request_error","code":"invalid_token"}}

## 修改的文件

- `crates/router/src/lib.rs`: 修改 failover 逻辑
- `src/cli/channel.rs`: 添加 xunfei 渠道类型支持

🤖 Generated with [Claude Code](https://claude.com/claude-code)