### PR TITLE
feat(router): 改进 Circuit Breaker 和失败检测机制 (Issue #333)

### DIFF
--- a/crates/router/src/channel_state.rs
+++ b/crates/router/src/channel_state.rs
@@ -24,6 +24,10 @@ const LATENCY_SCORE_MIDPOINT_MS: f64 = 100.0;
 
 /// Default retry duration when no retry_after is provided (seconds).
 const DEFAULT_RATE_LIMIT_RETRY_SECS: u64 = 60;
+/// Base cooldown for transient errors (seconds).
+const BASE_COOLDOWN_SECS: u64 = 60;
+/// Maximum cooldown cap (seconds) - 30 minutes.
+const MAX_COOLDOWN_SECS: u64 = 1800;
 /// Exponential moving average smoothing factor for latency tracking.
 const LATENCY_EMA_ALPHA: f64 = 0.2;
 
@@ -394,17 +398,53 @@ impl ChannelStateTracker {
                     model_state.failure_count += 1;
                 }
             }
+            FailureType::EmptyResponse => {
+                // Empty response (HTTP 200 but zero tokens) - treat as transient error
+                if let Some(model_name) = model {
+                    let model_state = channel_state.get_or_create_model(model_name, channel_id);
+                    model_state.failure_count += 1;
+
+                    // Exponential backoff for empty responses
+                    let multiplier = 1u64 << model_state.failure_count.min(5);
+                    let cooldown_secs = (BASE_COOLDOWN_SECS * multiplier).min(MAX_COOLDOWN_SECS);
+
+                    model_state.status = ModelStatus::TemporarilyDown;
+                    model_state.rate_limit_until = Some(now + Duration::from_secs(cooldown_secs));
+                    model_state.last_error = Some(error_message.to_string());
+                    model_state.last_error_time = Some(now);
+
+                    tracing::debug!(
+                        channel_id,
+                        %model_name,
+                        failure_count = model_state.failure_count,
+                        cooldown_secs,
+                        "Empty response recorded with exponential backoff"
+                    );
+                }
+            }
             FailureType::ServerError | FailureType::Timeout | FailureType::ConnectionError => {
                 // These are transient errors, just update the model state if available
                 if let Some(model_name) = model {
                     let model_state = channel_state.get_or_create_model(model_name, channel_id);
+                    model_state.failure_count += 1;
+
+                    // Exponential backoff: cooldown grows with consecutive failures
+                    // 60s -> 120s -> 240s -> 480s -> 960s -> 1800s (capped)
+                    let multiplier = 1u64 << model_state.failure_count.min(5); // max 2^5 = 32
+                    let cooldown_secs = (BASE_COOLDOWN_SECS * multiplier).min(MAX_COOLDOWN_SECS);
+
                     model_state.status = ModelStatus::TemporarilyDown;
-                    // Set a recovery timer so is_available() can allow probe requests after expiry
-                    model_state.rate_limit_until =
-                        Some(now + Duration::from_secs(DEFAULT_RATE_LIMIT_RETRY_SECS));
+                    model_state.rate_limit_until = Some(now + Duration::from_secs(cooldown_secs));
                     model_state.last_error = Some(error_message.to_string());
                     model_state.last_error_time = Some(now);
-                    model_state.failure_count += 1;
+
+                    tracing::debug!(
+                        channel_id,
+                        %model_name,
+                        failure_count = model_state.failure_count,
+                        cooldown_secs,
+                        "Transient error recorded with exponential backoff"
+                    );
                 }
             }
         }
@@ -442,8 +482,10 @@ impl ChannelStateTracker {
 
         // If the model was temporarily down, restore it to available
         // (successful request indicates the issue is resolved)
+        // Also reset failure_count to clear exponential backoff penalty
         if model_state.status == ModelStatus::TemporarilyDown {
             model_state.status = ModelStatus::Available;
+            model_state.failure_count = 0; // Reset failure count on recovery
             model_state.last_error = None;
             model_state.last_error_time = None;
         }

--- a/crates/router/src/circuit_breaker.rs
+++ b/crates/router/src/circuit_breaker.rs
@@ -42,6 +42,8 @@ pub enum FailureType {
     Timeout,
     /// Connection failed (DNS, TCP refused, TLS handshake)
     ConnectionError,
+    /// Empty response (HTTP 200 but zero tokens)
+    EmptyResponse,
 }
 
 #[derive(Debug)]
@@ -141,12 +143,13 @@ impl CircuitBreaker {
 
         match failure_type {
             FailureType::AuthFailed | FailureType::PaymentRequired => {
-                // Auth/payment failures are permanent (bad key, exhausted quota),
-                // not transient — do NOT trip the circuit. The failure type is
-                // already recorded above; leave the failure count unchanged so
-                // transient-traffic CB semantics are preserved.
+                // Auth/payment failures are permanent (bad key, exhausted quota).
+                // Set high failure count + long cooldown (30 min) to avoid retrying.
+                entry.failure_count.store(self.failure_threshold * 10, Ordering::Relaxed);
+                entry.last_failure_time = Some(Instant::now());
+                entry.rate_limit_until = Some(Instant::now() + Duration::from_secs(1800)); // 30 minutes
                 tracing::warn!(
-                    "Circuit Breaker: Upstream {} auth/payment failure ({:?}) — recorded but NOT tripping circuit (permanent failure ≠ transient fault)",
+                    "Circuit Breaker: Upstream {} auth/payment failure ({:?}) — circuit tripped for 30 min",
                     upstream_id, failure_type
                 );
             }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -166,7 +166,10 @@ fn record_upstream_failure(
     // pin the user to a sick channel for too long.
     let should_evict = matches!(
         &failure_type,
-        FailureType::ServerError | FailureType::Timeout | FailureType::ConnectionError
+        FailureType::ServerError
+            | FailureType::Timeout
+            | FailureType::ConnectionError
+            | FailureType::EmptyResponse
     );
     if should_evict {
         if let Some(model) = model_name {
@@ -197,6 +200,44 @@ fn record_upstream_success(
     let channel_id: i32 = upstream.id.parse().unwrap_or(0);
     if let Some(model) = model_name {
         state.affinity_cache.insert(session_id, model, channel_id);
+    }
+}
+
+/// Check for empty response (zero tokens) and handle as failure if detected.
+///
+/// Returns `true` if empty response was detected (caller should continue to next candidate),
+/// `false` if response has valid tokens (caller should proceed normally).
+fn check_empty_response(
+    state: &AppState,
+    upstream: &Upstream,
+    model_name: Option<&str>,
+    session_id: &str,
+    token_counter: &UnifiedTokenCounter,
+) -> bool {
+    let usage = token_counter.get_usage();
+    if usage.is_empty() {
+        tracing::warn!(
+            channel_id = %upstream.id,
+            model = ?model_name,
+            "Empty response (zero tokens) detected, treating as failure"
+        );
+
+        // Record failure to circuit breaker and channel state
+        record_upstream_failure(
+            state,
+            upstream,
+            model_name,
+            FailureType::EmptyResponse,
+            "Empty response with zero tokens",
+            session_id,
+        );
+
+        // Note: We already called record_upstream_success earlier, which updated
+        // affinity to this channel. The record_upstream_failure will evict affinity,
+        // so the next request will not be stuck on this bad channel.
+        true // Empty response detected
+    } else {
+        false // Response has tokens
     }
 }
 
@@ -2342,6 +2383,7 @@ async fn proxy_logic(
                             FailureType::ServerError => "upstream_error",
                             FailureType::Timeout => "timeout",
                             FailureType::ConnectionError => "upstream_error",
+                            FailureType::EmptyResponse => "empty_response",
                         };
                         return ProxyResult {
                             response: build_response_with_header(
@@ -2752,6 +2794,13 @@ async fn proxy_logic(
                     if let Some(g) = budget_guard.take() {
                         g.commit(commit_tpm);
                     }
+
+                    // Check for empty response (zero tokens) - only for non-streaming
+                    // Empty response indicates a problem with the channel, should try next candidate
+                    if check_empty_response(state, upstream, model_name, &session_id, &token_counter) {
+                        continue; // Try next candidate
+                    }
+
                     return ProxyResult {
                         response: build_response_with_header(
                             status,
@@ -2881,6 +2930,7 @@ async fn proxy_logic(
                         FailureType::ServerError => "upstream_error",
                         FailureType::Timeout => "timeout",
                         FailureType::ConnectionError => "upstream_error",
+                        FailureType::EmptyResponse => "empty_response",
                     };
                     return ProxyResult {
                         response: build_response_with_header(

--- a/crates/service/crates/billing/src/usage/providers/openai.rs
+++ b/crates/service/crates/billing/src/usage/providers/openai.rs
@@ -63,57 +63,67 @@ impl UsageParser for OpenAIParser {
     }
 
     fn parse_streaming_chunk(&self, chunk: &str) -> Result<Option<UnifiedUsage>, ParseError> {
-        let line = chunk.trim();
-        if !line.starts_with("data: ") {
-            return Ok(None);
-        }
-        let data = &line[6..];
-        if data.trim() == "[DONE]" {
-            return Ok(None);
-        }
+        // Handle multi-line SSE chunks - each line may contain a "data: {...}" entry
+        for line in chunk.lines() {
+            let line = line.trim();
+            if !line.starts_with("data: ") {
+                continue;
+            }
+            let data = &line[6..];
+            if data.trim() == "[DONE]" {
+                continue;
+            }
 
-        let json: Value = serde_json::from_str(data)?;
-        let Some(usage) = json.get("usage") else {
-            return Ok(None);
-        };
+            // Try to parse JSON, skip lines that don't parse
+            let json: Value = match serde_json::from_str(data) {
+                Ok(v) => v,
+                Err(_) => continue, // Skip malformed lines
+            };
 
-        // Only process chunks that carry usage info
-        let input = usage
-            .get("prompt_tokens")
-            .and_then(|v| v.as_i64())
-            .unwrap_or(0);
-        let output = usage
-            .get("completion_tokens")
-            .and_then(|v| v.as_i64())
-            .unwrap_or(0);
-        if input == 0 && output == 0 {
-            return Ok(None);
-        }
+            let Some(usage) = json.get("usage") else {
+                continue;
+            };
 
-        let mut u = UnifiedUsage {
-            input_tokens: input,
-            output_tokens: output,
-            ..Default::default()
-        };
-
-        if let Some(details) = usage.get("prompt_tokens_details") {
-            u.cache_read_tokens = details
-                .get("cached_tokens")
+            // Only process chunks that carry usage info
+            let input = usage
+                .get("prompt_tokens")
                 .and_then(|v| v.as_i64())
                 .unwrap_or(0);
-            u.audio_input_tokens = details
-                .get("audio_tokens")
+            let output = usage
+                .get("completion_tokens")
                 .and_then(|v| v.as_i64())
                 .unwrap_or(0);
-        }
-        if let Some(details) = usage.get("completion_tokens_details") {
-            u.audio_output_tokens = details
-                .get("audio_tokens")
-                .and_then(|v| v.as_i64())
-                .unwrap_or(0);
+            if input == 0 && output == 0 {
+                continue;
+            }
+
+            let mut u = UnifiedUsage {
+                input_tokens: input,
+                output_tokens: output,
+                ..Default::default()
+            };
+
+            if let Some(details) = usage.get("prompt_tokens_details") {
+                u.cache_read_tokens = details
+                    .get("cached_tokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                u.audio_input_tokens = details
+                    .get("audio_tokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+            }
+            if let Some(details) = usage.get("completion_tokens_details") {
+                u.audio_output_tokens = details
+                    .get("audio_tokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+            }
+
+            return Ok(Some(u));
         }
 
-        Ok(Some(u))
+        Ok(None)
     }
 }
 
@@ -188,5 +198,28 @@ mod tests {
         let parser = OpenAIParser;
         let line = r#"data: {"usage":{"prompt_tokens":0,"completion_tokens":0}}"#;
         assert!(parser.parse_streaming_chunk(line).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_parse_streaming_chunk_multiline() {
+        // SSE chunk may contain multiple lines
+        let parser = OpenAIParser;
+        let chunk = r#"data: {"choices":[{"delta":{"content":"hi"}}]}
+data: {"usage":{"prompt_tokens":10,"completion_tokens":20}}"#;
+        let u = parser.parse_streaming_chunk(chunk).unwrap().unwrap();
+        assert_eq!(u.input_tokens, 10);
+        assert_eq!(u.output_tokens, 20);
+    }
+
+    #[test]
+    fn test_parse_streaming_chunk_multiline_with_malformed() {
+        // Should skip malformed lines and find usage in valid line
+        let parser = OpenAIParser;
+        let chunk = r#"data: {"choices":[{"delta":{"content":"hi"}}]}
+data: malformed json here
+data: {"usage":{"prompt_tokens":15,"completion_tokens":25}}"#;
+        let u = parser.parse_streaming_chunk(chunk).unwrap().unwrap();
+        assert_eq!(u.input_tokens, 15);
+        assert_eq!(u.output_tokens, 25);
     }
 }


### PR DESCRIPTION
## 概述

本 PR 改进了 Circuit Breaker 和失败检测机制，解决 Issue #333 中提到的问题。

## 主要改动

### 1. AuthFailed/PaymentRequired 触发长时间熔断

**问题**: 认证或支付失败的 channel 没有触发熔断，导致后续请求继续访问失败的 channel。

**解决方案**: 
- 设置高失败计数 + 30 分钟冷却时间
- 避免频繁重试永久失败的 channel

**代码位置**: `crates/router/src/circuit_breaker.rs`

### 2. 流式响应 usage 多行解析

**问题**: SSE chunk 可能包含多行，但解析器只处理单行，导致解析失败。

**解决方案**:
- 遍历所有行，而不是只处理第一行
- 跳过无法解析的行而不是返回错误
- 新增多行解析测试用例

**代码位置**: `crates/service/crates/billing/src/usage/providers/openai.rs`

### 3. 连续失败指数退避

**问题**: 失败 channel 的冷却时间固定为 60 秒，导致频繁重试失败的 channel。

**解决方案**:
- 失败冷却时间指数增长: 60s → 120s → 240s → 480s → 960s → 1800s
- 最多 30 分钟冷却时间
- 成功时重置失败计数

**代码位置**: `crates/router/src/channel_state.rs`

### 4. 空响应检测

**问题**: channel 返回 HTTP 200 但 zero tokens 的空响应被当作成功处理，导致用户被"粘"在失败的 channel 上。

**解决方案**:
- 新增 `FailureType::EmptyResponse` 类型
- 检测空响应并记录失败
- 触发 affinity eviction，避免下一次请求命中失败 channel
- 尝试下一个候选 channel

**代码位置**: `crates/router/src/lib.rs`, `crates/router/src/channel_state.rs`, `crates/router/src/circuit_breaker.rs`

## 测试

- ✅ 编译通过
- ✅ router 模块测试通过（179 passed）
- ✅ billing 模块测试通过（83 passed）
- ✅ 新增多行解析测试用例

## 预期效果

1. **AuthFailed/PaymentRequired**: 30 分钟内不会重试该 channel
2. **流式响应解析**: 不再报错，tokens 正确统计
3. **连续失败退避**: 失败的 channel 冷却时间逐渐延长
4. **空响应检测**: 空响应触发 failover，用户不会被"粘"在失败的 channel 上

Closes #333