### PR TITLE
fix(router): do not penalize channels for empty streaming responses

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -2460,12 +2460,12 @@ async fn proxy_logic(
                             let counter_clone = Arc::clone(&token_counter);
 
                             // Clone state and upstream info for post-stream empty response check
-                            let state_clone = state.clone();
+                            let _state_clone = state.clone();
                             let upstream_id_str = upstream.id.clone();
-                            let upstream_name = upstream.name.clone();
+                            let _upstream_name = upstream.name.clone();
                             let model_name_clone = model_name.map(|s| s.to_string());
-                            let session_id_clone = session_id.to_string();
-                            let channel_id: i32 = upstream.id.parse().unwrap_or(0);
+                            let _session_id_clone = session_id.to_string();
+                            let _channel_id: i32 = upstream.id.parse().unwrap_or(0);
 
                             let parser = get_parser(channel_type);
 
@@ -3017,12 +3017,12 @@ async fn proxy_logic(
                         let parser = get_parser(channel_type);
 
                         // Clone state and upstream info for post-stream empty response check
-                        let state_clone = state.clone();
+                        let _state_clone = state.clone();
                         let upstream_id_str = upstream.id.clone();
-                        let upstream_name = upstream.name.clone();
+                        let _upstream_name = upstream.name.clone();
                         let model_name_clone = model_name.map(|s| s.to_string());
-                        let session_id_clone = session_id.to_string();
-                        let channel_id: i32 = upstream.id.parse().unwrap_or(0);
+                        let _session_id_clone = session_id.to_string();
+                        let _channel_id: i32 = upstream.id.parse().unwrap_or(0);
 
                         // Track if we've seen any tokens during streaming
                         let seen_tokens = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -3099,12 +3099,12 @@ async fn proxy_logic(
                         let parser = get_parser(channel_type);
 
                         // Clone state and upstream info for post-stream empty response check
-                        let state_clone = state.clone();
+                        let _state_clone = state.clone();
                         let upstream_id_str = upstream.id.clone();
-                        let upstream_name = upstream.name.clone();
+                        let _upstream_name = upstream.name.clone();
                         let model_name_clone = model_name.map(|s| s.to_string());
-                        let session_id_clone = session_id.to_string();
-                        let channel_id: i32 = upstream.id.parse().unwrap_or(0);
+                        let _session_id_clone = session_id.to_string();
+                        let _channel_id: i32 = upstream.id.parse().unwrap_or(0);
 
                         // Track if we've seen any tokens during streaming
                         let seen_tokens = Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -2500,35 +2500,13 @@ async fn proxy_logic(
                                 .chain(futures::stream::once(async move {
                                     // Check for empty response after stream ends
                                     if !seen_tokens.load(std::sync::atomic::Ordering::Relaxed) {
-                                        tracing::warn!(
+                                        // Empty response may be valid (e.g., user stop, simple ack)
+                                        // Only log debug message, do not penalize the channel
+                                        tracing::debug!(
                                             channel_id = %upstream_id_str,
                                             model = ?model_name_clone,
-                                            "Empty streaming response (zero tokens) detected after stream ended, treating as failure"
+                                            "Empty streaming response (zero tokens) detected, not penalizing channel"
                                         );
-
-                                        // Record failure to circuit breaker and channel state
-                                        state_clone.circuit_breaker.record_failure_with_type(
-                                            &upstream_id_str,
-                                            FailureType::EmptyResponse,
-                                        );
-                                        state_clone.channel_state_tracker.record_error(
-                                            channel_id,
-                                            model_name_clone.as_deref(),
-                                            &FailureType::EmptyResponse,
-                                            "Empty streaming response with zero tokens",
-                                        );
-
-                                        // Evict affinity so next request tries different channel
-                                        if let Some(model) = &model_name_clone {
-                                            state_clone.affinity_cache.evict(&session_id_clone, model);
-                                            tracing::debug!(
-                                                session_id = %session_id_clone,
-                                                model = %model,
-                                                channel_id,
-                                                "Affinity evicted — empty streaming response for {}",
-                                                upstream_name
-                                            );
-                                        }
                                     }
                                     // Return empty bytes to not affect the stream
                                     Ok(axum::body::Bytes::new())
@@ -3072,33 +3050,13 @@ async fn proxy_logic(
                         // Add post-stream check for empty response
                         let done = futures::stream::once(async move {
                             if !seen_tokens.load(std::sync::atomic::Ordering::Relaxed) {
-                                tracing::warn!(
+                                // Empty response may be valid (e.g., user stop, simple ack)
+                                // Only log debug message, do not penalize the channel
+                                tracing::debug!(
                                     channel_id = %upstream_id_str,
                                     model = ?model_name_clone,
-                                    "Empty streaming response (zero tokens) detected after stream ended, treating as failure"
+                                    "Empty streaming response (zero tokens) detected, not penalizing channel"
                                 );
-
-                                state_clone.circuit_breaker.record_failure_with_type(
-                                    &upstream_id_str,
-                                    FailureType::EmptyResponse,
-                                );
-                                state_clone.channel_state_tracker.record_error(
-                                    channel_id,
-                                    model_name_clone.as_deref(),
-                                    &FailureType::EmptyResponse,
-                                    "Empty streaming response with zero tokens",
-                                );
-
-                                if let Some(model) = &model_name_clone {
-                                    state_clone.affinity_cache.evict(&session_id_clone, model);
-                                    tracing::debug!(
-                                        session_id = %session_id_clone,
-                                        model = %model,
-                                        channel_id,
-                                        "Affinity evicted — empty streaming response for {}",
-                                        upstream_name
-                                    );
-                                }
                             }
                             Ok(axum::body::Bytes::new())
                         });
@@ -3186,35 +3144,13 @@ async fn proxy_logic(
                         let done = futures::stream::once(async move {
                             // Check for empty response after stream ends
                             if !seen_tokens.load(std::sync::atomic::Ordering::Relaxed) {
-                                tracing::warn!(
+                                // Empty response may be valid (e.g., user stop, simple ack)
+                                // Only log debug message, do not penalize the channel
+                                tracing::debug!(
                                     channel_id = %upstream_id_str,
                                     model = ?model_name_clone,
-                                    "Empty streaming response (zero tokens) detected after stream ended, treating as failure"
+                                    "Empty streaming response (zero tokens) detected, not penalizing channel"
                                 );
-
-                                // Record failure to circuit breaker and channel state
-                                state_clone.circuit_breaker.record_failure_with_type(
-                                    &upstream_id_str,
-                                    FailureType::EmptyResponse,
-                                );
-                                state_clone.channel_state_tracker.record_error(
-                                    channel_id,
-                                    model_name_clone.as_deref(),
-                                    &FailureType::EmptyResponse,
-                                    "Empty streaming response with zero tokens",
-                                );
-
-                                // Evict affinity so next request tries different channel
-                                if let Some(model) = &model_name_clone {
-                                    state_clone.affinity_cache.evict(&session_id_clone, model);
-                                    tracing::debug!(
-                                        session_id = %session_id_clone,
-                                        model = %model,
-                                        channel_id,
-                                        "Affinity evicted — empty streaming response for {}",
-                                        upstream_name
-                                    );
-                                }
                             }
                             Ok(axum::body::Bytes::from(SSE_DONE_MARKER))
                         });


### PR DESCRIPTION
## Problem

Empty streaming responses (zero tokens) were being treated as failures, causing channels to be marked as TemporarilyDown unnecessarily.

### Evidence from logs
- Channels 3, 4, 5, 9 frequently entered TemporarilyDown state
- Log shows: "Empty streaming response (zero tokens) detected after stream ended, treating as failure"
- Cooling period of 10-15 minutes affected service availability

### Root Cause
Some requests naturally return empty responses:
- User-initiated stop during streaming
- Simple acknowledgment responses
- Ping/health check requests

The code at lines 2502, 3074, 3188 was incorrectly treating these as failures and triggering:
1. Circuit breaker failure recording
2. Channel state error recording  
3. Affinity cache eviction

## Solution

Changed empty response handling from failure to debug log only:
- Removed  calls
- Removed  calls
- Removed  calls
- Empty responses now logged at DEBUG level without penalizing channels

## Testing
- `cargo check` passes successfully
- `cargo fix` applied for unused variable warnings

## Impact
- Channels will no longer be penalized for valid empty responses
- Service availability will improve
- Less unnecessary channel switching