### PR TITLE
fix(router): Prevent panic when logging bodies with multi-byte UTF-8 characters

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -348,6 +348,21 @@ const SENSITIVE_FIELDS: &[&str] = &[
     "secret",
     "authorization",
 ];
+/// Safely cut a string at a UTF-8 character boundary.
+/// Returns a string slice that is at most max_bytes long.
+fn safe_cut(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    
+    // Find the character boundary at or before max_bytes
+    let mut boundary = max_bytes;
+    while boundary > 0 && !s.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    
+    &s[..boundary]
+}
 
 /// Sanitize request body for logging: remove sensitive fields, truncate if too large.
 /// Returns (sanitized_body, was_truncated).
@@ -370,7 +385,7 @@ fn sanitize_request_body(body_bytes: &[u8]) -> (Option<String>, bool) {
             // Truncate the JSON string representation
             let json_str = json.to_string();
             format!("{}... [TRUNCATED: {} bytes total]",
-                &json_str[..json_str.len().min(MAX_LOG_BODY_SIZE)],
+                safe_cut(&json_str, MAX_LOG_BODY_SIZE),
                 body_bytes.len())
         } else {
             json.to_string()
@@ -380,7 +395,7 @@ fn sanitize_request_body(body_bytes: &[u8]) -> (Option<String>, bool) {
         // Not valid JSON, treat as plain text
         let sanitized = if truncated {
             format!("{}... [TRUNCATED: {} bytes total]",
-                &body_str[..body_str.len().min(MAX_LOG_BODY_SIZE)],
+                safe_cut(&body_str, MAX_LOG_BODY_SIZE),
                 body_bytes.len())
         } else {
             body_str.to_string()
@@ -448,7 +463,7 @@ fn sanitize_response_body(body: &[u8]) -> (Option<String>, bool) {
         let json_str = json.to_string();
         if truncated {
             (Some(format!("{}... [TRUNCATED: {} bytes total]",
-                &json_str[..json_str.len().min(MAX_LOG_BODY_SIZE)],
+                safe_cut(&json_str, MAX_LOG_BODY_SIZE),
                 body.len())), true)
         } else {
             (Some(json_str), false)
@@ -456,7 +471,7 @@ fn sanitize_response_body(body: &[u8]) -> (Option<String>, bool) {
     } else {
         if truncated {
             (Some(format!("{}... [TRUNCATED: {} bytes total]",
-                &body_str[..body_str.len().min(MAX_LOG_BODY_SIZE)],
+                safe_cut(&body_str, MAX_LOG_BODY_SIZE),
                 body.len())), true)
         } else {
             (Some(body_str.to_string()), false)


### PR DESCRIPTION
## Problem
The burncloud server was experiencing panics when processing requests containing multi-byte UTF-8 characters (e.g., Chinese characters) that crossed the 64KB logging boundary. The error occurred at crates/router/src/lib.rs:373:

```
thread panicked: end byte index 65536 is not a char boundary;
it is inside 已 (bytes 65535..65538)
```

This happened because the code was using naive string slicing:
```rust
&json_str[..MAX_LOG_BODY_SIZE]
```

When MAX_LOG_BODY_SIZE (65536) fell in the middle of a multi-byte UTF-8 character, the slice operation would panic because Rust strings cannot be sliced at non-character-boundary byte positions.

## Solution
Added a `safe_cut()` helper function that:
1. Checks if the string length is within bounds
2. Finds the nearest valid UTF-8 character boundary at or before max_bytes
3. Returns a safely sliced string that never panics

The function uses `is_char_boundary()` to walk backwards from max_bytes until finding a valid boundary.

## Impact
- Fixes panic that could crash the server during request logging
- Maintains the 64KB logging limit for memory safety
- Slightly reduces the logged size when cutting at a character boundary
- No performance impact for normal-sized logs (only affects logs > 64KB)

## Testing
- Compiled successfully with `cargo build`
- Tested with Chinese characters in request bodies
- No more panics observed in logs/burncloud.out
- Server running stably for 24+ hours without crashes