### PR TITLE
Fix: Consistent Empty Response Penalty with Threshold Check

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -3200,36 +3200,50 @@ async fn proxy_logic(
                             }
                         });
 
-                        // Add post-stream check for empty response
+                        // Add post-stream check for empty response with sliding window counter
                         let done = futures::stream::once(async move {
                             if !seen_tokens.load(std::sync::atomic::Ordering::Relaxed) {
-                                tracing::warn!(
-                                    channel_id = %upstream_id_str,
-                                    model = ?model_name_clone,
-                                    "Empty streaming response (zero tokens) detected after stream ended, treating as failure"
-                                );
-
-                                state_clone.circuit_breaker.record_failure_with_type(
-                                    &upstream_id_str,
-                                    FailureType::EmptyResponse,
-                                );
-                                state_clone.channel_state_tracker.record_error(
-                                    channel_id,
-                                    model_name_clone.as_deref(),
-                                    &FailureType::EmptyResponse,
-                                    "Empty streaming response with zero tokens",
-                                );
-
-                                if let Some(model) = &model_name_clone {
-                                    state_clone.affinity_cache.evict(&session_id_clone, model);
-                                    tracing::debug!(
-                                        session_id = %session_id_clone,
-                                        model = %model,
+                                // Use sliding window counter: only penalize after consecutive empty responses
+                                let should_penalize = state_clone.empty_response_counter.record_empty(&upstream_id_str);
+                                
+                                if should_penalize {
+                                    tracing::warn!(
+                                        channel_id = %upstream_id_str,
+                                        model = ?model_name_clone,
+                                        "Consecutive empty streaming responses exceeded threshold, treating as failure"
+                                    );
+                                    
+                                    // Threshold exceeded - record failure
+                                    state_clone.circuit_breaker.record_failure_with_type(
+                                        &upstream_id_str,
+                                        FailureType::EmptyResponse,
+                                    );
+                                    state_clone.channel_state_tracker.record_error(
                                         channel_id,
-                                        "Affinity evicted — empty streaming response for {}",
-                                        upstream_name
+                                        model_name_clone.as_deref(),
+                                        &FailureType::EmptyResponse,
+                                        "Consecutive empty streaming responses exceeded threshold",
+                                    );
+
+                                    if let Some(model) = &model_name_clone {
+                                        state_clone.affinity_cache.evict(&session_id_clone, model);
+                                        tracing::debug!(
+                                            session_id = %session_id_clone,
+                                            model = %model,
+                                            channel_id,
+                                            "Affinity evicted — consecutive empty responses for {}",
+                                            upstream_name
+                                        );
+                                    }
+                                } else {
+                                    tracing::debug!(
+                                        channel_id = %upstream_id_str,
+                                        "Empty streaming response recorded but threshold not yet exceeded"
                                     );
                                 }
+                            } else {
+                                // Successful response - reset the counter
+                                state_clone.empty_response_counter.record_success(&upstream_id_str);
                             }
                             Ok(axum::body::Bytes::new())
                         });
@@ -3341,37 +3355,50 @@ async fn proxy_logic(
                         });
 
                         let done = futures::stream::once(async move {
-                            // Check for empty response after stream ends
+                            // Check for empty response after stream ends with sliding window counter
                             if !seen_tokens.load(std::sync::atomic::Ordering::Relaxed) {
-                                tracing::warn!(
-                                    channel_id = %upstream_id_str,
-                                    model = ?model_name_clone,
-                                    "Empty streaming response (zero tokens) detected after stream ended, treating as failure"
-                                );
-
-                                // Record failure to circuit breaker and channel state
-                                state_clone.circuit_breaker.record_failure_with_type(
-                                    &upstream_id_str,
-                                    FailureType::EmptyResponse,
-                                );
-                                state_clone.channel_state_tracker.record_error(
-                                    channel_id,
-                                    model_name_clone.as_deref(),
-                                    &FailureType::EmptyResponse,
-                                    "Empty streaming response with zero tokens",
-                                );
-
-                                // Evict affinity so next request tries different channel
-                                if let Some(model) = &model_name_clone {
-                                    state_clone.affinity_cache.evict(&session_id_clone, model);
-                                    tracing::debug!(
-                                        session_id = %session_id_clone,
-                                        model = %model,
+                                // Use sliding window counter: only penalize after consecutive empty responses
+                                let should_penalize = state_clone.empty_response_counter.record_empty(&upstream_id_str);
+                                
+                                if should_penalize {
+                                    tracing::warn!(
+                                        channel_id = %upstream_id_str,
+                                        model = ?model_name_clone,
+                                        "Consecutive empty streaming responses exceeded threshold, treating as failure"
+                                    );
+                                    
+                                    // Threshold exceeded - record failure to circuit breaker and channel state
+                                    state_clone.circuit_breaker.record_failure_with_type(
+                                        &upstream_id_str,
+                                        FailureType::EmptyResponse,
+                                    );
+                                    state_clone.channel_state_tracker.record_error(
                                         channel_id,
-                                        "Affinity evicted — empty streaming response for {}",
-                                        upstream_name
+                                        model_name_clone.as_deref(),
+                                        &FailureType::EmptyResponse,
+                                        "Consecutive empty streaming responses exceeded threshold",
+                                    );
+
+                                    // Evict affinity so next request tries different channel
+                                    if let Some(model) = &model_name_clone {
+                                        state_clone.affinity_cache.evict(&session_id_clone, model);
+                                        tracing::debug!(
+                                            session_id = %session_id_clone,
+                                            model = %model,
+                                            channel_id,
+                                            "Affinity evicted — consecutive empty responses for {}",
+                                            upstream_name
+                                        );
+                                    }
+                                } else {
+                                    tracing::debug!(
+                                        channel_id = %upstream_id_str,
+                                        "Empty streaming response recorded but threshold not yet exceeded"
                                     );
                                 }
+                            } else {
+                                // Successful response - reset the counter
+                                state_clone.empty_response_counter.record_success(&upstream_id_str);
                             }
                             Ok(axum::body::Bytes::from(SSE_DONE_MARKER))
                         });

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -3243,7 +3243,7 @@ async fn proxy_logic(
                                 }
                             } else {
                                 // Successful response - reset the counter
-                                state_clone.empty_response_counter.record_success(&upstream_id_str);
+                                state_clone.empty_response_counter.reset(&upstream_id_str);
                             }
                             Ok(axum::body::Bytes::new())
                         });
@@ -3398,7 +3398,7 @@ async fn proxy_logic(
                                 }
                             } else {
                                 // Successful response - reset the counter
-                                state_clone.empty_response_counter.record_success(&upstream_id_str);
+                                state_clone.empty_response_counter.reset(&upstream_id_str);
                             }
                             Ok(axum::body::Bytes::from(SSE_DONE_MARKER))
                         });


### PR DESCRIPTION
## 问题描述

代码中有三处检测 Empty streaming response 的逻辑，但实现不一致：

1. **第2612行**（OpenAI streaming path）：使用了 `EmptyResponseCounter` 滑动窗口计数器，只有连续3次空响应才惩罚 ✅
2. **第3204行**（OpenAI bytes streaming path）：直接记录失败，单次空响应就惩罚 ❌
3. **第3343行**（Non-OpenAI SSE streaming path）：直接记录失败，单次空响应就惩罚 ❌

这导致渠道5因为**单次**空响应就被立即标记为 `TemporarilyDown`，违背了 EmptyResponseCounter 的设计初衷。

## 修复方案

在两处代码中添加 `EmptyResponseCounter` 阈值检查：

```rust
// 检测到空响应时
if !seen_tokens.load(Ordering::Relaxed) {
    // 使用滑动窗口计数器
    let should_penalize = state_clone.empty_response_counter.record_empty(&upstream_id_str);
    
    if should_penalize {
        // 只有达到阈值（3次）才记录失败
        state_clone.circuit_breaker.record_failure_with_type(...);
        state_clone.channel_state_tracker.record_error(...);
        state_clone.affinity_cache.evict(...);
    } else {
        // 记录但暂不惩罚
        tracing::debug!("Empty response recorded but threshold not yet exceeded");
    }
} else {
    // 成功响应 - 重置计数器
    state_clone.empty_response_counter.reset(&upstream_id_str);
}
```

## 影响

**修复前：**
- 单次空响应 → 立即标记 `TemporarilyDown`
- 渠道过早被熔断，影响可用性
- 网络抖动可能触发误报

**修复后：**
- 需要连续3次空响应才标记失败
- 允许偶尔的网络问题
- 更准确的故障检测
- 与现有设计保持一致

## 测试验证

- ✅ 编译成功
- ✅ 服务正常启动（PID: 917034，端口: 3000）
- ✅ 渠道7持续成功（100%成功率）
- ✅ 渠道5空响应不再立即触发熔断

## 修改文件

- `crates/router/src/lib.rs`: 两处修改（3204-3249行、3357-3405行）

## 相关 Issue

此修复完善了 PR #337 的设计，确保所有 Empty Response 处理路径都使用一致的阈值检查机制。
