### PR TITLE
Fix: Delay record_upstream_success for streaming responses until content confirmed

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -2524,7 +2524,10 @@ async fn proxy_logic(
                     }
 
                     if status.is_success() {
-                        record_upstream_success(state, upstream, model_name, &session_id);
+                        // For streaming responses, delay recording success until we confirm non-empty response
+                        if !is_stream {
+                            record_upstream_success(state, upstream, model_name, &session_id);
+                        }
 
                         let channel_id: i32 = upstream.id.parse().unwrap_or(0);
                         let latency_ms = request_start_time.elapsed().as_millis() as u64;
@@ -2644,8 +2647,13 @@ async fn proxy_logic(
                                             }
                                         }
                                     } else {
-                                        // Successful response - reset the counter
+                                        // Successful response - reset the counter and record success
                                         state_clone.empty_response_counter.reset(&upstream_id_str);
+                                        // Now we can safely record success for the streaming response
+                                        state_clone.circuit_breaker.record_success(&upstream_id_str);
+                                        if let Some(model) = &model_name_clone {
+                                            state_clone.affinity_cache.insert(&session_id_clone, model, channel_id);
+                                        }
                                     }
                                     // Return empty bytes to not affect the stream
                                     Ok(axum::body::Bytes::new())
@@ -3040,7 +3048,10 @@ async fn proxy_logic(
                 }
 
                 if resp.status().is_success() {
-                    record_upstream_success(state, upstream, model_name, &session_id);
+                    // For streaming responses, delay recording success until we confirm non-empty response
+                    if !is_stream {
+                        record_upstream_success(state, upstream, model_name, &session_id);
+                    }
                     let status = resp.status();
 
                     // Parse rate limit info from response headers
@@ -3254,8 +3265,13 @@ async fn proxy_logic(
                                     );
                                 }
                             } else {
-                                // Successful response - reset the counter
+                                // Successful response - reset the counter and record success
                                 state_clone.empty_response_counter.reset(&upstream_id_str);
+                                // Now we can safely record success for the streaming response
+                                state_clone.circuit_breaker.record_success(&upstream_id_str);
+                                if let Some(model) = &model_name_clone {
+                                    state_clone.affinity_cache.insert(&session_id_clone, model, channel_id);
+                                }
                             }
                             Ok(axum::body::Bytes::new())
                         });
@@ -3409,8 +3425,13 @@ async fn proxy_logic(
                                     );
                                 }
                             } else {
-                                // Successful response - reset the counter
+                                // Successful response - reset the counter and record success
                                 state_clone.empty_response_counter.reset(&upstream_id_str);
+                                // Now we can safely record success for the streaming response
+                                state_clone.circuit_breaker.record_success(&upstream_id_str);
+                                if let Some(model) = &model_name_clone {
+                                    state_clone.affinity_cache.insert(&session_id_clone, model, channel_id);
+                                }
                             }
                             Ok(axum::body::Bytes::from(SSE_DONE_MARKER))
                         });


### PR DESCRIPTION
## Problem Description

When handling streaming responses, the code was calling `record_upstream_success()` immediately after receiving a 200 OK status, before knowing whether the stream would actually contain any content.

This caused a critical bug where empty streaming responses could not properly trigger circuit breaker protection:

1. Empty streaming responses (HTTP 200 but zero tokens) would first record SUCCESS
2. Then when the stream ended empty, it would record FAILURE  
3. But `record_upstream_success()` resets the circuit breaker failure counter to 0
4. So the failure could never accumulate to trigger circuit breaker protection
5. Bad channels with empty responses would never be properly marked as TemporarilyDown

## Root Cause Analysis

In both passthrough and converted streaming paths:
- `record_upstream_success(state, upstream, model_name, &session_id)` was called immediately when `status.is_success()` was true
- For streaming responses, this happened before the stream was even read
- If the stream turned out to be empty, the success was already recorded, negating the failure

## Solution Implemented

### 1. Delay success recording for streams
Only call `record_upstream_success()` for non-streaming responses immediately at response start.

### 2. Record success after confirming content
For streaming responses, only call `circuit_breaker.record_success()` and update affinity cache AFTER confirming the stream has content (seen_tokens == true).

### 3. Applied fix to all three streaming paths
- Passthrough streaming path (line ~2527)
- OpenAI protocol streaming path (line ~3051)
- Non-OpenAI converted streaming path (line ~3310)

## Code Changes

```diff
- record_upstream_success(state, upstream, model_name, &session_id);
+ // For streaming responses, delay recording success until we confirm non-empty response
+ if !is_stream {
+     record_upstream_success(state, upstream, model_name, &session_id);
+ }
```

And in the stream completion handler:
```diff
- // Successful response - reset the counter
- state_clone.empty_response_counter.reset(&upstream_id_str);
+ // Successful response - reset the counter and record success
+ state_clone.empty_response_counter.reset(&upstream_id_str);
+ // Now we can safely record success for the streaming response
+ state_clone.circuit_breaker.record_success(&upstream_id_str);
+ if let Some(model) = &model_name_clone {
+     state_clone.affinity_cache.insert(&session_id_clone, model, channel_id);
+ }
```

## Impact and Benefits

- Empty response failures now properly accumulate in circuit breaker
- Bad channels will be correctly marked as TemporarilyDown after threshold
- Affinity cache is only updated for genuinely successful responses
- System can now properly protect against channels that return empty streams
- Normal channels (7-9) continue to work correctly as before

## Testing Performed

- ✅ Code compiles successfully (release build)
- ✅ Service restarts and health check passes
- ✅ Existing functionality unaffected for non-streaming responses
- ✅ Fix applied consistently to all streaming code paths

## Observed Behavior Before Fix

From logs, channel 5 was showing repeated:
```
WARN burncloud_router: Consecutive empty responses exceeded threshold, marking as failure channel_id="5" count=3..9 threshold=3
WARN burncloud_router::channel_state: is_available=false: TemporarilyDown (timer active)
```

But the failure count never accumulated properly because each "success" reset it first.

## Expected Behavior After Fix

- Empty streaming responses will properly accumulate failures
- After reaching threshold (3 consecutive), circuit breaker will trip
- Channel will be marked TemporarilyDown with proper cooldown
- Subsequent requests will route to healthy channels
- System will have proper resilience against failing channels

---

This fix ensures the circuit breaker and channel state tracking work correctly for streaming responses, improving system stability and reliability.