### PR TITLE
feat: Enhance EmptyResponseCounter with monitoring and admin capabilities

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -53,7 +53,16 @@ impl EmptyResponseCounter {
         let count = counters.entry(channel_id.to_string()).or_insert(0);
         *count += 1;
         let exceeded = *count >= self.threshold;
-        if exceeded {
+        
+        // Warning when approaching threshold (threshold - 1)
+        if *count == self.threshold - 1 {
+            tracing::warn!(
+                channel_id = channel_id,
+                count = *count,
+                threshold = self.threshold,
+                "Empty response counter approaching threshold - consider monitoring channel"
+            );
+        } else if exceeded {
             tracing::warn!(
                 channel_id = channel_id,
                 count = *count,
@@ -84,6 +93,37 @@ impl EmptyResponseCounter {
                 *count = 0;
             }
         }
+    }
+
+    /// Get current counter value for a channel (for monitoring/admin purposes).
+    pub fn get_count(&self, channel_id: &str) -> u32 {
+        let counters = self.counters.read().unwrap();
+        counters.get(channel_id).copied().unwrap_or(0)
+    }
+
+    /// Force reset counter for a channel (admin override).
+    /// Returns the previous count value.
+    pub fn force_reset(&self, channel_id: &str) -> u32 {
+        let mut counters = self.counters.write().unwrap();
+        let previous_count = counters.remove(channel_id).unwrap_or(0);
+        if previous_count > 0 {
+            tracing::info!(
+                channel_id = channel_id,
+                previous_count = previous_count,
+                "Admin forced reset of empty response counter"
+            );
+        }
+        previous_count
+    }
+
+    /// Get all channels with non-zero counters (for monitoring).
+    pub fn get_all_counts(&self) -> Vec<(String, u32)> {
+        let counters = self.counters.read().unwrap();
+        counters
+            .iter()
+            .filter(|(_, &count)| count > 0)
+            .map(|(k, &v)| (k.clone(), v))
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `get_count()` method to query current counter value for a specific channel
- Add `force_reset()` method for admin override to reset counters
- Add `get_all_counts()` method to list all channels with non-zero counters
- Add early warning mechanism when counter reaches `threshold - 1`
- Improve logging with more context for proactive monitoring

## Changes
### New Methods in EmptyResponseCounter
1. **`get_count(channel_id: &str) -> u32`**: Query current counter value for monitoring
2. **`force_reset(channel_id: &str) -> u32`**: Admin override to reset counter, returns previous count
3. **`get_all_counts() -> Vec<(String, u32)>`**: List all channels with active counters

### Enhanced Warning System
- Added warning log when counter reaches `threshold - 1` (e.g., at count 2 when threshold is 3)
- This provides early notification before circuit breaker activates
- Helps operators take proactive action

## Benefits
- **Better Observability**: Monitor channel health before issues escalate
- **Admin Control**: Ability to manually reset counters when needed
- **Proactive Alerts**: Early warning system prevents surprises
- **No Breaking Changes**: All new methods are additive, existing functionality unchanged

## Testing
- ✅ Code compiles successfully (`cargo check --release`)
- ✅ No breaking changes to existing API
- ✅ Logging enhancement tested through code review

## Related Issues
Resolves issue_001 (P2 optimization suggestion)

## Verification Checklist
- [x] New API interfaces available
- [x] Warning mechanism integrated
- [x] No impact on existing circuit breaker logic
- [x] Code compiles without errors