### PR TITLE
docs: add repository-local runtime atlas for chat completions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# BurnCloud Agent Instructions
+
+This file is the repository entrypoint for coding agents. Keep it short. Detailed rules live under `docs/`.
+
+## Authority
+
+When sources disagree, use this order:
+
+`current source code > executable tests > current contracts/invariants > current architecture/runtime docs > engineering standards > historical/external docs`
+
+A document never makes behavior true. Re-confirm the relevant code before changing it.
+
+## Required bootstrap
+
+Before making a repository change:
+
+1. Read `docs/CLAUDE.md`.
+2. Read `docs/agent/START_HERE.md`.
+3. Route the requested behavior with `docs/agent/TASK_ROUTER.md`.
+4. Read the smallest real execution path needed for the task.
+5. Check `docs/agent/INVARIANTS.md`.
+6. Select verification from `docs/agent/TEST_MATRIX.md`.
+7. Follow `docs/agent/CHANGE_PROTOCOL.md`.
+
+For data-plane behavior, also open `docs/runtime/README.md` and the relevant runtime flow document if one exists.
+
+## Execution contract
+
+For every non-trivial change, establish these facts before editing:
+
+- **Behavior** — the user/operator-visible behavior being changed.
+- **Entry** — route, CLI command, UI event, background trigger, or other real entrypoint.
+- **Execution path** — `entry -> branch -> callee -> state/external effect -> return/error`.
+- **Impact** — files, crates, persistence, external calls, billing/accounting, auth, routing, and tests affected.
+- **Invariants** — existing truths that must remain true.
+- **Acceptance** — observable conditions that prove the task is complete.
+
+Classify important execution claims as:
+
+- **STATIC CONFIRMED** — directly visible in current source/tests.
+- **DYNAMIC** — runtime configuration, trait/adaptor/provider/channel selection, environment, or data controls the next target.
+- **INFERRED** — plausible but not fully proven from the inspected path.
+
+Never turn a DYNAMIC or INFERRED edge into a fixed architecture claim.
+
+## Change discipline
+
+- Prefer one runtime behavior per change.
+- Make the smallest coherent change that satisfies the acceptance criteria.
+- Do not perform opportunistic refactors unless they are required for correctness or testability.
+- Do not infer behavior from filenames or crate names.
+- Do not hide uncertainty: mark it and identify the source needed to resolve it.
+- Do not declare completion while required verification is failing.
+
+## Runtime documentation rule
+
+If a change alters observable routing, authentication/admission, provider dispatch, failover, persistence, billing/accounting, response behavior, or a documented invariant, update the corresponding repository-local runtime/contract document in the same change.
+
+Runtime documents are navigation and evidence maps, not replacements for source code. Prefer stable evidence references in the form:
+
+`path/to/file.rs :: SymbolName`
+
+Use line numbers only for point-in-time review comments.
+
+## Definition of done
+
+A task is complete only when:
+
+- the intended behavior is implemented;
+- affected error/failure paths were considered;
+- relevant tests/checks from `docs/agent/TEST_MATRIX.md` pass, or any un-runnable check is explicitly reported;
+- observable behavior changes are reflected in docs;
+- the final diff contains no unrelated changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,31 +3,35 @@ doc_id: docs.index
 doc_type: agent-index
 truth: normative
 status: active
-audited_against: c7107382b8479deb44f992e9e5ae8dcac5efb417
+audited_against: 956041a8b54d8c6964e57fa2284f825cc322b0d2
 ---
 
 # BurnCloud Engineering Docs
 
-`docs/` is the engineering harness for AI agents working on BurnCloud. It is intentionally small, text-only, and code-first.
+`docs/` is the engineering harness for humans and AI agents working on BurnCloud. It is intentionally code-first and should remain smaller than the implementation it explains.
+
+The repository-level agent entrypoint is [`../AGENTS.md`](../AGENTS.md).
 
 ## Purpose
 
-These docs exist to help an agent answer five questions quickly:
+These docs exist to help an engineer or agent answer six questions quickly:
 
-1. What user/runtime flow does this task affect?
-2. Which code is the primary implementation?
-3. Which invariants must not be broken?
-4. Which tests should be run?
-5. When docs and code disagree, which source wins?
+1. What user/runtime behavior does this task affect?
+2. What is the real entrypoint and execution path?
+3. Which code is the primary implementation?
+4. Which invariants must not be broken?
+5. Which tests should be run?
+6. When docs and code disagree, which source wins?
 
 ## Start here
 
-- [`CLAUDE.md`](CLAUDE.md) — short bootstrap context for agents.
+- [`../AGENTS.md`](../AGENTS.md) — repository-level agent operating contract.
+- [`CLAUDE.md`](CLAUDE.md) — short bootstrap context.
 - [`agent/START_HERE.md`](agent/START_HERE.md) — required task workflow.
-- [`agent/TASK_ROUTER.md`](agent/TASK_ROUTER.md) — task → runtime area → source → tests.
+- [`agent/TASK_ROUTER.md`](agent/TASK_ROUTER.md) — task -> runtime area -> source -> tests.
 - [`agent/DOC_PRIORITY.md`](agent/DOC_PRIORITY.md) — truth hierarchy and conflict resolution.
 - [`agent/INVARIANTS.md`](agent/INVARIANTS.md) — verified cross-cutting behavior.
-- [`agent/TEST_MATRIX.md`](agent/TEST_MATRIX.md) — affected area → test scope.
+- [`agent/TEST_MATRIX.md`](agent/TEST_MATRIX.md) — affected area -> test scope.
 - [`agent/CHANGE_PROTOCOL.md`](agent/CHANGE_PROTOCOL.md) — plan/code/test/docs/commit loop.
 
 ## Current-system references
@@ -37,25 +41,45 @@ These docs exist to help an agent answer five questions quickly:
 - [`standards/RUST.md`](standards/RUST.md)
 - [`standards/SERVER.md`](standards/SERVER.md)
 - [`standards/DATABASE.md`](standards/DATABASE.md)
-- [`runtime/README.md`](runtime/README.md)
+
+## Runtime Atlas
+
+Repository-local runtime flow documents live under [`runtime/`](runtime/README.md).
+
+Current source-derived flow:
+
+- [`runtime/CHAT_COMPLETIONS.md`](runtime/CHAT_COMPLETIONS.md) — `POST /v1/chat/completions` from unified server entry through auth/admission, model routing, upstream execution, billing/logging, quota settlement, and response.
+
+Use [`runtime/FLOW_TEMPLATE.md`](runtime/FLOW_TEMPLATE.md) for future End-to-End Request Flow + progressive ICFG documents.
 
 ## Truth policy
 
-`Source code > executable tests > current contracts/invariants > current architecture docs > engineering standards > external/runtime explanatory docs`.
+`Source code > executable tests > current contracts/invariants > current architecture/runtime docs > engineering standards > historical/external explanatory docs`.
 
-A document never overrides observable code behavior. If a normative rule intentionally changes desired behavior, the code and tests must be changed in the same workstream before the rule can be treated as implemented.
+A document never overrides observable code behavior. If a normative rule intentionally changes desired behavior, code and tests must change in the same workstream before that rule can be treated as implemented.
+
+Runtime documents must distinguish:
+
+- **STATIC CONFIRMED** — proven by current source/tests;
+- **DYNAMIC** — runtime data/configuration selects the branch/target;
+- **INFERRED** — plausible but not fully proven.
+
+Do not convert a dynamic or inferred edge into a fixed call graph.
 
 ## What is deliberately not stored here
 
-- Product roadmaps or speculative future architecture.
+- Product roadmaps or speculative future architecture mixed with current truth.
 - Planned database tables mixed with current schema facts.
-- Historical issue reports and one-off audit snapshots.
-- Screenshots or other image assets.
-- Duplicate Chinese/English constitutions that can drift apart.
-- Generated function-by-function prose that is not compiler-backed.
+- Historical issue reports and one-off audit snapshots as architecture truth.
+- Screenshots or other binary documentation assets.
+- Duplicate constitutions that can drift apart.
+- Generated function-by-function prose that is not tied to a user/runtime flow.
+- Giant repository-wide call graphs that are impossible to review or keep current.
 
-Future plans belong in GitHub Issues/Projects/PRs. Runtime explanations for humans are rendered at `https://burncloud.github.io/`; the long-term direction is for source-derived runtime docs to be versioned with this repository and rendered externally.
+Future plans belong in GitHub Issues/Projects/PRs. The Docusaurus site at `https://burncloud.github.io/` can render human-oriented runtime documentation, but repository-local Markdown should increasingly own source-derived runtime truth so documentation can evolve with the same commit as code.
 
 ## Maintenance rule
 
-When code changes observable runtime behavior, routing, persistence, authentication, billing, or an invariant listed here, update the relevant doc in the same PR. Keep docs smaller than the code they point to; use file paths and symbols as evidence instead of duplicating implementation detail.
+When code changes observable runtime behavior, routing, persistence, authentication, billing, provider dispatch, failure behavior, or a listed invariant, update the relevant doc in the same PR.
+
+Keep docs smaller than the code they point to; use file paths and symbols as evidence instead of duplicating implementation detail.

--- a/docs/runtime/CHAT_COMPLETIONS.md
+++ b/docs/runtime/CHAT_COMPLETIONS.md
@@ -1,0 +1,514 @@
+---
+doc_id: runtime.chat-completions
+doc_type: runtime-flow
+truth: source-derived
+status: active
+audited_against: 956041a8b54d8c6964e57fa2284f825cc322b0d2
+---
+
+# Chat Completions Runtime Flow
+
+## User action
+
+A client sends an OpenAI-compatible request:
+
+`POST /v1/chat/completions`
+
+with an API credential, a JSON body containing `model`, and chat messages.
+
+This document follows that request from unified server entry to admission, model routing, upstream execution, response processing, billing/logging, and the final client response.
+
+## Scope
+
+Included:
+
+- unified server fallback entry;
+- path normalization;
+- API credential resolution and token validation;
+- quota and local rate admission;
+- request buffering/model extraction;
+- scheduler/candidate selection;
+- path/channel compatibility filtering;
+- billing preflight;
+- per-candidate shaper/circuit checks;
+- OpenAI passthrough branch;
+- failover state relevant to the request;
+- usage/cost/log/quota settlement;
+- route-tracing response headers.
+
+Not fully expanded here:
+
+- internals of scheduler scoring and affinity ranking;
+- every provider conversion adaptor;
+- every streaming parser branch;
+- database SQL implementation details.
+
+Those are separate drill-down flows when they become necessary.
+
+---
+
+# L0 — User Journey
+
+```mermaid
+flowchart TD
+    A[Client sends POST /v1/chat/completions] --> B[BurnCloud unified server]
+    B --> C[Data-plane fallback router]
+    C --> D[Authenticate API credential]
+    D --> E[Quota and local rate admission]
+    E --> F[Read body and resolve model]
+    F --> G[Select candidate channels]
+    G --> H[Billing preflight]
+    H --> I[Candidate failover loop]
+    I --> J[Execute upstream request]
+    J --> K[Parse/stream response and usage]
+    K --> L[Cost, logs, quota settlement]
+    L --> M[Return response + route headers]
+```
+
+All major edges above are **STATIC CONFIRMED** at the responsibility level. The exact candidate and some downstream execution branches are **DYNAMIC** because database state, user group/order type, health, scheduler policy, channel configuration, and request fields participate in selection.
+
+---
+
+# L1 — Entry and Admission ICFG
+
+```mermaid
+flowchart TD
+    A[server::create_app] --> B[router::create_router_app]
+    B --> C[fallback proxy_handler]
+    C --> D[normalize_doubled_path]
+    D --> E{credential header exists?}
+    E -- no --> E1[401 missing_token]
+    E -- yes --> F[validate_token_and_get_info]
+    F --> G{current token record?}
+    G -- yes --> H[user_id/group/quota/order/price_cap]
+    G -- no --> I[validate_token_detailed]
+    I --> J{legacy token valid?}
+    J -- yes --> H
+    J -- expired --> J1[401 token_expired]
+    J -- invalid --> K[JWT decode fallback]
+    K -- invalid --> K1[401 invalid_token]
+    K -- valid --> H
+    H --> L{quota exhausted?}
+    L -- yes --> L1[402 insufficient_quota]
+    L -- no --> M{local RateLimiter admits?}
+    M -- no --> M1[429 rate_limit_exceeded]
+    M -- yes --> N[collect request body]
+    N --> O[extract model and request traits]
+    O --> P[proxy_logic]
+```
+
+## Entry evidence
+
+- `crates/server/src/lib.rs :: create_app` composes the data-plane router into the unified Axum application as fallback.
+- `crates/router/src/lib.rs :: create_router_app` registers a few explicit data-plane routes and installs `fallback(proxy_handler)` for unmatched data-plane requests.
+- Therefore `POST /v1/chat/completions` enters through `proxy_handler`; it does not require a dedicated Axum `.route()` registration.
+
+Classification: **STATIC CONFIRMED**.
+
+## Path normalization
+
+`proxy_handler` normalizes doubled client-SDK paths before routing. For example, duplicated `/v1/chat/completions/v1/chat/completions` can collapse to the canonical endpoint.
+
+Evidence:
+
+- `crates/router/src/lib.rs :: normalize_doubled_path`
+- `crates/router/src/lib.rs :: proxy_handler`
+
+Classification: **STATIC CONFIRMED**.
+
+## Credential resolution
+
+The fallback accepts the first available credential from:
+
+1. `Authorization: Bearer ...`
+2. `x-api-key`
+3. `x-goog-api-key`
+
+Missing credentials return HTTP 401 before body routing.
+
+Evidence:
+
+- `crates/router/src/lib.rs :: proxy_handler`
+
+Classification: **STATIC CONFIRMED**.
+
+## Token validation chain
+
+The current chain is:
+
+1. `RouterDatabase::validate_token_and_get_info`
+2. if absent, `RouterDatabase::validate_token_detailed`
+3. if legacy validation reports invalid, JWT decode fallback
+
+The successful result feeds user id, user group, quota fields, order type, and optional price cap into later routing/admission decisions.
+
+Classification: **STATIC CONFIRMED** for the branch structure; database contents are **DYNAMIC**.
+
+## Admission gates
+
+Before calling `proxy_logic`, the handler rejects:
+
+- exhausted quota with HTTP 402;
+- local per-user rate limiting with HTTP 429;
+- unreadable request body with HTTP 400.
+
+Classification: **STATIC CONFIRMED**.
+
+---
+
+# L2 — Model Routing and Candidate Construction
+
+```mermaid
+flowchart TD
+    A[proxy_logic] --> B[parse JSON body]
+    B --> C{model available?}
+    C -- no --> C1[eventually no candidate / reject]
+    C -- yes --> D[load scheduler policy for user group]
+    D --> E[resolve traffic class]
+    E --> F[build OrderType]
+    F --> G[build SchedulingRequest]
+    G --> H[ModelRouter::route_with_scheduler]
+    H --> I{channels returned?}
+    I -- error --> I1[503 scheduler/order_type rejection]
+    I -- none --> J[no candidates]
+    I -- some --> K[path/channel compatibility filter]
+    K --> L[candidate Upstream list]
+    L --> M{candidate list empty?}
+    M -- yes --> M1[404 no_available_channel]
+    M -- no --> N[billing preflight]
+```
+
+## Request-derived routing inputs
+
+For this flow, `proxy_handler` extracts `model` from the JSON body before calling `proxy_logic`. `proxy_logic` also computes:
+
+- estimated TPM from `max_tokens`, with a 4096 fallback;
+- session id from `conversation_id`, falling back to `user_id`;
+- traffic class via `UserService::resolve_traffic_class`;
+- `OrderType` from token/order database fields.
+
+Classification: **STATIC CONFIRMED** for computation rules; values are **DYNAMIC**.
+
+## Scheduler selection
+
+`proxy_logic` reads the scheduler policy keyed by the lower-cased user group and calls:
+
+`crates/router/src/model_router.rs :: ModelRouter::route_with_scheduler`
+
+with group, model, channel health state, pricing/exchange information, scheduler kind, request classification, and affinity cache.
+
+The exact ordered channel result is **DYNAMIC**.
+
+## Critical OpenAI-path filter
+
+After `route_with_scheduler` returns channel records, the current code applies an additional path/channel compatibility filter.
+
+For paths beginning with:
+
+- `/v1/chat/completions`
+- `/v1/completions`
+- `/v1/embeddings`
+
+only channels mapped to `ChannelType::OpenAI` or `ChannelType::Zai` survive candidate construction.
+
+This means the candidate list used by the current `/v1/chat/completions` path is narrower than the raw result returned by the model router.
+
+Evidence:
+
+- `crates/router/src/lib.rs :: proxy_logic`
+- `crates/common/src/types.rs :: ChannelType`
+
+Classification: **STATIC CONFIRMED**.
+
+## No-candidate exits
+
+There are two materially different local rejection families:
+
+- scheduler/order-type routing error: HTTP 503 with `X-Rejected-By` and `Retry-After`;
+- candidate list empty after routing/filtering: HTTP 404 `no_available_channel`.
+
+Do not collapse these into one generic routing error in clients or observability.
+
+---
+
+# L3 — Billing Preflight and Candidate Failover Loop
+
+```mermaid
+flowchart TD
+    A[candidates available] --> B{price preflight succeeds?}
+    B -- strict + fail --> B1[400 model_not_found / no configured price]
+    B -- pass/non-strict --> C[for candidate in order]
+    C --> D{L2 shaper configured?}
+    D -- no --> E[fail-open, count unconfigured]
+    D -- yes --> F{budget admits?}
+    F -- no --> G[record failover attempt; next candidate]
+    F -- yes --> H[hold BudgetGuard]
+    E --> I{circuit breaker allows?}
+    H --> I
+    I -- no --> J[record failover attempt; next candidate]
+    I -- yes --> K[derive channel protocol/type]
+    K --> L[should_passthrough]
+    L --> M[execute passthrough or conversion branch]
+    M --> N{success?}
+    N -- no/retryable --> O[record failure/failover; next candidate]
+    N -- yes --> P[response path]
+```
+
+## Billing preflight
+
+When `model_name` is known, `proxy_logic` runs the cost calculator preflight before external execution.
+
+- strict mode is enabled by default unless `BILLING_STRICT_MODE` is false/0;
+- in strict mode, missing/unsupported pricing rejects the request before the upstream call;
+- non-strict mode logs and allows the request.
+
+Evidence:
+
+- `crates/router/src/lib.rs :: create_router_app`
+- `crates/router/src/lib.rs :: proxy_logic`
+
+Classification: **STATIC CONFIRMED** for behavior; configured pricing is **DYNAMIC**.
+
+## Per-candidate local controls
+
+Each candidate passes through local controls before an upstream HTTP request:
+
+1. L2 rate-budget/shaper admission;
+2. circuit-breaker admission;
+3. protocol/adaptor branch selection.
+
+The shaper may reject one candidate and continue to the next. An unconfigured shaper channel currently fails open and increments observability state.
+
+Classification: **STATIC CONFIRMED**.
+
+## Failover
+
+The loop iterates ordered candidates. Later attempts update the routing decision to `Failover { attempt }`, and rejected/failed attempts can be recorded into detailed request-log data.
+
+The exact number and identity of attempts are **DYNAMIC**.
+
+---
+
+# L4 — OpenAI Upstream Execution Branch
+
+For the current `/v1/chat/completions` flow, an OpenAI channel survives the path filter and `should_passthrough` returns passthrough for the OpenAI-native chat path.
+
+```mermaid
+flowchart TD
+    A[OpenAI candidate] --> B[should_passthrough]
+    B --> C[Passthrough]
+    C --> D[base_url + /chat/completions]
+    D --> E[Authorization: Bearer upstream key]
+    E --> F[apply optional header_override]
+    F --> G[send JSON body with reqwest]
+    G --> H{HTTP result}
+    H -- 5xx/error branch --> I[record channel/circuit failure and failover]
+    H -- success non-stream --> J[record upstream success]
+    H -- success stream --> K[first-chunk/stream validation]
+    J --> L[usage/response processing]
+    K --> L
+```
+
+Evidence:
+
+- `crates/router/src/passthrough.rs :: should_passthrough`
+- `crates/router/src/lib.rs :: proxy_logic`
+
+Classification: **STATIC CONFIRMED** for the OpenAI-channel branch.
+
+## Important dynamic boundary
+
+Do not generalize the OpenAI passthrough branch into a universal provider call graph.
+
+`proxy_logic` contains both passthrough and conversion execution paths, and runtime channel/protocol data determines the applicable branch. A provider-specific runtime document must prove its candidate eligibility and adaptor target independently.
+
+---
+
+# L5 — Response, Usage, Billing, Logging, Quota
+
+After `proxy_logic` returns, `proxy_handler` performs post-execution settlement and observability.
+
+```mermaid
+flowchart TD
+    A[ProxyResult] --> B[get UnifiedTokenCounter usage]
+    B --> C[provider/media-specific usage injection when applicable]
+    C --> D[CostCalculator::calculate]
+    D --> E[construct RouterLog]
+    E --> F[async router log channel]
+    E --> G[detailed request log if enabled]
+    D --> H{cost > 0?}
+    H -- yes --> I[spawn async deduct_quota]
+    H -- no --> J[no quota deduction task]
+    F --> K[inject X-Channel-Id]
+    G --> K
+    I --> K
+    J --> K
+    K --> L[inject X-Model-Id when model known]
+    L --> M[return upstream/client response]
+```
+
+## Cost calculation
+
+The handler reads unified usage collected while processing the response and calculates cost when usage is non-empty and a model is known.
+
+A missing price after execution is recorded as a billing status/counter and can yield zero recorded cost; it is distinct from the strict preflight rejection path.
+
+Classification: **STATIC CONFIRMED**.
+
+## Logging
+
+Two logging paths exist:
+
+- `RouterLog` is sent through an async channel for database insertion;
+- detailed `RouterRequestLog` is emitted when request-log storage policy is not `none`.
+
+Request logging code sanitizes sensitive headers/body fields and can truncate large bodies.
+
+Classification: **STATIC CONFIRMED**.
+
+## Quota settlement
+
+When calculated `cost > 0`, quota deduction is spawned asynchronously using the authenticated user/token.
+
+This is a **fire-and-forget side effect** relative to the client response path; document changes to it carefully because request success and accounting persistence are not the same atomic operation.
+
+Evidence:
+
+- `crates/router/src/lib.rs :: proxy_handler`
+
+Classification: **STATIC CONFIRMED**.
+
+## Client-visible route evidence
+
+If an upstream channel id exists, the response receives:
+
+- `X-Channel-Id`
+- `X-Model-Id` when model is known
+
+before returning to the client.
+
+Classification: **STATIC CONFIRMED**.
+
+---
+
+# Decision Table
+
+| Decision | Condition | Result | Classification | Evidence |
+|---|---|---|---|---|
+| Data-plane entry | unmatched route such as `/v1/chat/completions` | `proxy_handler` | STATIC CONFIRMED | `crates/router/src/lib.rs :: create_router_app` |
+| Credential source | bearer / x-api-key / x-goog-api-key | token string or 401 | STATIC CONFIRMED | `crates/router/src/lib.rs :: proxy_handler` |
+| Token source | current token row / legacy token / JWT fallback | user routing context or auth error | DYNAMIC branch input | `crates/router/src/lib.rs :: proxy_handler` |
+| Quota admission | quota exhausted | 402 | STATIC CONFIRMED | `crates/router/src/lib.rs :: proxy_handler` |
+| Local rate admission | limiter rejects | 429 | STATIC CONFIRMED | `crates/router/src/lib.rs :: proxy_handler` |
+| Scheduler result | group/model/health/pricing/order/affinity | ordered channels or 503 | DYNAMIC | `crates/router/src/model_router.rs :: route_with_scheduler` |
+| OpenAI path compatibility | `/v1/chat/completions` | only OpenAI/Zai candidates survive | STATIC CONFIRMED | `crates/router/src/lib.rs :: proxy_logic` |
+| Price preflight | price missing + strict mode | 400 before upstream | DYNAMIC data, STATIC rule | `crates/router/src/lib.rs :: proxy_logic` |
+| Shaper | configured budget rejects | try next candidate | DYNAMIC state, STATIC rule | `crates/router/src/lib.rs :: proxy_logic` |
+| Circuit breaker | circuit open | try next candidate | DYNAMIC state, STATIC rule | `crates/router/src/lib.rs :: proxy_logic` |
+| OpenAI execution | OpenAI candidate + chat path | passthrough to `/chat/completions` | STATIC CONFIRMED | `crates/router/src/passthrough.rs :: should_passthrough`; `proxy_logic` |
+| Quota deduction | calculated cost > 0 | async deduction task | STATIC CONFIRMED | `crates/router/src/lib.rs :: proxy_handler` |
+
+---
+
+# State and Side Effects
+
+Current flow can touch or depend on:
+
+- router token/user-group/quota data;
+- token `accessed_time` update task;
+- scheduler policy state;
+- channel health state;
+- affinity cache;
+- rate-budget/shaper state;
+- circuit breaker state;
+- external provider HTTP request;
+- token/usage counters;
+- price cache/cost calculator;
+- router log database writer;
+- detailed request log writer;
+- async quota deduction.
+
+Not every request mutates every item; many branches are conditional.
+
+---
+
+# Failure Exits to Preserve
+
+At minimum, changes in this flow must consider these distinct exits:
+
+- 401 missing credential;
+- 401 expired/invalid credential;
+- 402 insufficient quota;
+- 429 local rate limit;
+- 400 invalid body/read failure;
+- 503 scheduler/order-type local rejection;
+- 404 no candidate after filtering;
+- 400 strict billing preflight rejection;
+- candidate-level shaper rejection and failover;
+- circuit-open candidate skip and failover;
+- upstream HTTP/server/network error;
+- streaming first-chunk/empty-response failure;
+- post-response billing/logging failure that may not change the already-produced upstream response.
+
+Do not change one of these branches by editing a nearby success path without verifying its state effects.
+
+---
+
+# Executable Evidence
+
+Primary integration evidence:
+
+- `crates/tests/tests/api/relay.rs :: test_e2e_real_upstream`
+  - creates an OpenAI channel;
+  - calls `/v1/chat/completions`;
+  - expects an upstream-compatible `choices` response.
+
+Additional routing/provider/billing tests should be selected using `docs/agent/TEST_MATRIX.md` when changing a deeper branch.
+
+---
+
+# Verification Gap — Gemini Relay Test vs Current Path Filter
+
+`crates/tests/tests/api/relay.rs :: test_gemini_adaptor` creates channel type `24` (Gemini) and calls `/v1/chat/completions`.
+
+However, the current `proxy_logic` path compatibility filter allows `/v1/chat/completions` candidates only when `ChannelType` is `OpenAI` or `Zai`, and `ChannelType::Gemini` is value `24`.
+
+Therefore the test intent and the inspected routing branch appear inconsistent.
+
+This is recorded as a **verification gap**, not resolved by this document.
+
+Important detail: the Gemini integration test exits early when `TEST_GEMINI_KEY` is unavailable, so its presence alone does not prove the current path succeeds in normal CI.
+
+To resolve the gap, use a targeted test with a deterministic/mock Gemini channel or explicitly decide whether OpenAI-format-to-Gemini conversion should remain supported. Then change source/tests/docs together.
+
+---
+
+# Source Evidence Index
+
+- `crates/server/src/lib.rs :: create_app`
+- `crates/router/src/lib.rs :: create_router_app`
+- `crates/router/src/lib.rs :: normalize_doubled_path`
+- `crates/router/src/lib.rs :: proxy_handler`
+- `crates/router/src/lib.rs :: proxy_logic`
+- `crates/router/src/model_router.rs :: ModelRouter::route_with_scheduler`
+- `crates/router/src/passthrough.rs :: should_passthrough`
+- `crates/common/src/types.rs :: ChannelType`
+- `crates/tests/tests/api/relay.rs :: test_e2e_real_upstream`
+- `crates/tests/tests/api/relay.rs :: test_gemini_adaptor`
+
+---
+
+# Maintenance Trigger
+
+Update this document in the same PR when a change modifies:
+
+- `/v1/chat/completions` entry behavior;
+- credential/token/quota admission;
+- scheduler inputs or candidate filtering;
+- OpenAI/Zai eligibility for the path;
+- provider/adaptor selection;
+- shaper/circuit/failover semantics;
+- billing preflight or settlement;
+- request/router logging;
+- quota deduction;
+- client-visible route tracing headers.

--- a/docs/runtime/FLOW_TEMPLATE.md
+++ b/docs/runtime/FLOW_TEMPLATE.md
@@ -1,0 +1,140 @@
+---
+doc_id: runtime.flow-template
+doc_type: runtime-template
+truth: normative
+status: active
+audited_against: 956041a8b54d8c6964e57fa2284f825cc322b0d2
+---
+
+# Runtime Flow Template
+
+Use this template for repository-local End-to-End Request Flow + drill-down ICFG documentation.
+
+The goal is not to draw every function. The goal is to let a human or coding agent move from a user action to the exact source that controls the behavior.
+
+## 1. User action
+
+State one concrete behavior.
+
+Example:
+
+`User sends POST /v1/chat/completions with an API token and a model.`
+
+## 2. Scope
+
+Document:
+
+- what starts the flow;
+- what successful completion means;
+- major rejection/failure exits;
+- persistent/external side effects;
+- what is intentionally outside this flow.
+
+Do not mix multiple independent user journeys into one document.
+
+## 3. End-to-end flow
+
+Use a small Mermaid graph. Nodes should represent runtime responsibilities, not filenames.
+
+```mermaid
+flowchart TD
+    A[User action] --> B[Entry]
+    B --> C[Admission]
+    C --> D[Routing]
+    D --> E[External/state effect]
+    E --> F[Response]
+```
+
+Every node must be backed by source evidence below.
+
+## 4. Execution classification
+
+Classify each important edge:
+
+- **STATIC CONFIRMED** — current source/tests directly prove the edge.
+- **DYNAMIC** — runtime data/configuration selects the target or branch.
+- **INFERRED** — likely, but the inspected source does not fully prove it.
+
+Never use a straight arrow to imply a fixed target when the code performs dynamic dispatch or data-driven selection.
+
+## 5. Progressive drill-down
+
+Start at the entrypoint, then expand only high-value nodes.
+
+Recommended levels:
+
+1. **L0 — User journey**
+2. **L1 — End-to-end runtime flow**
+3. **L2 — Entry/admission ICFG**
+4. **L3 — Routing/provider ICFG**
+5. **L4 — Persistence/billing/observability ICFG**
+6. **L5 — Source evidence**
+
+Avoid repository-wide call graphs.
+
+## 6. Decision table
+
+Use a table for branches that matter to correctness.
+
+| Decision | Condition | Result | Classification | Evidence |
+|---|---|---|---|---|
+| Example | runtime condition | next behavior | STATIC/DYNAMIC/INFERRED | `path :: Symbol` |
+
+## 7. State and side effects
+
+Explicitly list:
+
+- database reads/writes;
+- caches/affinity/circuit state;
+- async logging;
+- quota/billing effects;
+- external HTTP calls;
+- response headers/status/body effects.
+
+If a side effect is fire-and-forget, say so.
+
+## 8. Failure exits
+
+Document important exits such as:
+
+- authentication failure;
+- quota/rate rejection;
+- no route/candidate;
+- local shaper/scheduler rejection;
+- upstream HTTP/network error;
+- streaming first-chunk failure;
+- billing/price failure.
+
+Do not collapse different failures into one generic "error" node when they produce different state changes or client contracts.
+
+## 9. Source evidence
+
+Prefer stable symbol references:
+
+- `path/to/file.rs :: SymbolName`
+- `path/to/test.rs :: test_name`
+
+Source is authoritative. Tests are executable evidence but may be conditional, skipped, stale, or incomplete; call that out when relevant.
+
+## 10. Verification gaps
+
+Create a short section whenever source/tests/docs disagree or an important runtime branch cannot be proven statically.
+
+A verification gap is not permission to guess. Record:
+
+- what is uncertain;
+- why it is uncertain;
+- what test/trace/source inspection would resolve it.
+
+## 11. Maintenance trigger
+
+Update the flow when a change modifies any of these:
+
+- entry/routing;
+- authentication/admission;
+- candidate selection/scheduling;
+- provider/adaptor dispatch;
+- failover/circuit/affinity behavior;
+- billing/quota/accounting;
+- persistence/logging;
+- client-visible status/body/headers.

--- a/docs/runtime/README.md
+++ b/docs/runtime/README.md
@@ -3,32 +3,71 @@ doc_id: runtime.index
 doc_type: runtime-navigation
 truth: informational
 status: active
-audited_against: c7107382b8479deb44f992e9e5ae8dcac5efb417
+audited_against: 956041a8b54d8c6964e57fa2284f825cc322b0d2
 ---
 
 # Runtime Flow Navigation
 
-The human-facing progressive Runtime Flow & ICFG Atlas is currently rendered at:
+Repository-local runtime documents are the versioned navigation layer from user behavior to source evidence.
 
-**https://burncloud.github.io/**
+Reading model:
 
-It is organized from user action to source:
+`User Action -> End-to-End Flow -> Drill-down ICFG -> Decision/Side Effects -> Source Evidence`
 
-`User Action → End-to-End Flow → Drill-down ICFG → smaller ICFG → Source Evidence`.
+The purpose is not to duplicate the source tree. A runtime document should expose the smallest execution map needed to understand and safely change a user-visible behavior.
+
+## Available flows
+
+| User/runtime behavior | Document | Status |
+|---|---|---|
+| OpenAI-compatible Chat Completions | [`CHAT_COMPLETIONS.md`](CHAT_COMPLETIONS.md) | source-derived |
+
+Use [`FLOW_TEMPLATE.md`](FLOW_TEMPLATE.md) when adding the next flow.
+
+## Recommended expansion order
+
+Add flows one user journey at a time. Suggested next targets:
+
+1. public register/login;
+2. API token creation/use;
+3. channel create/update/delete;
+4. channel selection/scheduler/affinity drill-down;
+5. provider-specific execution flows;
+6. billing/quota settlement;
+7. logs/monitoring;
+8. streaming response handling.
+
+Do not generate all flows in one task. Each flow should be source-audited and reviewable on its own.
 
 ## Agent usage
 
-Use the Runtime Atlas to understand the execution path and discover source evidence. Before changing code:
+Before changing runtime behavior:
 
-1. open the current repository source linked by the flow;
-2. confirm the relevant branch still exists;
-3. inspect current tests;
-4. classify dynamic dispatch/configuration honestly.
+1. start at `docs/agent/START_HERE.md`;
+2. route the task with `docs/agent/TASK_ROUTER.md`;
+3. open the relevant runtime flow if one exists;
+4. re-confirm every affected branch in the current source;
+5. inspect executable tests;
+6. classify dynamic/inferred edges honestly;
+7. update the runtime doc only when the observable truth changes.
 
-The website is a navigation/explanation layer, not authority over the current checkout.
+The runtime document is not authority over source code.
 
-## Long-term direction
+## Flow quality rules
 
-Source-derived runtime Markdown should eventually be versioned in this repository so code and runtime explanation share a commit. The Docusaurus repository should become a renderer rather than an independent owner of behavioral truth.
+A good flow:
 
-That migration is intentionally not performed in this first docs-cleanup change; keeping the first PR small makes the truth model reviewable before moving the full Runtime Atlas.
+- starts from one concrete user/operator action;
+- identifies the real entrypoint;
+- separates admission, routing, execution, state effects, and response behavior;
+- expands important branches progressively instead of drawing a giant call graph;
+- marks **STATIC CONFIRMED**, **DYNAMIC**, and **INFERRED** behavior;
+- lists failure exits that have different client/state consequences;
+- cites stable source symbols;
+- records test/source contradictions as verification gaps instead of guessing.
+
+## External renderer
+
+The human-facing Docusaurus Runtime Flow & ICFG site remains available at `https://burncloud.github.io/`.
+
+Its role should increasingly be rendering/navigation. Repository-local source-derived Markdown is the preferred owner for runtime truth because it can evolve in the same commit/PR as code.


### PR DESCRIPTION
## What changed

- add a root `AGENTS.md` as the repository-level operating contract for coding agents
- add `docs/runtime/FLOW_TEMPLATE.md` for incremental End-to-End Request Flow + progressive ICFG documentation
- add a source-derived `POST /v1/chat/completions` runtime atlas covering entry, authentication/admission, model routing, candidate filtering, billing preflight, failover, upstream execution, settlement/logging, and response behavior
- update the docs indexes so repository-local runtime Markdown becomes the versioned truth/navigation layer

## Why

BurnCloud already has a strong agent engineering harness, but runtime-flow truth was still primarily delegated to the external Docusaurus site. This change starts moving source-derived runtime knowledge into the same repository and review lifecycle as the code.

The flow intentionally stays incremental and reviewable instead of generating a repository-wide call graph. Important edges are classified as STATIC CONFIRMED, DYNAMIC, or INFERRED, and contradictions are recorded as verification gaps instead of being guessed away.

## Verification

- docs-only diff; no runtime behavior changed
- audited source paths and symbols against current `main` at `956041a8b54d8c6964e57fa2284f825cc322b0d2`
- checked the current router fallback, authentication/admission chain, scheduler/candidate construction, OpenAI passthrough branch, billing/logging/quota settlement, and integration evidence
- recorded an existing verification gap: `test_gemini_adaptor` expects a Gemini channel to handle `/v1/chat/completions`, while the current `proxy_logic` path filter only retains OpenAI/Zai channels for OpenAI-format paths; this PR documents the inconsistency but does not change behavior

## Follow-up

Add the next runtime journey one flow per PR (for example auth/login, API token lifecycle, channel management, scheduler/affinity, provider-specific dispatch, or billing settlement).