### PR TITLE
Refine BurnCloud console UX around operator workflows

### DIFF
--- a/.github/workflows/client-ui.yml
+++ b/.github/workflows/client-ui.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Check functional console wiring
         run: bash scripts/check-functional-wiring.sh
 
+      - name: Check product UX contracts
+        run: bash scripts/check-product-ux.sh
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/crates/client/scripts/check-product-ux.sh
+++ b/crates/client/scripts/check-product-ux.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+require() {
+  local needle="$1"
+  local file="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    echo "Missing product UX contract: '$needle' in $file" >&2
+    exit 1
+  fi
+}
+
+forbid() {
+  local needle="$1"
+  local file="$2"
+  if grep -Fq "$needle" "$file"; then
+    echo "Prototype/backend-detail UI reintroduced: '$needle' in $file" >&2
+    exit 1
+  fi
+}
+
+line_of() {
+  local needle="$1"
+  local file="$2"
+  grep -nF "$needle" "$file" | head -n1 | cut -d: -f1
+}
+
+# Navigation follows the operator workflow: configure supply -> understand catalog/routing -> test traffic.
+providers_line=$(line_of 'NavItem { to:Route::Providers' src/functional_layout.rs)
+models_line=$(line_of 'NavItem { to:Route::Models' src/functional_layout.rs)
+routes_line=$(line_of 'NavItem { to:Route::Routes' src/functional_layout.rs)
+playground_line=$(line_of 'NavItem { to:Route::Playground' src/functional_layout.rs)
+logs_line=$(line_of 'NavItem { to:Route::Logs' src/functional_layout.rs)
+evaluation_line=$(line_of 'NavItem { to:Route::Evaluation' src/functional_layout.rs)
+billing_line=$(line_of 'NavItem { to:Route::Billing' src/functional_layout.rs)
+
+if ! (( providers_line < models_line && models_line < routes_line && routes_line < playground_line )); then
+  echo "Traffic Setup navigation must remain Providers -> Models -> Routes -> Playground" >&2
+  exit 1
+fi
+if ! (( logs_line < evaluation_line && evaluation_line < billing_line )); then
+  echo "Observe navigation must remain Logs -> Evaluation -> Billing" >&2
+  exit 1
+fi
+
+# Overview must answer readiness and next action before technical diagnostics.
+require 'Setup & readiness' src/critical_pages/dashboard.rs
+require 'BurnCloud is ready to serve traffic' src/critical_pages/dashboard.rs
+require 'Finish setup before sending production traffic' src/critical_pages/dashboard.rs
+require 'Add first provider' src/critical_pages/dashboard.rs
+require 'Test a request' src/critical_pages/dashboard.rs
+
+# Auth must expose only current backend capabilities, not prototype choices.
+forbid 'Onboarding Account Preference' src/critical_pages/auth.rs
+forbid 'TierButton' src/critical_pages/auth.rs
+forbid 'Company / Team' src/critical_pages/auth.rs
+forbid 'auth-tabs' src/critical_pages/auth.rs
+require 'Password recovery' src/critical_pages/auth.rs
+require 'Account email' src/critical_pages/auth.rs
+
+# Providers present product concepts instead of raw enum IDs and protect destructive changes.
+require 'PROVIDER_TYPES' src/functional_pages/providers.rs
+require 'Provider type' src/functional_pages/providers.rs
+require 'Advanced routing & capacity' src/functional_pages/providers.rs
+require 'Leave blank to keep stored credential' src/functional_pages/providers.rs
+require 'pending_delete' src/functional_pages/providers.rs
+forbid 'Provider Type ID' src/functional_pages/providers.rs
+
+# Models/Routes communicate service availability and resilience, not just database fields.
+require 'Single upstream' src/functional_pages/catalog.rs
+require 'Redundant' src/functional_pages/catalog.rs
+require 'Unavailable' src/functional_pages/catalog.rs
+require 'No failover redundancy' src/functional_pages/catalog.rs
+
+# Playground is a guided end-to-end test and blocks impossible workflows.
+require 'Playground is not ready yet' src/functional_pages/playground_live.rs
+require 'Connect an active provider first' src/functional_pages/playground_live.rs
+require 'Create an API key for the test' src/functional_pages/playground_live.rs
+require 'Select a configured model' src/functional_pages/playground_live.rs
+require 'Send Test Request' src/functional_pages/playground_live.rs
+
+# Customers and staff have separate product responsibilities.
+require 'Manage business accounts' src/critical_pages/customers_portable.rs
+require '!is_staff_role(&user.role)' src/critical_pages/customers_portable.rs
+require 'Environment operators' src/functional_pages/access_live.rs
+require 'is_staff_role(&user.role)' src/functional_pages/access_live.rs
+require 'role management is read-only' src/functional_pages/access_live.rs
+
+# API keys must be human-owned and lifecycle/destructive actions need explicit steps.
+require 'Choose which account will own this router credential' src/functional_pages/access_live.rs
+require 'API Key Created' src/functional_pages/access_live.rs
+require 'Rotate API Key' src/functional_pages/access_live.rs
+require 'Delete API Key' src/functional_pages/access_live.rs
+
+# Diagnostic pages prioritize conclusions and risks.
+require 'Failures' src/functional_pages/logs_full.rs
+require 'Outcome' src/functional_pages/logs_full.rs
+require 'Operational attention' src/functional_pages/analytics_full.rs
+require 'Spend by model' src/functional_pages/analytics.rs
+
+# Dangerous operational actions require explicit acknowledgement and stay in danger zones.
+require 'confirm_trip' src/functional_pages/guardrails_live.rs
+require 'DANGER ZONE' src/functional_pages/guardrails_live.rs
+require 'confirm_clear' src/functional_pages/settings.rs
+require 'MAINTENANCE' src/functional_pages/settings.rs
+
+# Chrome must not overclaim runtime health.
+require 'Server Configured' src/functional_layout.rs
+forbid 'Server Connected' src/functional_layout.rs
+
+echo "Product UX contracts OK"

--- a/crates/client/scripts/check-product-ux.sh
+++ b/crates/client/scripts/check-product-ux.sh
@@ -87,7 +87,7 @@ require 'Manage business accounts' src/critical_pages/customers_portable.rs
 require '!is_staff_role(&user.role)' src/critical_pages/customers_portable.rs
 require 'Environment operators' src/functional_pages/access_live.rs
 require 'is_staff_role(&user.role)' src/functional_pages/access_live.rs
-require 'role management is read-only' src/functional_pages/access_live.rs
+require 'Team will become editable only when the backend has explicit role-management endpoints.' src/functional_pages/access_live.rs
 
 # API keys must be human-owned and lifecycle/destructive actions need explicit steps.
 require 'Choose which account will own this router credential' src/functional_pages/access_live.rs

--- a/crates/client/src/app.rs
+++ b/crates/client/src/app.rs
@@ -83,6 +83,7 @@ pub fn App() -> Element {
             title { "BurnCloud" }
             style { dangerous_inner_html: include_str!("styles.css") }
             style { dangerous_inner_html: include_str!("critical_pages.css") }
+            style { dangerous_inner_html: include_str!("product_ui.css") }
             style { dangerous_inner_html: include_str!("desktop_chrome.css") }
         }
         DesktopChrome {}

--- a/crates/client/src/critical_pages/auth.rs
+++ b/crates/client/src/critical_pages/auth.rs
@@ -3,7 +3,7 @@ use dioxus::prelude::*;
 use crate::{
     app::Route,
     backend::{use_auth, AuthService, ClientState, CurrentUser},
-    components::{Badge, Icon, Logo},
+    components::{Badge, Logo},
 };
 
 #[component]
@@ -15,21 +15,20 @@ pub fn Login() -> Element {
 
     let mut username = use_signal(move || last_username);
     let mut password = use_signal(String::new);
-    let mut passkey = use_signal(|| false);
+    let mut recovery_open = use_signal(|| false);
+    let mut recovery_email = use_signal(String::new);
     let mut loading = use_signal(|| false);
+    let mut recovery_loading = use_signal(|| false);
     let mut status = use_signal(String::new);
     let mut is_error = use_signal(|| false);
+    let mut recovery_status = use_signal(String::new);
+    let mut recovery_error = use_signal(|| false);
 
     use_effect(move || {
         if was_authenticated {
             auth.clear();
         }
     });
-
-    let submit_nav = navigator.clone();
-    let forgot_username = username;
-    let mut forgot_status = status;
-    let mut forgot_error = is_error;
 
     rsx! {
         div { class: "auth-page",
@@ -47,187 +46,159 @@ pub fn Login() -> Element {
             main { class: "auth-main",
                 div { class: "auth-wrap",
                     div { class: "auth-intro",
-                        Badge { text: "BurnCloud Secure Console", tone: "brand" }
-                        h1 { "Sign in to BurnCloud" }
-                        p { "Authenticate against the local BurnCloud server and resume your protected console session." }
+                        Badge { text: "BurnCloud Console", tone: "brand" }
+                        h1 { "Sign in" }
+                        p { "Use your BurnCloud username and password to access the connected environment." }
                     }
 
                     div { class: "card auth-card",
-                        div { class: "auth-tabs",
-                            button {
-                                r#type: "button",
-                                class: if !passkey() { "auth-tab active" } else { "auth-tab" },
-                                onclick: move |_| {
-                                    passkey.set(false);
-                                    status.set(String::new());
-                                    is_error.set(false);
-                                },
-                                "Password"
+                        form {
+                            class: "auth-form",
+                            onsubmit: move |event| {
+                                event.prevent_default();
+                                let user_name = username().trim().to_string();
+                                let user_password = password();
+                                if user_name.is_empty() || user_password.is_empty() {
+                                    is_error.set(true);
+                                    status.set("Username and password are required.".to_string());
+                                    return;
+                                }
+                                loading.set(true);
+                                is_error.set(false);
+                                status.set("Signing in…".to_string());
+                                let nav = navigator.clone();
+                                spawn(async move {
+                                    match AuthService::login(&user_name, &user_password).await {
+                                        Ok(response) => {
+                                            let user = CurrentUser {
+                                                id: response.id,
+                                                username: response.username,
+                                                roles: response.roles,
+                                            };
+                                            auth.set(response.token, user, true);
+                                            loading.set(false);
+                                            status.set(String::new());
+                                            nav.replace(Route::Overview {});
+                                        }
+                                        Err(error) => {
+                                            loading.set(false);
+                                            is_error.set(true);
+                                            status.set(format!("Sign in failed: {error}"));
+                                        }
+                                    }
+                                });
+                            },
+                            div { class: "field",
+                                label { "Username" }
+                                input {
+                                    class: "input",
+                                    r#type: "text",
+                                    autocomplete: "username",
+                                    required: true,
+                                    value: "{username}",
+                                    placeholder: "Your BurnCloud username",
+                                    disabled: loading(),
+                                    oninput: move |event| username.set(event.value()),
+                                }
                             }
+
+                            div { class: "field",
+                                div { class: "row between",
+                                    label { "Password" }
+                                    button {
+                                        r#type: "button",
+                                        class: "button button-ghost button-sm",
+                                        disabled: loading(),
+                                        onclick: move |_| {
+                                            recovery_open.set(!recovery_open());
+                                            recovery_status.set(String::new());
+                                            recovery_error.set(false);
+                                        },
+                                        "Forgot password?"
+                                    }
+                                }
+                                input {
+                                    class: "input",
+                                    r#type: "password",
+                                    autocomplete: "current-password",
+                                    required: true,
+                                    value: "{password}",
+                                    placeholder: "Enter your password",
+                                    disabled: loading(),
+                                    oninput: move |event| password.set(event.value()),
+                                }
+                            }
+
+                            if !status().is_empty() {
+                                div { class: if is_error() { "terminal auth-status auth-status-error" } else { "terminal auth-status" }, "{status}" }
+                            }
+
                             button {
-                                r#type: "button",
-                                class: if passkey() { "auth-tab active" } else { "auth-tab" },
-                                onclick: move |_| {
-                                    passkey.set(true);
-                                    status.set("Passkey authentication is not exposed by the current BurnCloud server API yet.".to_string());
-                                    is_error.set(false);
-                                },
-                                "◉ Passkey"
+                                r#type: "submit",
+                                class: "button button-primary button-lg",
+                                style: "width:100%",
+                                disabled: loading(),
+                                if loading() { "Signing in…" } else { "Sign in to Console" }
                             }
                         }
 
-                        if !passkey() {
-                            div { class: "auth-form",
+                        if recovery_open() {
+                            div { class: "form-section", style: "margin-top:18px",
+                                div { class: "form-section-head",
+                                    strong { "Password recovery" }
+                                    small { "Enter the email stored on your BurnCloud account. Recovery is separate from the username you use to sign in." }
+                                }
                                 div { class: "field",
-                                    label { "Username" }
-                                    div { class: "auth-input-wrap",
-                                        span { class: "auth-input-icon", "@" }
-                                        input {
-                                            class: "input auth-input-with-icon",
-                                            r#type: "text",
-                                            required: true,
-                                            value: "{username}",
-                                            placeholder: "your BurnCloud username",
-                                            disabled: loading(),
-                                            oninput: move |evt| username.set(evt.value()),
-                                        }
+                                    label { "Account email" }
+                                    input {
+                                        class: "input",
+                                        r#type: "email",
+                                        autocomplete: "email",
+                                        value: "{recovery_email}",
+                                        placeholder: "name@company.com",
+                                        disabled: recovery_loading(),
+                                        oninput: move |event| recovery_email.set(event.value()),
                                     }
                                 }
-
-                                div { class: "field",
-                                    div { class: "row between",
-                                        label { "Password" }
-                                        button {
-                                            r#type: "button",
-                                            class: "button button-ghost button-sm",
-                                            disabled: loading(),
-                                            onclick: move |_| {
-                                                let account = forgot_username().trim().to_string();
-                                                if account.is_empty() || !account.contains('@') {
-                                                    forgot_error.set(true);
-                                                    forgot_status.set("Password reset requires the account email address. Enter the email in Username if your account uses email as its username, or use the registered email from the recovery flow.".to_string());
-                                                    return;
-                                                }
-                                                forgot_error.set(false);
-                                                forgot_status.set("Requesting password reset…".to_string());
-                                                spawn(async move {
-                                                    match AuthService::forgot_password(&account).await {
-                                                        Ok(()) => {
-                                                            forgot_error.set(false);
-                                                            forgot_status.set("Password reset request accepted by the BurnCloud server.".to_string());
-                                                        }
-                                                        Err(error) => {
-                                                            forgot_error.set(true);
-                                                            forgot_status.set(format!("Password reset failed: {error}"));
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            "Forgot?"
-                                        }
-                                    }
-                                    div { class: "auth-input-wrap",
-                                        span { class: "auth-input-icon", "•" }
-                                        input {
-                                            class: "input auth-input-with-icon",
-                                            r#type: "password",
-                                            required: true,
-                                            value: "{password}",
-                                            placeholder: "Enter password",
-                                            disabled: loading(),
-                                            oninput: move |evt| password.set(evt.value()),
-                                            onkeydown: move |evt| {
-                                                if evt.key() == Key::Enter && !loading() {
-                                                    let u = username().trim().to_string();
-                                                    let p = password();
-                                                    if u.is_empty() || p.is_empty() {
-                                                        is_error.set(true);
-                                                        status.set("Username and password are required.".to_string());
-                                                        return;
-                                                    }
-                                                    loading.set(true);
-                                                    is_error.set(false);
-                                                    status.set("Authenticating with BurnCloud…".to_string());
-                                                    let nav = submit_nav.clone();
-                                                    spawn(async move {
-                                                        match AuthService::login(&u, &p).await {
-                                                            Ok(response) => {
-                                                                let user = CurrentUser { id: response.id, username: response.username, roles: response.roles };
-                                                                auth.set(response.token, user, true);
-                                                                loading.set(false);
-                                                                status.set(String::new());
-                                                                nav.replace(Route::Overview {});
-                                                            }
-                                                            Err(error) => {
-                                                                loading.set(false);
-                                                                is_error.set(true);
-                                                                status.set(format!("Sign in failed: {error}"));
-                                                            }
-                                                        }
-                                                    });
-                                                }
-                                            },
-                                        }
-                                    }
+                                if !recovery_status().is_empty() {
+                                    div { class: if recovery_error() { "terminal auth-status auth-status-error" } else { "terminal auth-status" }, "{recovery_status}" }
                                 }
-
-                                if !status().is_empty() {
-                                    div { class: if is_error() { "terminal auth-status auth-status-error" } else { "terminal auth-status" }, "{status}" }
-                                }
-
                                 button {
                                     r#type: "button",
-                                    class: "button button-primary",
-                                    style: "width:100%",
-                                    disabled: loading(),
+                                    class: "button button-secondary",
+                                    disabled: recovery_loading(),
                                     onclick: move |_| {
-                                        let u = username().trim().to_string();
-                                        let p = password();
-                                        if u.is_empty() || p.is_empty() {
-                                            is_error.set(true);
-                                            status.set("Username and password are required.".to_string());
+                                        let email = recovery_email().trim().to_string();
+                                        if email.is_empty() || !email.contains('@') {
+                                            recovery_error.set(true);
+                                            recovery_status.set("Enter the email address attached to the account.".to_string());
                                             return;
                                         }
-                                        loading.set(true);
-                                        is_error.set(false);
-                                        status.set("Authenticating with BurnCloud…".to_string());
-                                        let nav = navigator.clone();
+                                        recovery_loading.set(true);
+                                        recovery_error.set(false);
+                                        recovery_status.set("Requesting password recovery…".to_string());
                                         spawn(async move {
-                                            match AuthService::login(&u, &p).await {
-                                                Ok(response) => {
-                                                    let user = CurrentUser { id: response.id, username: response.username, roles: response.roles };
-                                                    auth.set(response.token, user, true);
-                                                    loading.set(false);
-                                                    status.set(String::new());
-                                                    nav.replace(Route::Overview {});
+                                            match AuthService::forgot_password(&email).await {
+                                                Ok(()) => {
+                                                    recovery_loading.set(false);
+                                                    recovery_error.set(false);
+                                                    recovery_status.set("Password recovery request accepted by the BurnCloud server.".to_string());
                                                 }
                                                 Err(error) => {
-                                                    loading.set(false);
-                                                    is_error.set(true);
-                                                    status.set(format!("Sign in failed: {error}"));
+                                                    recovery_loading.set(false);
+                                                    recovery_error.set(true);
+                                                    recovery_status.set(format!("Password recovery failed: {error}"));
                                                 }
                                             }
                                         });
                                     },
-                                    if loading() { "Signing in…" } else { "Sign in to Console →" }
+                                    if recovery_loading() { "Requesting…" } else { "Request Password Recovery" }
                                 }
-                            }
-                        } else {
-                            div { class: "auth-form",
-                                div { style: "text-align:center",
-                                    div { class: "metric-icon tone-purple", style: "margin:0 auto;width:64px;height:64px",
-                                        Icon { name: "lock" }
-                                    }
-                                    h3 { "Passkey authentication" }
-                                    p { class: "small muted", "The current BurnCloud backend exposes password/JWT authentication, OAuth URL generation and password recovery, but no passkey challenge endpoint." }
-                                }
-                                div { class: "terminal auth-status", "Backend support required before this control can be enabled." }
-                                button { r#type: "button", class: "button button-secondary", style: "width:100%", disabled: true, "Passkey challenge unavailable" }
                             }
                         }
                     }
 
-                    p { class: "tiny subtle mono", style: "text-align:center", "Session token is stored locally for authenticated console API calls." }
+                    p { class: "tiny subtle", style: "text-align:center", "BurnCloud stores the authenticated session locally so console API calls can use your JWT." }
                 }
             }
 
@@ -240,11 +211,9 @@ pub fn Login() -> Element {
 pub fn Register() -> Element {
     let navigator = use_navigator();
     let auth = use_auth();
-    let mut tier = use_signal(|| 1usize);
     let mut username = use_signal(String::new);
     let mut email = use_signal(String::new);
     let mut password = use_signal(String::new);
-    let mut company = use_signal(String::new);
     let mut terms = use_signal(|| false);
     let mut loading = use_signal(|| false);
     let mut status = use_signal(String::new);
@@ -264,62 +233,89 @@ pub fn Register() -> Element {
             }
 
             main { class: "auth-main",
-                div { class: "auth-wrap register",
+                div { class: "auth-wrap",
                     div { class: "auth-intro",
-                        Badge { text: "Create a real BurnCloud account", tone: "success" }
-                        h1 { "Open Your Gateway Console" }
-                        p { "This form now creates the account through /api/auth/register and uses the returned JWT immediately." }
+                        Badge { text: "BurnCloud Account", tone: "success" }
+                        h1 { "Create your account" }
+                        p { "Create the identity you will use to sign in to this BurnCloud environment." }
                     }
 
                     div { class: "card auth-card",
-                        div { class: "auth-form",
-                            div { class: "field",
-                                label { "Onboarding Account Preference" }
-                                p { class: "tiny subtle", "Visual preference only: the current backend does not persist billing tiers during registration." }
-                                div { class: "tier-grid",
-                                    TierButton { index: 0, current: tier(), name: "Free Sandbox", price: "$0 Free", detail: "Onboarding preference", on_select: move |index| tier.set(index) }
-                                    TierButton { index: 1, current: tier(), name: "Pay-As-You-Go", price: "Usage Based", detail: "Onboarding preference", popular: true, on_select: move |index| tier.set(index) }
-                                    TierButton { index: 2, current: tier(), name: "Enterprise", price: "Volume", detail: "Onboarding preference", on_select: move |index| tier.set(index) }
+                        form {
+                            class: "auth-form",
+                            onsubmit: move |event| {
+                                event.prevent_default();
+                                let user_name = username().trim().to_string();
+                                let account_email = email().trim().to_string();
+                                let user_password = password();
+                                if !terms() {
+                                    is_error.set(true);
+                                    status.set("Accept the Terms of Service and Privacy Policy to continue.".to_string());
+                                    return;
                                 }
+                                if user_name.is_empty() {
+                                    is_error.set(true);
+                                    status.set("Username is required.".to_string());
+                                    return;
+                                }
+                                if user_password.len() < 8 {
+                                    is_error.set(true);
+                                    status.set("Password must contain at least 8 characters.".to_string());
+                                    return;
+                                }
+                                loading.set(true);
+                                is_error.set(false);
+                                status.set("Creating your BurnCloud account…".to_string());
+                                let nav = navigator.clone();
+                                spawn(async move {
+                                    let email_arg = if account_email.is_empty() { None } else { Some(account_email.as_str()) };
+                                    match AuthService::register(&user_name, &user_password, email_arg).await {
+                                        Ok(response) => {
+                                            let user = CurrentUser {
+                                                id: response.id,
+                                                username: response.username,
+                                                roles: response.roles,
+                                            };
+                                            auth.set(response.token, user, true);
+                                            loading.set(false);
+                                            status.set(String::new());
+                                            nav.replace(Route::Overview {});
+                                        }
+                                        Err(error) => {
+                                            loading.set(false);
+                                            is_error.set(true);
+                                            status.set(format!("Account creation failed: {error}"));
+                                        }
+                                    }
+                                });
+                            },
+                            div { class: "field",
+                                label { "Username" }
+                                input {
+                                    class: "input",
+                                    r#type: "text",
+                                    autocomplete: "username",
+                                    required: true,
+                                    value: "{username}",
+                                    placeholder: "Choose a BurnCloud username",
+                                    disabled: loading(),
+                                    oninput: move |event| username.set(event.value()),
+                                }
+                                span { class: "tiny subtle", "This is the identity used on the Sign In page." }
                             }
 
-                            div { class: "auth-form-grid",
-                                div { class: "field",
-                                    label { "Username" }
-                                    input {
-                                        class: "input",
-                                        r#type: "text",
-                                        required: true,
-                                        value: "{username}",
-                                        placeholder: "burncloud-admin",
-                                        disabled: loading(),
-                                        oninput: move |evt| username.set(evt.value()),
-                                    }
-                                }
-                                div { class: "field",
-                                    label { "Company / Team" }
-                                    input {
-                                        class: "input",
-                                        r#type: "text",
-                                        value: "{company}",
-                                        placeholder: "Optional UI note",
-                                        disabled: loading(),
-                                        oninput: move |evt| company.set(evt.value()),
-                                    }
-                                    span { class: "tiny subtle", "Not persisted by the current registration API." }
-                                }
-                            }
-
                             div { class: "field",
-                                label { "Email" }
+                                label { "Email (recommended)" }
                                 input {
                                     class: "input",
                                     r#type: "email",
+                                    autocomplete: "email",
                                     value: "{email}",
                                     placeholder: "name@company.com",
                                     disabled: loading(),
-                                    oninput: move |evt| email.set(evt.value()),
+                                    oninput: move |event| email.set(event.value()),
                                 }
+                                span { class: "tiny subtle", "Add an email if you want to use the server's password-recovery flow." }
                             }
 
                             div { class: "field",
@@ -327,11 +323,12 @@ pub fn Register() -> Element {
                                 input {
                                     class: "input",
                                     r#type: "password",
+                                    autocomplete: "new-password",
                                     required: true,
                                     value: "{password}",
                                     placeholder: "At least 8 characters",
                                     disabled: loading(),
-                                    oninput: move |evt| password.set(evt.value()),
+                                    oninput: move |event| password.set(event.value()),
                                 }
                             }
 
@@ -340,7 +337,7 @@ pub fn Register() -> Element {
                                     r#type: "checkbox",
                                     checked: terms(),
                                     disabled: loading(),
-                                    onclick: move |_| terms.set(!terms()),
+                                    onchange: move |_| terms.set(!terms()),
                                 }
                                 span { "I agree to BurnCloud's Terms of Service and Privacy Policy." }
                             }
@@ -350,84 +347,20 @@ pub fn Register() -> Element {
                             }
 
                             button {
-                                r#type: "button",
+                                r#type: "submit",
                                 class: "button button-primary button-lg",
                                 style: "width:100%",
                                 disabled: loading(),
-                                onclick: move |_| {
-                                    let u = username().trim().to_string();
-                                    let e = email().trim().to_string();
-                                    let p = password();
-                                    if !terms() {
-                                        is_error.set(true);
-                                        status.set("Please accept the Terms of Service to proceed.".to_string());
-                                        return;
-                                    }
-                                    if u.is_empty() || p.is_empty() {
-                                        is_error.set(true);
-                                        status.set("Username and password are required.".to_string());
-                                        return;
-                                    }
-                                    if p.len() < 8 {
-                                        is_error.set(true);
-                                        status.set("Password must contain at least 8 characters.".to_string());
-                                        return;
-                                    }
-                                    loading.set(true);
-                                    is_error.set(false);
-                                    status.set("Creating account on BurnCloud…".to_string());
-                                    let nav = navigator.clone();
-                                    spawn(async move {
-                                        let email_arg = if e.is_empty() { None } else { Some(e.as_str()) };
-                                        match AuthService::register(&u, &p, email_arg).await {
-                                            Ok(response) => {
-                                                let user = CurrentUser { id: response.id, username: response.username, roles: response.roles };
-                                                auth.set(response.token, user, true);
-                                                loading.set(false);
-                                                status.set(String::new());
-                                                nav.replace(Route::Overview {});
-                                            }
-                                            Err(error) => {
-                                                loading.set(false);
-                                                is_error.set(true);
-                                                status.set(format!("Registration failed: {error}"));
-                                            }
-                                        }
-                                    });
-                                },
-                                if loading() { "Creating account…" } else { "Create Account & Open Console →" }
+                                if loading() { "Creating account…" } else { "Create Account" }
                             }
                         }
                     }
 
-                    p { class: "tiny subtle mono", style: "text-align:center", "Registration persists only fields supported by the current BurnCloud backend." }
+                    div { class: "product-note", "Registration now shows only fields the current BurnCloud backend can actually persist. Billing plans, company metadata, and passkeys will appear only when corresponding server capabilities exist." }
                 }
             }
 
             AuthFooter { alternate: "login" }
-        }
-    }
-}
-
-#[component]
-fn TierButton(
-    index: usize,
-    current: usize,
-    name: &'static str,
-    price: &'static str,
-    detail: &'static str,
-    #[props(default)] popular: bool,
-    on_select: EventHandler<usize>,
-) -> Element {
-    rsx! {
-        button {
-            r#type: "button",
-            class: if current == index { "tier active" } else { "tier" },
-            onclick: move |_| on_select.call(index),
-            if popular { span { class: "popular", "POPULAR" } }
-            strong { "{name}" }
-            span { class: "price", "{price}" }
-            small { "{detail}" }
         }
     }
 }

--- a/crates/client/src/critical_pages/customers_portable.rs
+++ b/crates/client/src/critical_pages/customers_portable.rs
@@ -9,6 +9,13 @@ fn format_nano(nano: i64, symbol: &str) -> String {
     format!("{symbol}{:.2}", nano as f64 / 1_000_000_000.0)
 }
 
+fn is_staff_role(role: &str) -> bool {
+    matches!(
+        role.trim().to_ascii_lowercase().as_str(),
+        "root" | "admin" | "administrator" | "operator" | "owner"
+    )
+}
+
 #[component]
 pub fn Customers() -> Element {
     let mut users = use_resource(move || async move { UserService::list().await });
@@ -27,43 +34,43 @@ pub fn Customers() -> Element {
 
     let resource = users.read().clone();
     let loading = resource.is_none();
-    let load_error = resource.as_ref().and_then(|r| r.as_ref().err().cloned());
-    let user_list = resource.and_then(Result::ok).unwrap_or_default();
-    let q = query().to_lowercase();
-    let filtered: Vec<User> = user_list
+    let load_error = resource.as_ref().and_then(|result| result.as_ref().err().cloned());
+    let all_users = resource.and_then(Result::ok).unwrap_or_default();
+    let customer_list: Vec<User> = all_users
+        .into_iter()
+        .filter(|user| !is_staff_role(&user.role))
+        .collect();
+
+    let search = query().to_lowercase();
+    let filtered: Vec<User> = customer_list
         .iter()
         .filter(|user| {
             (!active_only() || user.status == 1)
-                && (q.is_empty()
-                    || user.username.to_lowercase().contains(&q)
-                    || user.id.to_lowercase().contains(&q)
-                    || user.email.as_deref().unwrap_or("").to_lowercase().contains(&q)
-                    || user.role.to_lowercase().contains(&q))
+                && (search.is_empty()
+                    || user.username.to_lowercase().contains(&search)
+                    || user.id.to_lowercase().contains(&search)
+                    || user.email.as_deref().unwrap_or("").to_lowercase().contains(&search))
         })
         .cloned()
         .collect();
 
-    let active_count = user_list.iter().filter(|u| u.status == 1).count();
-    let cny_total: i64 = user_list.iter().map(|u| u.balance_cny).sum();
-    let usd_total: i64 = user_list.iter().map(|u| u.balance_usd).sum();
+    let active_count = customer_list.iter().filter(|user| user.status == 1).count();
+    let cny_total: i64 = customer_list.iter().map(|user| user.balance_cny).sum();
+    let usd_total: i64 = customer_list.iter().map(|user| user.balance_usd).sum();
     let cny_total_text = format_nano(cny_total, "CNY ");
     let usd_total_text = format_nano(usd_total, "$");
     let filtered_count = filtered.len();
-    let user_count = user_list.len();
+    let customer_count = customer_list.len();
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
-                    h2 { class: "page-title", "Customers / Users" }
-                    p { class: "page-subtitle", "Real BurnCloud accounts from /console/api/list_users. Account creation and balance top-up are connected to the server." }
+                    h2 { class: "page-title", "Customers" }
+                    p { class: "page-subtitle", "Manage business accounts, review wallet balances, and fund customer usage. Administrative staff are shown separately under Team." }
                 }
                 div { class: "header-actions",
-                    button {
-                        class: "button button-secondary",
-                        onclick: move |_| users.restart(),
-                        "Refresh"
-                    }
+                    button { class: "button button-secondary", onclick: move |_| users.restart(), "Refresh" }
                     button {
                         class: "button button-primary",
                         onclick: move |_| {
@@ -75,37 +82,49 @@ pub fn Customers() -> Element {
                             create_open.set(true);
                         },
                         Icon { name: "plus" }
-                        "Create User"
+                        "Create Customer"
                     }
                 }
             }
 
             div { class: "metrics",
                 div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Total Accounts" } span { class: "metric-value", "{user_count}" } }
+                    div { class: "metric-copy", span { class: "metric-label", "Customers" } span { class: "metric-value", "{customer_count}" } span { class: "metric-note", "business accounts" } }
                     div { class: "metric-icon tone-gray", Icon { name: "users" } }
                 }
                 div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Active Accounts" } span { class: "metric-value", "{active_count}" } }
+                    div { class: "metric-copy", span { class: "metric-label", "Active" } span { class: "metric-value", "{active_count}" } span { class: "metric-note", "enabled accounts" } }
                     div { class: "metric-icon tone-green", Icon { name: "activity" } }
                 }
                 div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "CNY Balance Pool" } span { class: "metric-value", "{cny_total_text}" } }
+                    div { class: "metric-copy", span { class: "metric-label", "CNY Wallets" } span { class: "metric-value", "{cny_total_text}" } span { class: "metric-note", "aggregate balance" } }
                     div { class: "metric-icon tone-amber", Icon { name: "dollar" } }
                 }
                 div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "USD Balance Pool" } span { class: "metric-value", "{usd_total_text}" } }
+                    div { class: "metric-copy", span { class: "metric-label", "USD Wallets" } span { class: "metric-value", "{usd_total_text}" } span { class: "metric-note", "aggregate balance" } }
                     div { class: "metric-icon tone-blue", Icon { name: "dollar" } }
                 }
             }
 
+            if !notice().is_empty() { div { class: "terminal auth-status", "{notice}" } }
+            if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
+
             if loading {
-                div { class: "card card-pad", "Loading accounts…" }
+                div { class: "card card-pad", "Loading customers…" }
             } else if let Some(message) = load_error {
                 div { class: "card card-pad stack",
-                    strong { class: "danger", "Unable to load users" }
+                    strong { class: "danger", "Customers could not be loaded" }
                     code { class: "terminal", "{message}" }
                     button { class: "button button-primary", onclick: move |_| users.restart(), "Retry" }
+                }
+            } else if customer_list.is_empty() {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "users" } }
+                        h3 { "Create the first customer account" }
+                        p { "Customer accounts own wallet balances and can receive API keys for routed model usage. Team members are intentionally managed separately." }
+                        button { class: "button button-primary", onclick: move |_| create_open.set(true), "Create Customer" }
+                    }
                 }
             } else {
                 div { class: "card table-card",
@@ -114,67 +133,70 @@ pub fn Customers() -> Element {
                             Icon { name: "search" }
                             input {
                                 class: "input",
-                                placeholder: "Search username, ID, email or role…",
+                                placeholder: "Search customer, email or ID…",
                                 value: "{query}",
-                                oninput: move |evt| query.set(evt.value()),
+                                oninput: move |event| query.set(event.value()),
                             }
                         }
                         label { class: "row gap-2 small muted",
-                            input {
-                                r#type: "checkbox",
-                                checked: active_only(),
-                                onclick: move |_| active_only.set(!active_only()),
-                            }
+                            input { r#type: "checkbox", checked: active_only(), onclick: move |_| active_only.set(!active_only()) }
                             "Active only"
                         }
-                        span { class: "small muted", "Showing {filtered_count} of {user_count} accounts" }
+                        span { class: "small muted", "Showing {filtered_count} of {customer_count}" }
                     }
 
                     if filtered.is_empty() {
-                        div { class: "card-pad small muted", "No accounts match the current filter." }
+                        div { class: "product-empty", style: "min-height:160px",
+                            div { class: "product-empty-inner",
+                                h3 { "No customers match this view" }
+                                p { "Change the search text or clear the Active only filter." }
+                            }
+                        }
                     } else {
                         div { class: "table-wrap",
                             table { class: "data-table",
                                 thead { tr {
-                                    th { "Username" }
-                                    th { "User ID" }
-                                    th { "Email" }
-                                    th { "Role" }
-                                    th { "Group" }
-                                    th { class: "right", "CNY Balance" }
-                                    th { class: "right", "USD Balance" }
-                                    th { class: "center", "Status" }
-                                    th { "" }
+                                    th { "Customer" }
+                                    th { "Status" }
+                                    th { "Wallet" }
+                                    th { "Preferred Currency" }
+                                    th { class: "right", "Actions" }
                                 } }
                                 tbody {
                                     for user in filtered {
                                         {
-                                            let email_text = user.email.clone().unwrap_or_else(|| "-".to_string());
+                                            let email_text = user.email.clone().unwrap_or_else(|| "No email".to_string());
                                             let status_text = if user.status == 1 { "Active" } else { "Disabled" };
-                                            let status_class = if user.status == 1 { "badge badge-success" } else { "badge badge-neutral" };
                                             let cny_text = format_nano(user.balance_cny, "CNY ");
                                             let usd_text = format_nano(user.balance_usd, "$");
+                                            let preferred = user.preferred_currency.clone().unwrap_or_else(|| "Not set".to_string());
                                             rsx! {
                                                 tr { key: "{user.id}",
-                                                    td { class: "table-primary", "{user.username}" }
-                                                    td { class: "mono muted", "{user.id}" }
-                                                    td { class: "muted", "{email_text}" }
-                                                    td { span { class: "badge badge-neutral", "{user.role}" } }
-                                                    td { "{user.group}" }
-                                                    td { class: "right tabular", "{cny_text}" }
-                                                    td { class: "right tabular", "{usd_text}" }
-                                                    td { class: "center", span { class: "{status_class}", "{status_text}" } }
                                                     td {
+                                                        div { class: "two-line",
+                                                            strong { class: "table-primary", "{user.username}" }
+                                                            small { class: "muted", "{email_text} • {user.id}" }
+                                                        }
+                                                    }
+                                                    td { span { class: if user.status == 1 { "badge badge-success" } else { "badge badge-neutral" }, "{status_text}" } }
+                                                    td {
+                                                        div { class: "two-line",
+                                                            strong { class: "tabular", "{cny_text}" }
+                                                            small { class: "tabular muted", "{usd_text}" }
+                                                        }
+                                                    }
+                                                    td { "{preferred}" }
+                                                    td { class: "right",
                                                         button {
-                                                            class: "button button-ghost button-sm",
+                                                            class: "button button-secondary button-sm",
                                                             onclick: move |_| {
                                                                 amount.set(0);
-                                                                currency.set("CNY".to_string());
+                                                                currency.set(user.preferred_currency.clone().filter(|value| value == "USD" || value == "CNY").unwrap_or_else(|| "CNY".to_string()));
                                                                 notice.set(String::new());
                                                                 error.set(String::new());
                                                                 topup_user.set(Some(user.clone()));
                                                             },
-                                                            "Top Up"
+                                                            "Add Funds"
                                                         }
                                                     }
                                                 }
@@ -185,8 +207,8 @@ pub fn Customers() -> Element {
                             }
                         }
                     }
-                    div { class: "card-pad tiny subtle",
-                        "User status is read-only because the current server does not expose an account suspend/reactivate endpoint. The previous fake suspend toggle has been removed."
+                    div { class: "card-pad product-note",
+                        "Account status is currently read-only because the BurnCloud server does not yet expose a safe suspend/reactivate endpoint. The UI does not simulate that action."
                     }
                 }
             }
@@ -195,58 +217,46 @@ pub fn Customers() -> Element {
                 div { class: "drawer-backdrop", onclick: move |_| create_open.set(false) }
                 aside { class: "drawer",
                     div { class: "drawer-head",
-                        h2 { "Create BurnCloud User" }
+                        div { h2 { "Create Customer" } p { class: "small muted", "Create a business account that can own wallet balance and API access." } }
                         button { class: "close-button", onclick: move |_| create_open.set(false), "×" }
                     }
                     div { class: "drawer-body stack-lg",
-                        div { class: "field",
-                            label { "Username" }
-                            input { class: "input", value: "{username}", disabled: busy(), oninput: move |evt| username.set(evt.value()) }
-                        }
-                        div { class: "field",
-                            label { "Email (optional)" }
-                            input { class: "input", r#type: "email", value: "{email}", disabled: busy(), oninput: move |evt| email.set(evt.value()) }
-                        }
-                        div { class: "field",
-                            label { "Password" }
-                            input { class: "input", r#type: "password", value: "{password}", disabled: busy(), placeholder: "At least 8 characters", oninput: move |evt| password.set(evt.value()) }
+                        div { class: "form-section",
+                            div { class: "form-section-head", strong { "Account identity" } small { "The username is the customer's BurnCloud login identity." } }
+                            div { class: "field", label { "Username" } input { class: "input", value: "{username}", disabled: busy(), oninput: move |event| username.set(event.value()) } }
+                            div { class: "field", label { "Email (optional)" } input { class: "input", r#type: "email", value: "{email}", disabled: busy(), oninput: move |event| email.set(event.value()) } }
+                            div { class: "field", label { "Temporary password" } input { class: "input", r#type: "password", value: "{password}", disabled: busy(), placeholder: "At least 8 characters", oninput: move |event| password.set(event.value()) } }
                         }
                         if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
-                        if !notice().is_empty() { div { class: "badge badge-success", "{notice}" } }
                         div { class: "row customer-form-actions",
                             button { class: "button button-secondary", disabled: busy(), onclick: move |_| create_open.set(false), "Cancel" }
                             button {
                                 class: "button button-primary",
                                 disabled: busy(),
                                 onclick: move |_| {
-                                    let u = username().trim().to_string();
-                                    let e = email().trim().to_string();
-                                    let p = password();
-                                    if u.is_empty() || p.len() < 8 {
-                                        error.set("Username is required and password must contain at least 8 characters.".to_string());
+                                    let username_value = username().trim().to_string();
+                                    let email_value = email().trim().to_string();
+                                    let password_value = password();
+                                    if username_value.is_empty() || password_value.len() < 8 {
+                                        error.set("Username is required and the password must contain at least 8 characters.".to_string());
                                         return;
                                     }
                                     busy.set(true);
                                     error.set(String::new());
-                                    notice.set("Creating account…".to_string());
                                     spawn(async move {
-                                        let email_arg = if e.is_empty() { None } else { Some(e.as_str()) };
-                                        match UserService::create(&u, &p, email_arg).await {
+                                        let email_arg = if email_value.is_empty() { None } else { Some(email_value.as_str()) };
+                                        match UserService::create(&username_value, &password_value, email_arg).await {
                                             Ok(_) => {
-                                                busy.set(false);
+                                                notice.set(format!("Customer {username_value} created."));
                                                 create_open.set(false);
-                                                notice.set(String::new());
                                                 users.restart();
                                             }
-                                            Err(message) => {
-                                                busy.set(false);
-                                                notice.set(String::new());
-                                                error.set(format!("Create user failed: {message}"));
-                                            }
+                                            Err(message) => error.set(format!("Create customer failed: {message}")),
                                         }
+                                        busy.set(false);
                                     });
                                 },
-                                if busy() { "Creating…" } else { "Create User" }
+                                if busy() { "Creating…" } else { "Create Customer" }
                             }
                         }
                     }
@@ -254,78 +264,72 @@ pub fn Customers() -> Element {
             }
 
             if let Some(user) = topup_user() {
-                div { class: "drawer-backdrop", onclick: move |_| topup_user.set(None) }
-                aside { class: "drawer",
-                    div { class: "drawer-head",
-                        h2 { "Top Up Balance" }
-                        button { class: "close-button", onclick: move |_| topup_user.set(None), "×" }
-                    }
-                    div { class: "drawer-body stack-lg",
-                        div { class: "card card-pad stack",
-                            span { class: "section-label", "Target account" }
-                            strong { "{user.username}" }
-                            code { class: "tiny muted", "{user.id}" }
-                        }
-                        div { class: "grid-2",
-                            div { class: "field",
-                                label { "Currency" }
-                                select { class: "select", value: "{currency}", disabled: busy(), onchange: move |evt| currency.set(evt.value()),
-                                    option { value: "CNY", "CNY" }
-                                    option { value: "USD", "USD" }
-                                }
+                {
+                    let current_cny = format_nano(user.balance_cny, "CNY ");
+                    let current_usd = format_nano(user.balance_usd, "$");
+                    rsx! {
+                        div { class: "drawer-backdrop", onclick: move |_| topup_user.set(None) }
+                        aside { class: "drawer",
+                            div { class: "drawer-head",
+                                div { h2 { "Add Funds" } p { class: "small muted", "Credit the customer's BurnCloud wallet." } }
+                                button { class: "close-button", onclick: move |_| topup_user.set(None), "×" }
                             }
-                            div { class: "field",
-                                label { "Amount" }
-                                input {
-                                    class: "input",
-                                    r#type: "number",
-                                    min: "1",
-                                    value: "{amount}",
-                                    disabled: busy(),
-                                    oninput: move |evt| amount.set(evt.value().parse::<i64>().unwrap_or(0)),
-                                }
-                            }
-                        }
-                        div { class: "row gap-2",
-                            button { class: "button button-secondary button-sm", onclick: move |_| amount.set(100), "100" }
-                            button { class: "button button-secondary button-sm", onclick: move |_| amount.set(500), "500" }
-                            button { class: "button button-secondary button-sm", onclick: move |_| amount.set(1000), "1000" }
-                        }
-                        if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
-                        if !notice().is_empty() { div { class: "terminal auth-status", "{notice}" } }
-                        div { class: "row customer-form-actions",
-                            button { class: "button button-secondary", disabled: busy(), onclick: move |_| topup_user.set(None), "Cancel" }
-                            button {
-                                class: "button button-primary",
-                                disabled: busy(),
-                                onclick: move |_| {
-                                    let value = amount();
-                                    let selected_currency = currency();
-                                    let uid = user.id.clone();
-                                    if value <= 0 {
-                                        error.set("Top-up amount must be greater than zero.".to_string());
-                                        return;
-                                    }
-                                    busy.set(true);
-                                    error.set(String::new());
-                                    notice.set("Submitting balance top-up…".to_string());
-                                    let amount_nano = value.saturating_mul(1_000_000_000);
-                                    spawn(async move {
-                                        match UserService::topup(&uid, amount_nano, &selected_currency).await {
-                                            Ok(new_balance) => {
-                                                busy.set(false);
-                                                notice.set(format!("Top-up confirmed. New raw balance: {new_balance}"));
-                                                users.restart();
-                                            }
-                                            Err(message) => {
-                                                busy.set(false);
-                                                notice.set(String::new());
-                                                error.set(format!("Top-up failed: {message}"));
+                            div { class: "drawer-body stack-lg",
+                                div { class: "form-section",
+                                    div { class: "form-section-head", strong { "{user.username}" } small { "Current balances: {current_cny} • {current_usd}" } }
+                                    div { class: "grid-2",
+                                        div { class: "field",
+                                            label { "Currency" }
+                                            select { class: "select", value: "{currency}", disabled: busy(), onchange: move |event| currency.set(event.value()),
+                                                option { value: "CNY", "CNY" }
+                                                option { value: "USD", "USD" }
                                             }
                                         }
-                                    });
-                                },
-                                if busy() { "Submitting…" } else { "Confirm Top Up" }
+                                        div { class: "field",
+                                            label { "Amount" }
+                                            input { class: "input", r#type: "number", min: "1", value: "{amount}", disabled: busy(), oninput: move |event| amount.set(event.value().parse::<i64>().unwrap_or(0)) }
+                                        }
+                                    }
+                                    div { class: "row gap-2",
+                                        button { class: "button button-secondary button-sm", onclick: move |_| amount.set(100), "100" }
+                                        button { class: "button button-secondary button-sm", onclick: move |_| amount.set(500), "500" }
+                                        button { class: "button button-secondary button-sm", onclick: move |_| amount.set(1000), "1,000" }
+                                    }
+                                }
+                                if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
+                                if !notice().is_empty() { div { class: "terminal auth-status", "{notice}" } }
+                                div { class: "row customer-form-actions",
+                                    button { class: "button button-secondary", disabled: busy(), onclick: move |_| topup_user.set(None), "Cancel" }
+                                    button {
+                                        class: "button button-primary",
+                                        disabled: busy(),
+                                        onclick: move |_| {
+                                            let value = amount();
+                                            let selected_currency = currency();
+                                            let user_id = user.id.clone();
+                                            let user_name = user.username.clone();
+                                            if value <= 0 {
+                                                error.set("Funding amount must be greater than zero.".to_string());
+                                                return;
+                                            }
+                                            busy.set(true);
+                                            error.set(String::new());
+                                            spawn(async move {
+                                                let amount_nano = value.saturating_mul(1_000_000_000);
+                                                match UserService::topup(&user_id, amount_nano, &selected_currency).await {
+                                                    Ok(_) => {
+                                                        notice.set(format!("Added {value} {selected_currency} to {user_name}."));
+                                                        topup_user.set(None);
+                                                        users.restart();
+                                                    }
+                                                    Err(message) => error.set(format!("Add funds failed: {message}")),
+                                                }
+                                                busy.set(false);
+                                            });
+                                        },
+                                        if busy() { "Adding…" } else { "Confirm Funding" }
+                                    }
+                                }
                             }
                         }
                     }

--- a/crates/client/src/critical_pages/dashboard.rs
+++ b/crates/client/src/critical_pages/dashboard.rs
@@ -164,6 +164,8 @@ pub fn Overview() -> Element {
     .into_iter()
     .flatten()
     .collect();
+    let has_errors = !errors.is_empty();
+    let errors_for_panel = errors.clone();
 
     let total_requests = billing.models.iter().map(|m| m.requests).sum::<i64>() + billing.pre_migration_requests;
     let active_channels = channels.iter().filter(|channel| channel.status == 1).count();
@@ -176,7 +178,7 @@ pub fn Overview() -> Element {
     let has_request = !logs.is_empty();
     let setup_complete = has_provider && has_model && has_key;
 
-    let (status_class, status_title, status_copy) = if !errors.is_empty() {
+    let (status_class, status_title, status_copy) = if has_errors {
         (
             "product-status-card status-blocked",
             "Some system data is unavailable",
@@ -243,8 +245,8 @@ pub fn Overview() -> Element {
             div { class: "product-hero",
                 div { class: "card {status_class}",
                     div { class: "row gap-2",
-                        span { class: if setup_complete && errors.is_empty() && down_channels == 0 { "badge badge-success" } else { "badge badge-warning" },
-                            if setup_complete && errors.is_empty() && down_channels == 0 { "READY" } else { "ATTENTION" }
+                        span { class: if setup_complete && !has_errors && down_channels == 0 { "badge badge-success" } else { "badge badge-warning" },
+                            if setup_complete && !has_errors && down_channels == 0 { "READY" } else { "ATTENTION" }
                         }
                     }
                     div {
@@ -282,12 +284,12 @@ pub fn Overview() -> Element {
                 }
             }
 
-            if !errors.is_empty() {
+            if has_errors {
                 div { class: "card card-pad stack",
                     div { class: "product-section-head",
                         div { h3 { class: "danger", "Needs attention" } p { "These sources failed to load on the latest refresh." } }
                     }
-                    for message in errors { code { class: "terminal", "{message}" } }
+                    for message in errors_for_panel { code { class: "terminal", "{message}" } }
                 }
             }
 
@@ -320,7 +322,10 @@ pub fn Overview() -> Element {
                         div { class: "stack",
                             for channel in channels.iter().take(6) {
                                 {
-                                    let model_summary = if channel.models.len() > 52 { format!("{}…", &channel.models[..52]) } else { channel.models.clone() };
+                                    let mut model_summary = channel.models.chars().take(52).collect::<String>();
+                                    if channel.models.chars().count() > 52 {
+                                        model_summary.push('…');
+                                    }
                                     rsx! {
                                         div { class: "source-line",
                                             div { class: "source-meta",

--- a/crates/client/src/critical_pages/dashboard.rs
+++ b/crates/client/src/critical_pages/dashboard.rs
@@ -1,9 +1,10 @@
 use dioxus::prelude::*;
 
 use crate::{
+    app::Route,
     backend::{
-        billing_summary, system_metrics, user_usage, use_auth, BillingSummary, Channel, ChannelService,
-        LogService, RouterLog, SystemMetrics, UsageStats,
+        billing_summary, system_metrics, user_usage, BillingSummary, Channel, ChannelService,
+        LogService, RouterLog, SystemMetrics, TokenDto, TokenService, UsageStats,
     },
     components::{Drawer, Icon},
 };
@@ -37,7 +38,14 @@ fn kpi(label: &str, value: String, note: String, icon: &'static str, tone: &'sta
 fn channel_model_count(channels: &[Channel]) -> usize {
     let mut models: Vec<String> = channels
         .iter()
-        .flat_map(|channel| channel.models.split(',').map(str::trim).filter(|m| !m.is_empty()).map(str::to_string))
+        .flat_map(|channel| {
+            channel
+                .models
+                .split(',')
+                .map(str::trim)
+                .filter(|model| !model.is_empty())
+                .map(str::to_string)
+        })
         .collect();
     models.sort();
     models.dedup();
@@ -71,12 +79,35 @@ fn route_receipt(log: &RouterLog) -> String {
 }
 
 #[component]
+fn SetupStep(
+    complete: bool,
+    title: &'static str,
+    detail: String,
+    to: Route,
+    action: &'static str,
+) -> Element {
+    rsx! {
+        div { class: if complete { "setup-step complete" } else { "setup-step" },
+            div { class: "setup-step-dot", if complete { "✓" } else { "·" } }
+            div {
+                strong { "{title}" }
+                small { "{detail}" }
+            }
+            if complete {
+                span { class: "badge badge-success", "Done" }
+            } else {
+                Link { class: "button button-ghost button-sm", to: to, "{action}" }
+            }
+        }
+    }
+}
+
+#[component]
 pub fn Overview() -> Element {
-    let auth = use_auth();
+    let auth = crate::backend::use_auth();
     let current_user = auth.user();
     let token = auth.token().unwrap_or_default();
     let user_id = current_user.as_ref().map(|u| u.id.clone()).unwrap_or_default();
-    let username = current_user.as_ref().map(|u| u.username.clone()).unwrap_or_else(|| "User".to_string());
 
     let token_for_usage = token.clone();
     let user_for_usage = user_id.clone();
@@ -85,6 +116,7 @@ pub fn Overview() -> Element {
     let mut metrics_resource = use_resource(move || async move { system_metrics().await });
     let mut channels_resource = use_resource(move || async move { ChannelService::list(100).await });
     let mut logs_resource = use_resource(move || async move { LogService::list(50).await });
+    let mut tokens_resource = use_resource(move || async move { TokenService::list().await });
     let mut usage_resource = use_resource(move || {
         let token = token_for_usage.clone();
         let uid = user_for_usage.clone();
@@ -110,19 +142,22 @@ pub fn Overview() -> Element {
     let metrics_result = metrics_resource.read().clone();
     let channels_result = channels_resource.read().clone();
     let logs_result = logs_resource.read().clone();
+    let tokens_result = tokens_resource.read().clone();
     let usage_result = usage_resource.read().clone();
     let billing_result = billing_resource.read().clone();
 
     let metrics: SystemMetrics = metrics_result.clone().and_then(Result::ok).unwrap_or_default();
     let channels: Vec<Channel> = channels_result.clone().and_then(Result::ok).unwrap_or_default();
     let logs: Vec<RouterLog> = logs_result.clone().and_then(Result::ok).unwrap_or_default();
+    let api_tokens: Vec<TokenDto> = tokens_result.clone().and_then(Result::ok).unwrap_or_default();
     let usage: UsageStats = usage_result.clone().and_then(Result::ok).unwrap_or_default();
     let billing: BillingSummary = billing_result.clone().and_then(Result::ok).unwrap_or_default();
 
     let errors: Vec<String> = [
-        metrics_result.as_ref().and_then(|v| v.as_ref().err()).map(|e| format!("Monitor: {e}")),
-        channels_result.as_ref().and_then(|v| v.as_ref().err()).map(|e| format!("Channels: {e}")),
+        metrics_result.as_ref().and_then(|v| v.as_ref().err()).map(|e| format!("Runtime: {e}")),
+        channels_result.as_ref().and_then(|v| v.as_ref().err()).map(|e| format!("Providers: {e}")),
         logs_result.as_ref().and_then(|v| v.as_ref().err()).map(|e| format!("Logs: {e}")),
+        tokens_result.as_ref().and_then(|v| v.as_ref().err()).map(|e| format!("API keys: {e}")),
         usage_result.as_ref().and_then(|v| v.as_ref().err()).map(|e| format!("Usage: {e}")),
         billing_result.as_ref().and_then(|v| v.as_ref().err()).map(|e| format!("Billing: {e}")),
     ]
@@ -132,80 +167,160 @@ pub fn Overview() -> Element {
 
     let total_requests = billing.models.iter().map(|m| m.requests).sum::<i64>() + billing.pre_migration_requests;
     let active_channels = channels.iter().filter(|channel| channel.status == 1).count();
-    let down_channels = channels.iter().filter(|channel| channel.status == 0).count();
+    let down_channels = channels.iter().filter(|channel| channel.status != 1).count();
     let model_count = channel_model_count(&channels);
+    let active_keys = api_tokens.iter().filter(|key| key.status == "active").count();
+    let has_provider = active_channels > 0;
+    let has_model = model_count > 0;
+    let has_key = active_keys > 0;
+    let has_request = !logs.is_empty();
+    let setup_complete = has_provider && has_model && has_key;
+
+    let (status_class, status_title, status_copy) = if !errors.is_empty() {
+        (
+            "product-status-card status-blocked",
+            "Some system data is unavailable",
+            "BurnCloud is reachable, but one or more operational data sources could not be loaded. Review the errors below before relying on this environment.",
+        )
+    } else if !setup_complete {
+        (
+            "product-status-card status-attention",
+            "Finish setup before sending production traffic",
+            "BurnCloud still needs one or more routing prerequisites. Complete the checklist to make a verified end-to-end request.",
+        )
+    } else if down_channels > 0 {
+        (
+            "product-status-card status-attention",
+            "Traffic is available, but a provider needs attention",
+            "At least one provider is inactive or down. Healthy providers can still serve traffic, but routing resilience may be reduced.",
+        )
+    } else {
+        (
+            "product-status-card status-ready",
+            "BurnCloud is ready to serve traffic",
+            "Providers, models and API access are configured. Use Playground for a controlled test or inspect recent request activity below.",
+        )
+    };
+
     let latest = logs.first().cloned();
-    let has_latest = latest.is_some();
     let latest_for_card = latest.clone();
     let latest_for_drawer = latest.clone();
+    let has_latest = latest.is_some();
     let request_text = compact(total_requests);
-    let billing_note = format!("${:.4} total billed", billing.total_cost_usd);
     let token_text = compact(usage.total_tokens);
-    let usage_note = format!("{} prompt / {} completion", compact(usage.prompt_tokens), compact(usage.completion_tokens));
-    let channel_note = format!("{} total • {} down", channels.len(), down_channels);
-    let system_text = format!("{:.0}% / {:.0}%", metrics.cpu.usage_percent, metrics.memory.usage_percent);
-    let system_note = format!("{} cores • {} models exposed", metrics.cpu.core_count, model_count);
+    let spend_text = format!("${:.4}", billing.total_cost_usd);
+    let provider_note = format!("{} total • {} need attention", channels.len(), down_channels);
+    let request_note = if has_request { "Billing period activity".to_string() } else { "No requests observed yet".to_string() };
+    let usage_note = format!("{} prompt • {} completion", compact(usage.prompt_tokens), compact(usage.completion_tokens));
+    let spend_note = format!("{} billed models", billing.models.len());
+    let runtime_cpu = format!("{:.0}%", metrics.cpu.usage_percent);
+    let runtime_memory = format!("{:.0}%", metrics.memory.usage_percent);
+    let runtime_detail = format!("{} CPU cores • {} mounted disks", metrics.cpu.core_count, metrics.disks.len());
     let mut receipt_open = use_signal(|| false);
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
-                    h2 { class: "page-title", "Good morning, {username}." }
-                    p { class: "page-subtitle", "Live data from the running BurnCloud server. Dashboard values are no longer seeded UI demo values." }
+                    h2 { class: "page-title", "System Overview" }
+                    p { class: "page-subtitle", "Know whether BurnCloud can serve traffic, what needs attention, and where to act next." }
                 }
-                div { class: "header-actions",
-                    button {
-                        class: "button button-secondary",
-                        onclick: move |_| {
-                            metrics_resource.restart();
-                            channels_resource.restart();
-                            logs_resource.restart();
-                            usage_resource.restart();
-                            billing_resource.restart();
-                        },
-                        Icon { name: "activity" }
-                        "Refresh All"
+                button {
+                    class: "button button-secondary",
+                    onclick: move |_| {
+                        metrics_resource.restart();
+                        channels_resource.restart();
+                        logs_resource.restart();
+                        tokens_resource.restart();
+                        usage_resource.restart();
+                        billing_resource.restart();
+                    },
+                    Icon { name: "activity" }
+                    "Refresh"
+                }
+            }
+
+            div { class: "product-hero",
+                div { class: "card {status_class}",
+                    div { class: "row gap-2",
+                        span { class: if setup_complete && errors.is_empty() && down_channels == 0 { "badge badge-success" } else { "badge badge-warning" },
+                            if setup_complete && errors.is_empty() && down_channels == 0 { "READY" } else { "ATTENTION" }
+                        }
                     }
-                    button {
-                        class: "button button-primary",
-                        disabled: !has_latest,
-                        onclick: move |_| receipt_open.set(true),
-                        Icon { name: "logs" }
-                        "Latest Request Receipt"
+                    div {
+                        div { class: "product-status-title", "{status_title}" }
+                        p { class: "product-status-copy", "{status_copy}" }
+                    }
+                    div { class: "product-actions",
+                        if !has_provider {
+                            Link { class: "button button-primary", to: Route::Providers {}, Icon { name: "plus" } "Add first provider" }
+                        } else if !has_key {
+                            Link { class: "button button-primary", to: Route::APIKeys {}, Icon { name: "key" } "Create API key" }
+                        } else {
+                            Link { class: "button button-primary", to: Route::Playground {}, Icon { name: "play" } "Test a request" }
+                        }
+                        Link { class: "button button-secondary", to: Route::Logs {}, "View request logs" }
+                    }
+                }
+
+                div { class: "card setup-card",
+                    div { class: "product-section-head",
+                        div {
+                            h3 { "Setup & readiness" }
+                            p { "The minimum path to a working routed request." }
+                        }
+                        span { class: if setup_complete { "badge badge-success" } else { "badge badge-neutral" },
+                            if setup_complete { "Ready" } else { "In progress" }
+                        }
+                    }
+                    div { class: "setup-list",
+                        SetupStep { complete: has_provider, title: "Provider connected", detail: format!("{} active providers", active_channels), to: Route::Providers {}, action: "Configure" }
+                        SetupStep { complete: has_model, title: "Model available", detail: format!("{} unique models exposed", model_count), to: Route::Models {}, action: "Review" }
+                        SetupStep { complete: has_key, title: "API access created", detail: format!("{} active API keys", active_keys), to: Route::APIKeys {}, action: "Create" }
+                        SetupStep { complete: has_request, title: "First request observed", detail: if has_request { "Traffic is visible in Logs".to_string() } else { "Send a request from Playground".to_string() }, to: Route::Playground {}, action: "Test" }
                     }
                 }
             }
 
             if !errors.is_empty() {
                 div { class: "card card-pad stack",
-                    strong { class: "danger", "Some live dashboard sources could not be loaded" }
+                    div { class: "product-section-head",
+                        div { h3 { class: "danger", "Needs attention" } p { "These sources failed to load on the latest refresh." } }
+                    }
                     for message in errors { code { class: "terminal", "{message}" } }
                 }
             }
 
             div { class: "metrics",
-                {kpi("Requests", request_text, billing_note, "activity", "tone-blue")}
-                {kpi("User Tokens", token_text, usage_note, "models", "tone-purple")}
-                {kpi("Active Channels", active_channels.to_string(), channel_note, "server", "tone-green")}
-                {kpi("CPU / Memory", system_text, system_note, "activity", "tone-amber")}
+                {kpi("Requests", request_text, request_note, "activity", "tone-blue")}
+                {kpi("Tokens", token_text, usage_note, "models", "tone-purple")}
+                {kpi("Spend", spend_text, spend_note, "dollar", "tone-amber")}
+                {kpi("Active Providers", active_channels.to_string(), provider_note, "server", "tone-green")}
             }
 
             div { class: "grid-2",
                 div { class: "card card-pad stack",
-                    div { class: "row between",
-                        span { class: "section-label", "Live Provider / Channel Pool" }
-                        span { class: if down_channels == 0 { "badge badge-success" } else { "badge badge-warning" },
-                            if down_channels == 0 { "ALL HEALTHY" } else { "DEGRADED" }
+                    div { class: "product-section-head",
+                        div {
+                            h3 { "Provider health" }
+                            p { "The upstream supply currently available to the router." }
                         }
+                        Link { class: "button button-ghost button-sm", to: Route::Providers {}, "Manage providers" }
                     }
                     if channels.is_empty() {
-                        p { class: "small muted", "No channels were returned. Admin role may be required for the channel API." }
+                        div { class: "product-empty", style: "min-height:150px",
+                            div { class: "product-empty-inner",
+                                div { class: "product-empty-icon", Icon { name: "providers" } }
+                                h3 { "No providers configured" }
+                                p { "Add an upstream provider before BurnCloud can expose models or route requests." }
+                                Link { class: "button button-primary button-sm", to: Route::Providers {}, "Add provider" }
+                            }
+                        }
                     } else {
                         div { class: "stack",
-                            for channel in channels.iter().take(8) {
+                            for channel in channels.iter().take(6) {
                                 {
-                                    let detail = format!("type={} • weight={} • models={}", channel.type_, channel.weight, channel.models);
+                                    let model_summary = if channel.models.len() > 52 { format!("{}…", &channel.models[..52]) } else { channel.models.clone() };
                                     rsx! {
                                         div { class: "source-line",
                                             div { class: "source-meta",
@@ -214,7 +329,7 @@ pub fn Overview() -> Element {
                                                     if channel.status == 1 { "ACTIVE" } else { "DOWN" }
                                                 }
                                             }
-                                            div { class: "tiny subtle mono", "{detail}" }
+                                            div { class: "tiny subtle mono", "{model_summary}" }
                                         }
                                     }
                                 }
@@ -224,9 +339,12 @@ pub fn Overview() -> Element {
                 }
 
                 div { class: "card card-pad stack",
-                    div { class: "row between",
-                        span { class: "section-label", "Latest Real Router Receipt" }
-                        span { class: "badge badge-neutral", "router_logs" }
+                    div { class: "product-section-head",
+                        div {
+                            h3 { "Latest request" }
+                            p { "A fast confidence check that traffic reached the router." }
+                        }
+                        Link { class: "button button-ghost button-sm", to: Route::Logs {}, "Open logs" }
                     }
                     if let Some(log) = latest_for_card {
                         {
@@ -235,52 +353,56 @@ pub fn Overview() -> Element {
                             let status_text = format!("HTTP {} • {}", log.status_code, log.status_label());
                             rsx! {
                                 div { class: "receipt",
-                                    div { class: "receipt-row", label { "Request:" } strong { class: "mono", "{log.request_id}" } }
-                                    div { class: "receipt-row", label { "Model:" } strong { "{model_text}" } }
-                                    div { class: "receipt-row", label { "Upstream:" } strong { "{upstream_text}" } }
-                                    div { class: "receipt-row", label { "Status:" } strong { "{status_text}" } }
+                                    div { class: "receipt-row", label { "Request" } strong { class: "mono", "{log.request_id}" } }
+                                    div { class: "receipt-row", label { "Model" } strong { "{model_text}" } }
+                                    div { class: "receipt-row", label { "Upstream" } strong { "{upstream_text}" } }
+                                    div { class: "receipt-row", label { "Result" } strong { "{status_text}" } }
                                 }
-                                button { class: "button button-primary", style: "width:100%", onclick: move |_| receipt_open.set(true), "Inspect Stored Route Metadata" }
+                                button { class: "button button-secondary", style: "width:100%", onclick: move |_| receipt_open.set(true), "Inspect routing metadata" }
                             }
                         }
                     } else {
-                        p { class: "small muted", "No router log receipt is currently available." }
+                        div { class: "product-empty", style: "min-height:150px",
+                            div { class: "product-empty-inner",
+                                div { class: "product-empty-icon", Icon { name: "logs" } }
+                                h3 { "No request activity yet" }
+                                p { "Use Playground to make the first routed request, then return here to verify the result." }
+                                Link { class: "button button-primary button-sm", to: Route::Playground {}, "Open Playground" }
+                            }
+                        }
                     }
                 }
             }
 
-            div { class: "card table-card",
-                div { class: "card-pad row between",
-                    span { class: "section-label", "Billing Model Breakdown" }
-                    span { class: "small muted", "{billing.models.len()} billed models" }
+            div { class: "grid-2",
+                div { class: "card card-pad stack",
+                    div { class: "product-section-head",
+                        div { h3 { "Runtime" } p { "Host resource pressure is secondary to traffic health, but useful for capacity diagnosis." } }
+                        Link { class: "button button-ghost button-sm", to: Route::Settings {}, "System details" }
+                    }
+                    div { class: "grid-2",
+                        div { class: "receipt-row", label { "CPU" } strong { class: "mono", "{runtime_cpu}" } }
+                        div { class: "receipt-row", label { "Memory" } strong { class: "mono", "{runtime_memory}" } }
+                    }
+                    span { class: "tiny subtle mono", "{runtime_detail}" }
                 }
-                if billing.models.is_empty() {
-                    div { class: "card-pad small muted", "No billing model usage returned for the current account/period." }
-                } else {
-                    div { class: "table-wrap",
-                        table { class: "data-table",
-                            thead { tr {
-                                th { "Model" }
-                                th { class: "right", "Requests" }
-                                th { class: "right", "Prompt" }
-                                th { class: "right", "Completion" }
-                                th { class: "right", "Cost" }
-                            } }
-                            tbody {
-                                for model in billing.models.iter().take(12) {
-                                    {
-                                        let request_count = compact(model.requests);
-                                        let prompt_count = compact(model.prompt_tokens);
-                                        let completion_count = compact(model.completion_tokens);
-                                        let cost_text = format!("${:.6}", model.cost_usd);
-                                        rsx! {
-                                            tr { key: "{model.model}",
-                                                td { class: "table-primary", "{model.model}" }
-                                                td { class: "right tabular", "{request_count}" }
-                                                td { class: "right tabular", "{prompt_count}" }
-                                                td { class: "right tabular", "{completion_count}" }
-                                                td { class: "right strong tabular", "{cost_text}" }
-                                            }
+
+                div { class: "card card-pad stack",
+                    div { class: "product-section-head",
+                        div { h3 { "Spend by model" } p { "Top billed models for the current billing period." } }
+                        Link { class: "button button-ghost button-sm", to: Route::Billing {}, "Open billing" }
+                    }
+                    if billing.models.is_empty() {
+                        p { class: "small muted", "No billed usage is available yet." }
+                    } else {
+                        div { class: "stack",
+                            for model in billing.models.iter().take(5) {
+                                {
+                                    let cost = format!("${:.6}", model.cost_usd);
+                                    rsx! {
+                                        div { class: "row between",
+                                            span { class: "mono small", "{model.model}" }
+                                            strong { class: "mono small", "{cost}" }
                                         }
                                     }
                                 }
@@ -292,16 +414,15 @@ pub fn Overview() -> Element {
 
             Drawer {
                 title: "Stored Request Route Receipt",
-                open: receipt_open(),
+                open: receipt_open() && has_latest,
                 on_close: move |_| receipt_open.set(false),
                 if let Some(log) = latest_for_drawer {
                     {
                         let receipt = route_receipt(&log);
                         rsx! {
                             div { class: "stack-lg",
-                                div { class: "card card-pad stack",
-                                    span { class: "section-label", "What this proves" }
-                                    p { class: "small muted", "These are the actual observability fields persisted by BurnCloud for the request. This UI does not claim TPM or cryptographic verification because the current router_logs schema does not store a hardware signature." }
+                                div { class: "product-note",
+                                    "This is the routing metadata BurnCloud actually persisted for the request. It is useful for operational traceability; it is not presented as a cryptographic attestation."
                                 }
                                 pre { class: "terminal", style: "white-space:pre-wrap;line-height:1.65", "{receipt}" }
                             }

--- a/crates/client/src/functional_layout.rs
+++ b/crates/client/src/functional_layout.rs
@@ -34,19 +34,19 @@ fn search_route(query: &str) -> Option<Route> {
     }
 
     let pages = [
-        ("overview dashboard home console", Route::Overview {}),
-        ("playground chat completion inference", Route::Playground {}),
-        ("routes routing groups priority weight", Route::Routes {}),
-        ("models model", Route::Models {}),
-        ("providers provider channels channel upstream", Route::Providers {}),
-        ("api keys key tokens token", Route::APIKeys {}),
-        ("customers users user accounts account", Route::Customers {}),
+        ("overview dashboard health status home console", Route::Overview {}),
+        ("providers provider channels channel upstream supply", Route::Providers {}),
+        ("models model catalog", Route::Models {}),
+        ("routes routing groups priority weight traffic", Route::Routes {}),
+        ("playground chat completion inference test", Route::Playground {}),
+        ("logs requests router log observability errors", Route::Logs {}),
+        ("evaluation metrics latency success performance", Route::Evaluation {}),
+        ("billing cost usage spend finance", Route::Billing {}),
+        ("api keys key tokens token access", Route::APIKeys {}),
+        ("customers users user accounts account balance", Route::Customers {}),
         ("guardrails security filters risk circuit breaker", Route::Guardrails {}),
-        ("logs requests router log observability", Route::Logs {}),
-        ("evaluation metrics latency success", Route::Evaluation {}),
-        ("billing cost usage spend", Route::Billing {}),
-        ("team members roles", Route::Team {}),
-        ("settings cache runtime server", Route::Settings {}),
+        ("team members roles operators admins", Route::Team {}),
+        ("settings cache runtime server system", Route::Settings {}),
     ];
 
     pages
@@ -93,29 +93,31 @@ pub fn FunctionalConsoleLayout() -> Element {
                     Link { to:Route::Overview {}, class:"brand-link", Logo {} span { class:"brand-name", "BurnCloud" } }
                 }
                 nav { class:"sidebar-nav",
-                    NavGroup { title:"Core Platform",
+                    NavGroup { title:"Workspace",
                         NavItem { to:Route::Overview {}, icon:"overview", label:"Overview" }
-                        NavItem { to:Route::Playground {}, icon:"terminal", label:"Playground" }
-                        NavItem { to:Route::Routes {}, icon:"routes", label:"Routes" }
-                        NavItem { to:Route::Models {}, icon:"models", label:"Models" }
+                    }
+                    NavGroup { title:"Traffic Setup",
                         NavItem { to:Route::Providers {}, icon:"providers", label:"Providers" }
+                        NavItem { to:Route::Models {}, icon:"models", label:"Models" }
+                        NavItem { to:Route::Routes {}, icon:"routes", label:"Routes" }
+                        NavItem { to:Route::Playground {}, icon:"terminal", label:"Playground" }
                     }
-                    NavGroup { title:"Access & Control",
-                        NavItem { to:Route::APIKeys {}, icon:"key", label:"API Keys" }
-                        NavItem { to:Route::Customers {}, icon:"users", label:"Customers" }
-                        NavItem { to:Route::Guardrails {}, icon:"shield", label:"Guardrails" }
-                    }
-                    NavGroup { title:"Ops & Finance",
+                    NavGroup { title:"Observe",
                         NavItem { to:Route::Logs {}, icon:"logs", label:"Logs" }
                         NavItem { to:Route::Evaluation {}, icon:"chart", label:"Evaluation" }
                         NavItem { to:Route::Billing {}, icon:"billing", label:"Billing" }
                     }
-                    NavGroup { title:"System",
+                    NavGroup { title:"Access & Customers",
+                        NavItem { to:Route::APIKeys {}, icon:"key", label:"API Keys" }
+                        NavItem { to:Route::Customers {}, icon:"users", label:"Customers" }
+                    }
+                    NavGroup { title:"Security & System",
+                        NavItem { to:Route::Guardrails {}, icon:"shield", label:"Guardrails" }
                         NavItem { to:Route::Team {}, icon:"users", label:"Team" }
                         NavItem { to:Route::Settings {}, icon:"settings", label:"Settings" }
                     }
                     div { class:"public-links",
-                        h4 { class:"nav-group-title", "Public Portal" }
+                        h4 { class:"nav-group-title", "External" }
                         div { class:"nav-items",
                             NavItem { to:Route::Home {}, icon:"globe", label:"Landing Page" }
                             button {
@@ -140,7 +142,7 @@ pub fn FunctionalConsoleLayout() -> Element {
                             Icon { name:"search" }
                             input {
                                 r#type:"text",
-                                placeholder:"Jump to page…",
+                                placeholder:"Jump to a page…",
                                 value:"{search}",
                                 oninput:move |evt| {
                                     search.set(evt.value());
@@ -161,10 +163,10 @@ pub fn FunctionalConsoleLayout() -> Element {
                             }
                         }
                         div { class:"top-actions",
-                            Link { to:Route::Home {}, class:"tiny-link", Icon { name:"globe" } span { "Visit Landing Page" } }
-                            div { class:"env-chip", title:"Current console environment", span { class:"green-dot" } "Production" }
-                            Link { to:Route::Logs {}, class:"icon-button", title:"Open logs", Icon { name:"bell" } }
-                            Link { to:Route::Settings {}, class:"icon-button", title:"Open settings", Icon { name:"help" } }
+                            Link { to:Route::Home {}, class:"tiny-link", Icon { name:"globe" } span { "Landing Page" } }
+                            div { class:"env-chip", title:"Connected to the configured BurnCloud server", span { class:"green-dot" } "Server Connected" }
+                            Link { to:Route::Logs {}, class:"icon-button", title:"Open request logs", Icon { name:"bell" } }
+                            Link { to:Route::Settings {}, class:"icon-button", title:"System settings", Icon { name:"help" } }
                             div { class:"top-divider" }
                             div { class:"profile-link",
                                 div { class:"avatar", "{avatar}" }

--- a/crates/client/src/functional_layout.rs
+++ b/crates/client/src/functional_layout.rs
@@ -164,7 +164,7 @@ pub fn FunctionalConsoleLayout() -> Element {
                         }
                         div { class:"top-actions",
                             Link { to:Route::Home {}, class:"tiny-link", Icon { name:"globe" } span { "Landing Page" } }
-                            div { class:"env-chip", title:"Connected to the configured BurnCloud server", span { class:"green-dot" } "Server Connected" }
+                            div { class:"env-chip", title:"BurnCloud server is configured; live health is shown on Overview", span { class:"green-dot" } "Server Configured" }
                             Link { to:Route::Logs {}, class:"icon-button", title:"Open request logs", Icon { name:"bell" } }
                             Link { to:Route::Settings {}, class:"icon-button", title:"System settings", Icon { name:"help" } }
                             div { class:"top-divider" }

--- a/crates/client/src/functional_pages/access_live.rs
+++ b/crates/client/src/functional_pages/access_live.rs
@@ -1,22 +1,38 @@
+use std::collections::BTreeMap;
+
 use dioxus::prelude::*;
 
 use crate::{
-    backend::{use_auth, TokenDto, TokenService, UserService},
+    backend::{use_auth, TokenDto, TokenService, User, UserService},
     components::Icon,
 };
 
 fn masked(token: &str) -> String {
-    if token.len() <= 16 { return "••••••••".to_string(); }
-    format!("{}••••••••{}", &token[..8], &token[token.len()-6..])
+    if token.len() <= 16 {
+        return "••••••••".to_string();
+    }
+    format!("{}••••••••{}", &token[..8], &token[token.len() - 6..])
+}
+
+fn is_staff_role(role: &str) -> bool {
+    matches!(
+        role.trim().to_ascii_lowercase().as_str(),
+        "root" | "admin" | "administrator" | "operator" | "owner"
+    )
 }
 
 #[component]
 pub fn APIKeys() -> Element {
     let auth = use_auth();
-    let default_user = auth.user().map(|u| u.id).unwrap_or_default();
-    let mut resource = use_resource(move || async move { TokenService::list().await });
+    let default_user = auth.user().map(|user| user.id).unwrap_or_default();
+    let mut tokens_resource = use_resource(move || async move { TokenService::list().await });
+    let mut users_resource = use_resource(move || async move { UserService::list().await });
+
     let mut create_open = use_signal(|| false);
     let mut whitelist_target = use_signal(|| None::<TokenDto>);
+    let mut rotate_target = use_signal(|| None::<TokenDto>);
+    let mut delete_target = use_signal(|| None::<TokenDto>);
+    let mut new_key = use_signal(|| None::<String>);
     let mut user_id = use_signal(move || default_user);
     let mut quota = use_signal(String::new);
     let mut whitelist = use_signal(String::new);
@@ -24,73 +40,183 @@ pub fn APIKeys() -> Element {
     let mut notice = use_signal(String::new);
     let mut error = use_signal(String::new);
 
-    let snapshot = resource.read().clone();
-    let load_error = snapshot.as_ref().and_then(|r| r.as_ref().err().cloned());
-    let list = snapshot.and_then(Result::ok).unwrap_or_default();
-    let active = list.iter().filter(|t| t.status == "active").count();
-    let total = list.len();
+    let token_snapshot = tokens_resource.read().clone();
+    let user_snapshot = users_resource.read().clone();
+    let load_error = token_snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
+    let users_error = user_snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
+    let tokens = token_snapshot.and_then(Result::ok).unwrap_or_default();
+    let users: Vec<User> = user_snapshot.and_then(Result::ok).unwrap_or_default();
+
+    let owner_names: BTreeMap<String, String> = users
+        .iter()
+        .map(|user| (user.id.clone(), user.username.clone()))
+        .collect();
+    let active = tokens.iter().filter(|token| token.status == "active").count();
+    let disabled = tokens.len().saturating_sub(active);
+    let restricted = tokens
+        .iter()
+        .filter(|token| token.ip_whitelist.as_deref().is_some_and(|value| !value.trim().is_empty()))
+        .count();
+    let total = tokens.len();
 
     rsx! {
-        div { class:"page",
-            div { class:"page-header",
-                div { h2 { class:"page-title", "API Keys" } p { class:"page-subtitle", "Real BurnCloud router tokens: create, enable/disable, rotate, restrict by IP, and delete." } }
-                div { class:"header-actions",
-                    button { class:"button button-secondary", onclick:move |_| resource.restart(), "Refresh" }
-                    button { class:"button button-primary", onclick:move |_| { error.set(String::new()); create_open.set(true); }, Icon { name:"plus" } "Create API Key" }
+        div { class: "page",
+            div { class: "page-header",
+                div {
+                    h2 { class: "page-title", "API Keys" }
+                    p { class: "page-subtitle", "Control which BurnCloud account can send router traffic and protect credentials over their lifecycle." }
+                }
+                div { class: "header-actions",
+                    button {
+                        class: "button button-secondary",
+                        onclick: move |_| {
+                            tokens_resource.restart();
+                            users_resource.restart();
+                        },
+                        "Refresh"
+                    }
+                    button {
+                        class: "button button-primary",
+                        onclick: move |_| {
+                            quota.set(String::new());
+                            notice.set(String::new());
+                            error.set(String::new());
+                            create_open.set(true);
+                        },
+                        Icon { name: "plus" }
+                        "Create API Key"
+                    }
                 }
             }
-            div { class:"metrics",
-                div { class:"card metric", div { class:"metric-copy", span { class:"metric-label", "Keys" } span { class:"metric-value", "{total}" } } div { class:"metric-icon tone-blue", Icon { name:"key" } } }
-                div { class:"card metric", div { class:"metric-copy", span { class:"metric-label", "Active" } span { class:"metric-value", "{active}" } } div { class:"metric-icon tone-green", Icon { name:"activity" } } }
+
+            div { class: "metrics",
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Total Keys" } span { class: "metric-value", "{total}" } span { class: "metric-note", "router credentials" } }
+                    div { class: "metric-icon tone-blue", Icon { name: "key" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Active" } span { class: "metric-value", "{active}" } span { class: "metric-note", "can send traffic" } }
+                    div { class: "metric-icon tone-green", Icon { name: "activity" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Disabled" } span { class: "metric-value", "{disabled}" } span { class: "metric-note", "blocked credentials" } }
+                    div { class: "metric-icon tone-gray", Icon { name: "lock" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "IP Restricted" } span { class: "metric-value", "{restricted}" } span { class: "metric-note", "keys with allowlists" } }
+                    div { class: "metric-icon tone-purple", Icon { name: "shield" } }
+                }
             }
-            if !notice().is_empty() { div { class:"terminal auth-status", "{notice}" } }
-            if !error().is_empty() { div { class:"terminal auth-status auth-status-error", "{error}" } }
+
+            if !notice().is_empty() { div { class: "terminal auth-status", "{notice}" } }
+            if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
+            if let Some(message) = users_error {
+                div { class: "product-note", "Owner names could not be loaded ({message}). Existing keys still work; owner IDs will be shown where necessary." }
+            }
+
             if let Some(message) = load_error {
-                div { class:"card card-pad stack", strong { class:"danger", "Unable to load API keys" } code { class:"terminal", "{message}" } }
+                div { class: "card card-pad stack",
+                    strong { class: "danger", "API keys could not be loaded" }
+                    code { class: "terminal", "{message}" }
+                    button { class: "button button-primary", onclick: move |_| tokens_resource.restart(), "Retry" }
+                }
+            } else if tokens.is_empty() {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "key" } }
+                        h3 { "Create the first client credential" }
+                        p { "API keys are how Playground and external OpenAI-compatible clients authenticate to the BurnCloud router." }
+                        button { class: "button button-primary", onclick: move |_| create_open.set(true), "Create API Key" }
+                    }
+                }
             } else {
-                div { class:"card table-card",
-                    if list.is_empty() { div { class:"card-pad small muted", "No API keys exist yet." } }
-                    else {
-                        div { class:"table-wrap",
-                            table { class:"data-table",
-                                thead { tr { th { "Key" } th { "User" } th { "Status" } th { class:"right", "Quota" } th { class:"right", "Used" } th { "IP Rules" } th { "Version" } th { "Actions" } } }
-                                tbody {
-                                    for item in list {
-                                        {
-                                            let row_key = item.token.clone();
-                                            let token_toggle = item.token.clone();
-                                            let token_rotate = item.token.clone();
-                                            let token_delete = item.token.clone();
-                                            let item_for_whitelist = item.clone();
-                                            let label = masked(&item.token);
-                                            let next_status = if item.status == "active" { "disabled" } else { "active" };
-                                            let toggle_label = if item.status == "active" { "Disable" } else { "Enable" };
-                                            let quota_text = if item.quota_limit < 0 { "Unlimited".to_string() } else { item.quota_limit.to_string() };
-                                            let ip_text = item.ip_whitelist.clone().unwrap_or_else(|| "Any IP".to_string());
-                                            rsx! {
-                                                tr { key:"{row_key}",
-                                                    td { class:"mono table-primary", "{label}" }
-                                                    td { class:"mono muted", "{item.user_id}" }
-                                                    td { span { class:if item.status == "active" { "badge badge-success" } else { "badge badge-neutral" }, "{item.status}" } }
-                                                    td { class:"right tabular", "{quota_text}" }
-                                                    td { class:"right tabular", "{item.used_quota}" }
-                                                    td { class:"mono muted", "{ip_text}" }
-                                                    td { class:"mono", "v{item.key_version}" }
-                                                    td { div { class:"row gap-2", style:"flex-wrap:wrap",
-                                                        button { class:"button button-ghost button-sm", disabled:busy(), onclick:move |_| {
-                                                            let token = token_toggle.clone(); busy.set(true); error.set(String::new());
-                                                            spawn(async move { let r = TokenService::set_status(&token, next_status).await; match r { Ok(()) => { notice.set(format!("Key status changed to {next_status}.")); resource.restart(); }, Err(e) => error.set(format!("Status update failed: {e}")) } busy.set(false); });
-                                                        }, "{toggle_label}" }
-                                                        button { class:"button button-ghost button-sm", disabled:busy(), onclick:move |_| {
-                                                            let token = token_rotate.clone(); busy.set(true); error.set(String::new());
-                                                            spawn(async move { let r = TokenService::rotate(&token, 24, false).await; match r { Ok(v) => { notice.set(format!("Rotation result: {v}")); resource.restart(); }, Err(e) => error.set(format!("Rotation failed: {e}")) } busy.set(false); });
-                                                        }, "Rotate" }
-                                                        button { class:"button button-ghost button-sm", onclick:move |_| { whitelist.set(item_for_whitelist.ip_whitelist.clone().unwrap_or_default()); whitelist_target.set(Some(item_for_whitelist.clone())); }, "IP Rules" }
-                                                        button { class:"button button-ghost button-sm danger", disabled:busy(), onclick:move |_| {
-                                                            let token = token_delete.clone(); busy.set(true); error.set(String::new());
-                                                            spawn(async move { let r = TokenService::delete(&token).await; match r { Ok(()) => { notice.set("API key deleted.".to_string()); resource.restart(); }, Err(e) => error.set(format!("Delete failed: {e}")) } busy.set(false); });
-                                                        }, "Delete" }
-                                                    } }
+                div { class: "card table-card",
+                    div { class: "card-pad product-section-head",
+                        div {
+                            h3 { "Credentials" }
+                            p { "Keys are masked after creation. Rotate credentials instead of sharing or recreating them casually." }
+                        }
+                    }
+                    div { class: "table-wrap",
+                        table { class: "data-table",
+                            thead { tr {
+                                th { "Key" }
+                                th { "Owner" }
+                                th { "Status" }
+                                th { "Quota" }
+                                th { "Network Access" }
+                                th { "Version" }
+                                th { class: "right", "Actions" }
+                            } }
+                            tbody {
+                                for item in tokens {
+                                    {
+                                        let row_key = item.token.clone();
+                                        let token_toggle = item.token.clone();
+                                        let item_for_whitelist = item.clone();
+                                        let item_for_rotate = item.clone();
+                                        let item_for_delete = item.clone();
+                                        let label = masked(&item.token);
+                                        let next_status = if item.status == "active" { "disabled" } else { "active" };
+                                        let toggle_label = if item.status == "active" { "Disable" } else { "Enable" };
+                                        let quota_text = if item.quota_limit < 0 { "Unlimited".to_string() } else { item.quota_limit.to_string() };
+                                        let ip_text = item
+                                            .ip_whitelist
+                                            .clone()
+                                            .filter(|value| !value.trim().is_empty())
+                                            .unwrap_or_else(|| "Any IP".to_string());
+                                        let owner_name = owner_names.get(&item.user_id).cloned().unwrap_or_else(|| item.user_id.clone());
+                                        rsx! {
+                                            tr { key: "{row_key}",
+                                                td { class: "mono table-primary", "{label}" }
+                                                td {
+                                                    div { class: "two-line",
+                                                        strong { "{owner_name}" }
+                                                        small { class: "mono muted", "{item.user_id}" }
+                                                    }
+                                                }
+                                                td { span { class: if item.status == "active" { "badge badge-success" } else { "badge badge-neutral" }, "{item.status}" } }
+                                                td {
+                                                    div { class: "two-line",
+                                                        strong { class: "small", "{quota_text}" }
+                                                        small { class: "muted", "used {item.used_quota}" }
+                                                    }
+                                                }
+                                                td { class: "mono muted", "{ip_text}" }
+                                                td { class: "mono", "v{item.key_version}" }
+                                                td { class: "right",
+                                                    div { class: "action-menu",
+                                                        button {
+                                                            class: "button button-ghost button-sm",
+                                                            disabled: busy(),
+                                                            onclick: move |_| {
+                                                                let token = token_toggle.clone();
+                                                                busy.set(true);
+                                                                error.set(String::new());
+                                                                spawn(async move {
+                                                                    match TokenService::set_status(&token, next_status).await {
+                                                                        Ok(()) => {
+                                                                            notice.set(format!("API key {next_status}."));
+                                                                            tokens_resource.restart();
+                                                                        }
+                                                                        Err(message) => error.set(format!("Status update failed: {message}")),
+                                                                    }
+                                                                    busy.set(false);
+                                                                });
+                                                            },
+                                                            "{toggle_label}"
+                                                        }
+                                                        button { class: "button button-ghost button-sm", onclick: move |_| rotate_target.set(Some(item_for_rotate.clone())), "Rotate" }
+                                                        button {
+                                                            class: "button button-ghost button-sm",
+                                                            onclick: move |_| {
+                                                                whitelist.set(item_for_whitelist.ip_whitelist.clone().unwrap_or_default());
+                                                                whitelist_target.set(Some(item_for_whitelist.clone()));
+                                                            },
+                                                            "IP Rules"
+                                                        }
+                                                        button { class: "button button-ghost button-sm danger", onclick: move |_| delete_target.set(Some(item_for_delete.clone())), "Delete" }
+                                                    }
                                                 }
                                             }
                                         }
@@ -101,33 +227,212 @@ pub fn APIKeys() -> Element {
                     }
                 }
             }
+
             if create_open() {
-                div { class:"drawer-backdrop", onclick:move |_| create_open.set(false) }
-                aside { class:"drawer",
-                    div { class:"drawer-head", h2 { "Create API Key" } button { class:"close-button", onclick:move |_| create_open.set(false), "×" } }
-                    div { class:"drawer-body stack-lg",
-                        div { class:"field", label { "User ID" } input { class:"input mono", value:"{user_id}", oninput:move |e| user_id.set(e.value()) } }
-                        div { class:"field", label { "Quota (optional raw quota)" } input { class:"input", r#type:"number", value:"{quota}", oninput:move |e| quota.set(e.value()) } }
-                        button { class:"button button-primary", disabled:busy(), onclick:move |_| {
-                            let uid=user_id().trim().to_string(); let q=quota().trim().parse::<i64>().ok();
-                            if uid.is_empty() { error.set("User ID is required.".to_string()); return; }
-                            busy.set(true); error.set(String::new());
-                            spawn(async move { match TokenService::create(&uid,q).await { Ok(token)=>{ notice.set(format!("Created API key: {token} — copy it now.")); create_open.set(false); resource.restart(); }, Err(e)=>error.set(format!("Create key failed: {e}")) } busy.set(false); });
-                        }, if busy() { "Creating…" } else { "Create Key" } }
+                div { class: "drawer-backdrop", onclick: move |_| create_open.set(false) }
+                aside { class: "drawer",
+                    div { class: "drawer-head",
+                        div { h2 { "Create API Key" } p { class: "small muted", "Choose which account will own this router credential." } }
+                        button { class: "close-button", onclick: move |_| create_open.set(false), "×" }
+                    }
+                    div { class: "drawer-body stack-lg",
+                        div { class: "form-section",
+                            div { class: "form-section-head", strong { "Owner" } small { "Usage and billing attribution follow the selected BurnCloud account." } }
+                            if users.is_empty() {
+                                div { class: "field",
+                                    label { "Owner user ID" }
+                                    input { class: "input mono", value: "{user_id}", oninput: move |event| user_id.set(event.value()) }
+                                }
+                            } else {
+                                div { class: "field",
+                                    label { "Account" }
+                                    select { class: "select", value: "{user_id}", onchange: move |event| user_id.set(event.value()),
+                                        for user in users.iter() {
+                                            option { value: "{user.id}", "{user.username} — {user.role}" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        div { class: "form-section",
+                            div { class: "form-section-head", strong { "Quota" } small { "Leave blank for unlimited. The server currently exposes a single quota limit rather than named scopes." } }
+                            div { class: "field",
+                                label { "Quota limit (optional)" }
+                                input { class: "input", r#type: "number", value: "{quota}", placeholder: "Unlimited", oninput: move |event| quota.set(event.value()) }
+                            }
+                        }
+
+                        if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
+                        div { class: "row customer-form-actions",
+                            button { class: "button button-secondary", disabled: busy(), onclick: move |_| create_open.set(false), "Cancel" }
+                            button {
+                                class: "button button-primary",
+                                disabled: busy(),
+                                onclick: move |_| {
+                                    let uid = user_id().trim().to_string();
+                                    let quota_value = quota().trim().parse::<i64>().ok();
+                                    if uid.is_empty() {
+                                        error.set("Choose an owner for this API key.".to_string());
+                                        return;
+                                    }
+                                    busy.set(true);
+                                    error.set(String::new());
+                                    spawn(async move {
+                                        match TokenService::create(&uid, quota_value).await {
+                                            Ok(token) => {
+                                                new_key.set(Some(token));
+                                                create_open.set(false);
+                                                tokens_resource.restart();
+                                            }
+                                            Err(message) => error.set(format!("Create key failed: {message}")),
+                                        }
+                                        busy.set(false);
+                                    });
+                                },
+                                if busy() { "Creating…" } else { "Create API Key" }
+                            }
+                        }
                     }
                 }
             }
+
+            if let Some(created_key) = new_key() {
+                div { class: "drawer-backdrop", onclick: move |_| new_key.set(None) }
+                aside { class: "drawer",
+                    div { class: "drawer-head",
+                        h2 { "API Key Created" }
+                        button { class: "close-button", onclick: move |_| new_key.set(None), "×" }
+                    }
+                    div { class: "drawer-body stack-lg",
+                        div { class: "form-section",
+                            strong { "Copy this credential now" }
+                            p { class: "small muted", "The table will only show a masked version after you close this panel." }
+                            code { class: "terminal", style: "word-break:break-all;user-select:all", "{created_key}" }
+                        }
+                        div { class: "product-note", "Store API keys in a secret manager or environment variable. Do not paste them into source code, tickets, or chat logs." }
+                        button { class: "button button-primary", onclick: move |_| new_key.set(None), "I saved the key" }
+                    }
+                }
+            }
+
             if let Some(target) = whitelist_target() {
-                div { class:"drawer-backdrop", onclick:move |_| whitelist_target.set(None) }
-                aside { class:"drawer",
-                    div { class:"drawer-head", h2 { "IP Whitelist" } button { class:"close-button", onclick:move |_| whitelist_target.set(None), "×" } }
-                    div { class:"drawer-body stack-lg",
-                        p { class:"small muted", "Empty means unrestricted. The value is sent directly to BurnCloud token IP whitelist configuration." }
-                        textarea { class:"textarea mono", rows:"6", value:"{whitelist}", oninput:move |e| whitelist.set(e.value()) }
-                        button { class:"button button-primary", disabled:busy(), onclick:move |_| {
-                            let token=target.token.clone(); let rules=whitelist(); busy.set(true); error.set(String::new());
-                            spawn(async move { match TokenService::set_ip_whitelist(&token,&rules).await { Ok(())=>{ notice.set("IP whitelist saved.".to_string()); whitelist_target.set(None); resource.restart(); }, Err(e)=>error.set(format!("Whitelist failed: {e}")) } busy.set(false); });
-                        }, "Save IP Rules" }
+                div { class: "drawer-backdrop", onclick: move |_| whitelist_target.set(None) }
+                aside { class: "drawer",
+                    div { class: "drawer-head", h2 { "Network Access" } button { class: "close-button", onclick: move |_| whitelist_target.set(None), "×" } }
+                    div { class: "drawer-body stack-lg",
+                        div { class: "form-section",
+                            div { class: "form-section-head", strong { "IP whitelist" } small { "Empty means unrestricted. Only add rules when the calling network has stable source addresses." } }
+                            textarea { class: "textarea mono", rows: "6", value: "{whitelist}", oninput: move |event| whitelist.set(event.value()) }
+                        }
+                        button {
+                            class: "button button-primary",
+                            disabled: busy(),
+                            onclick: move |_| {
+                                let token = target.token.clone();
+                                let rules = whitelist();
+                                busy.set(true);
+                                error.set(String::new());
+                                spawn(async move {
+                                    match TokenService::set_ip_whitelist(&token, &rules).await {
+                                        Ok(()) => {
+                                            notice.set("IP whitelist saved.".to_string());
+                                            whitelist_target.set(None);
+                                            tokens_resource.restart();
+                                        }
+                                        Err(message) => error.set(format!("Whitelist update failed: {message}")),
+                                    }
+                                    busy.set(false);
+                                });
+                            },
+                            "Save Network Rules"
+                        }
+                    }
+                }
+            }
+
+            if let Some(target) = rotate_target() {
+                {
+                    let token = target.token.clone();
+                    let label = masked(&target.token);
+                    rsx! {
+                        div { class: "drawer-backdrop", onclick: move |_| rotate_target.set(None) }
+                        aside { class: "drawer",
+                            div { class: "drawer-head", h2 { "Rotate API Key" } button { class: "close-button", onclick: move |_| rotate_target.set(None), "×" } }
+                            div { class: "drawer-body stack-lg",
+                                div { class: "form-section",
+                                    strong { "Rotate {label}?" }
+                                    p { class: "small muted", "BurnCloud will create a new key version and keep the old credential valid for the configured 24-hour transition period." }
+                                }
+                                div { class: "product-note", "Update clients to the new credential before the transition period ends. Rotation is safer than deleting an in-use key." }
+                                div { class: "row customer-form-actions",
+                                    button { class: "button button-secondary", disabled: busy(), onclick: move |_| rotate_target.set(None), "Cancel" }
+                                    button {
+                                        class: "button button-primary",
+                                        disabled: busy(),
+                                        onclick: move |_| {
+                                            busy.set(true);
+                                            error.set(String::new());
+                                            spawn(async move {
+                                                match TokenService::rotate(&token, 24, false).await {
+                                                    Ok(value) => {
+                                                        notice.set(format!("Key rotation accepted: {value}"));
+                                                        rotate_target.set(None);
+                                                        tokens_resource.restart();
+                                                    }
+                                                    Err(message) => error.set(format!("Rotation failed: {message}")),
+                                                }
+                                                busy.set(false);
+                                            });
+                                        },
+                                        if busy() { "Rotating…" } else { "Rotate Key" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some(target) = delete_target() {
+                {
+                    let token = target.token.clone();
+                    let label = masked(&target.token);
+                    let owner = owner_names.get(&target.user_id).cloned().unwrap_or_else(|| target.user_id.clone());
+                    rsx! {
+                        div { class: "drawer-backdrop", onclick: move |_| delete_target.set(None) }
+                        aside { class: "drawer",
+                            div { class: "drawer-head", h2 { class: "danger", "Delete API Key" } button { class: "close-button", onclick: move |_| delete_target.set(None), "×" } }
+                            div { class: "drawer-body stack-lg",
+                                div { class: "form-section danger-zone",
+                                    strong { "Delete {label}?" }
+                                    p { class: "small muted", "This immediately removes the credential owned by {owner}. Any client still using it will stop authenticating." }
+                                }
+                                div { class: "row customer-form-actions",
+                                    button { class: "button button-secondary", disabled: busy(), onclick: move |_| delete_target.set(None), "Cancel" }
+                                    button {
+                                        class: "button button-primary",
+                                        disabled: busy(),
+                                        onclick: move |_| {
+                                            busy.set(true);
+                                            error.set(String::new());
+                                            spawn(async move {
+                                                match TokenService::delete(&token).await {
+                                                    Ok(()) => {
+                                                        notice.set("API key deleted.".to_string());
+                                                        delete_target.set(None);
+                                                        tokens_resource.restart();
+                                                    }
+                                                    Err(message) => error.set(format!("Delete failed: {message}")),
+                                                }
+                                                busy.set(false);
+                                            });
+                                        },
+                                        if busy() { "Deleting…" } else { "Delete API Key" }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -137,24 +442,87 @@ pub fn APIKeys() -> Element {
 
 #[component]
 pub fn Team() -> Element {
-    let auth=use_auth();
-    let session=auth.user();
-    let mut resource=use_resource(move || async move { UserService::list().await });
-    let snapshot=resource.read().clone();
-    let error=snapshot.as_ref().and_then(|r| r.as_ref().err().cloned());
-    let users=snapshot.and_then(Result::ok).unwrap_or_default();
-    let username=session.as_ref().map(|u|u.username.clone()).unwrap_or_else(||"-".to_string());
-    let user_id=session.as_ref().map(|u|u.id.clone()).unwrap_or_else(||"-".to_string());
-    let roles=session.as_ref().map(|u|u.roles.join(", ")).unwrap_or_else(||"-".to_string());
+    let auth = use_auth();
+    let session = auth.user();
+    let mut resource = use_resource(move || async move { UserService::list().await });
+    let snapshot = resource.read().clone();
+    let load_error = snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
+    let all_users = snapshot.and_then(Result::ok).unwrap_or_default();
+    let staff: Vec<User> = all_users
+        .iter()
+        .filter(|user| is_staff_role(&user.role))
+        .cloned()
+        .collect();
+
+    let username = session.as_ref().map(|user| user.username.clone()).unwrap_or_else(|| "-".to_string());
+    let user_id = session.as_ref().map(|user| user.id.clone()).unwrap_or_else(|| "-".to_string());
+    let roles = session.as_ref().map(|user| user.roles.join(", ")).unwrap_or_else(|| "-".to_string());
+
     rsx! {
-        div { class:"page",
-            div { class:"page-header", div { h2 { class:"page-title", "Team" } p { class:"page-subtitle", "Live BurnCloud accounts. Account creation is managed from Customers / Users." } } button { class:"button button-secondary", onclick:move |_| resource.restart(), "Refresh" } }
-            div { class:"card card-pad stack", span { class:"section-label", "Current Session" } strong { "{username}" } code { "{user_id}" } span { class:"small muted", "Roles: {roles}" } }
-            if let Some(message)=error { div { class:"terminal auth-status auth-status-error", "{message}" } }
-            else { div { class:"card table-card", div { class:"table-wrap", table { class:"data-table",
-                thead { tr { th { "Username" } th { "Email" } th { "Role" } th { "Group" } th { "Status" } } }
-                tbody { for user in users { { let email=user.email.clone().unwrap_or_else(||"-".to_string()); let status=if user.status==1 {"Active"} else {"Disabled"}; rsx!{ tr { key:"{user.id}", td { class:"table-primary", "{user.username}" } td { "{email}" } td { "{user.role}" } td { "{user.group}" } td { span { class:if user.status==1 {"badge badge-success"} else {"badge badge-neutral"}, "{status}" } } } } } } }
-            } } } }
+        div { class: "page",
+            div { class: "page-header",
+                div {
+                    h2 { class: "page-title", "Team" }
+                    p { class: "page-subtitle", "People with administrative or operator roles who manage this BurnCloud environment." }
+                }
+                button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
+            }
+
+            div { class: "grid-2",
+                div { class: "card card-pad stack",
+                    div { class: "product-section-head", div { h3 { "Your session" } p { "The identity currently operating this console." } } }
+                    div { class: "receipt-row", label { "User" } strong { "{username}" } }
+                    div { class: "receipt-row", label { "User ID" } strong { class: "mono", "{user_id}" } }
+                    div { class: "receipt-row", label { "Roles" } strong { "{roles}" } }
+                }
+                div { class: "card card-pad stack",
+                    div { class: "product-section-head", div { h3 { "Role management" } p { "Why this page is read-only today." } } }
+                    p { class: "small muted", "The current BurnCloud server exposes user roles when listing accounts, but it does not expose an API to invite a staff member or change roles safely." }
+                    div { class: "product-note", "Customer account creation remains under Customers. Team will become editable only when the backend has explicit role-management endpoints." }
+                }
+            }
+
+            if let Some(message) = load_error {
+                div { class: "terminal auth-status auth-status-error", "{message}" }
+            } else if staff.is_empty() {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "users" } }
+                        h3 { "No staff roles returned" }
+                        p { "The current session may still be authorized, but the user list did not return accounts with admin, root, owner, or operator roles." }
+                    }
+                }
+            } else {
+                div { class: "card table-card",
+                    div { class: "card-pad product-section-head", div { h3 { "Environment operators" } p { "Administrative identities are separated from customer accounts." } } }
+                    div { class: "table-wrap",
+                        table { class: "data-table",
+                            thead { tr { th { "Member" } th { "Email" } th { "Role" } th { "Status" } } }
+                            tbody {
+                                for user in staff {
+                                    {
+                                        let email = user.email.clone().unwrap_or_else(|| "-".to_string());
+                                        let status = if user.status == 1 { "Active" } else { "Disabled" };
+                                        rsx! {
+                                            tr { key: "{user.id}",
+                                                td {
+                                                    div { class: "two-line",
+                                                        strong { class: "table-primary", "{user.username}" }
+                                                        small { class: "mono muted", "{user.id}" }
+                                                    }
+                                                }
+                                                td { "{email}" }
+                                                td { span { class: "badge badge-neutral", "{user.role}" } }
+                                                td { span { class: if user.status == 1 { "badge badge-success" } else { "badge badge-neutral" }, "{status}" } }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/client/src/functional_pages/access_live.rs
+++ b/crates/client/src/functional_pages/access_live.rs
@@ -371,6 +371,7 @@ pub fn APIKeys() -> Element {
                                         class: "button button-primary",
                                         disabled: busy(),
                                         onclick: move |_| {
+                                            let token = token.clone();
                                             busy.set(true);
                                             error.set(String::new());
                                             spawn(async move {
@@ -414,6 +415,7 @@ pub fn APIKeys() -> Element {
                                         class: "button button-primary",
                                         disabled: busy(),
                                         onclick: move |_| {
+                                            let token = token.clone();
                                             busy.set(true);
                                             error.set(String::new());
                                             spawn(async move {

--- a/crates/client/src/functional_pages/analytics.rs
+++ b/crates/client/src/functional_pages/analytics.rs
@@ -1,17 +1,20 @@
-use std::collections::BTreeMap;
-
 use dioxus::prelude::*;
 
 use crate::{
-    backend::{billing_summary, use_auth, BillingSummary, LogService, RouterLog},
+    backend::{billing_summary, use_auth, BillingSummary},
     components::Icon,
 };
 
 fn compact(n: i64) -> String {
-    if n.abs() >= 1_000_000_000 { format!("{:.2}B", n as f64 / 1_000_000_000.0) }
-    else if n.abs() >= 1_000_000 { format!("{:.2}M", n as f64 / 1_000_000.0) }
-    else if n.abs() >= 1_000 { format!("{:.2}K", n as f64 / 1_000.0) }
-    else { n.to_string() }
+    if n.abs() >= 1_000_000_000 {
+        format!("{:.2}B", n as f64 / 1_000_000_000.0)
+    } else if n.abs() >= 1_000_000 {
+        format!("{:.2}M", n as f64 / 1_000_000.0)
+    } else if n.abs() >= 1_000 {
+        format!("{:.2}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
 }
 
 #[component]
@@ -19,71 +22,144 @@ pub fn Billing() -> Element {
     let auth = use_auth();
     let token = auth.token().unwrap_or_default();
     let token_for_resource = token.clone();
-    let mut summary = use_resource(move || {
+    let mut summary_resource = use_resource(move || {
         let token = token_for_resource.clone();
         async move {
-            if token.is_empty() { Err("No authenticated token".to_string()) } else { billing_summary(&token).await }
+            if token.is_empty() {
+                Err("No authenticated token".to_string())
+            } else {
+                billing_summary(&token).await
+            }
         }
     });
-    let result = summary.read().clone();
-    let loading = result.is_none();
-    let load_error = result.as_ref().and_then(|r| r.as_ref().err().cloned());
-    let data: BillingSummary = result.and_then(Result::ok).unwrap_or_default();
-    let request_count = data.models.iter().map(|m| m.requests).sum::<i64>() + data.pre_migration_requests;
-    let prompt_tokens = data.models.iter().map(|m| m.prompt_tokens).sum::<i64>();
-    let completion_tokens = data.models.iter().map(|m| m.completion_tokens).sum::<i64>();
+
+    let snapshot = summary_resource.read().clone();
+    let loading = snapshot.is_none();
+    let load_error = snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
+    let data: BillingSummary = snapshot.and_then(Result::ok).unwrap_or_default();
+
+    let request_count = data.models.iter().map(|model| model.requests).sum::<i64>() + data.pre_migration_requests;
+    let total_tokens = data
+        .models
+        .iter()
+        .map(|model| {
+            model.prompt_tokens
+                + model.cache_read_tokens
+                + model.completion_tokens
+                + model.reasoning_tokens
+        })
+        .sum::<i64>();
+    let model_count = data.models.len();
     let request_text = compact(request_count);
-    let prompt_text = compact(prompt_tokens);
-    let completion_text = compact(completion_tokens);
-    let cost_text = format!("${:.6}", data.total_cost_usd);
+    let token_text = compact(total_tokens);
+    let cost_text = format!("${:.4}", data.total_cost_usd);
     let period_text = match (&data.period_start, &data.period_end) {
         (Some(start), Some(end)) => format!("{start} → {end}"),
-        _ => "Current server billing period".to_string(),
+        _ => "Current billing period".to_string(),
     };
+
+    let mut models = data.models.clone();
+    models.sort_by(|left, right| {
+        right
+            .cost_usd
+            .partial_cmp(&left.cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
-                div { h2 { class: "page-title", "Billing" } p { class: "page-subtitle", "Live per-user billing summary from /api/billing/summary." } }
-                button { class: "button button-secondary", onclick: move |_| summary.restart(), "Refresh" }
+                div {
+                    h2 { class: "page-title", "Billing" }
+                    p { class: "page-subtitle", "Understand how much this account spent, which models drove the cost, and the usage behind that spend." }
+                }
+                div { class: "header-actions",
+                    span { class: "badge badge-neutral mono", "{period_text}" }
+                    button { class: "button button-secondary", onclick: move |_| summary_resource.restart(), "Refresh" }
+                }
             }
+
             if loading {
                 div { class: "card card-pad", "Loading billing summary…" }
             } else if let Some(message) = load_error {
-                div { class: "terminal auth-status auth-status-error", "{message}" }
-            } else {
-                div { class: "card card-pad row between", span { class: "section-label", "Billing Period" } strong { class: "mono", "{period_text}" } }
-                div { class: "metrics",
-                    div { class: "card metric", div { class: "metric-copy", span { class: "metric-label", "Requests" } span { class: "metric-value", "{request_text}" } } div { class: "metric-icon tone-blue", Icon { name: "activity" } } }
-                    div { class: "card metric", div { class: "metric-copy", span { class: "metric-label", "Prompt Tokens" } span { class: "metric-value", "{prompt_text}" } } div { class: "metric-icon tone-purple", Icon { name: "models" } } }
-                    div { class: "card metric", div { class: "metric-copy", span { class: "metric-label", "Completion Tokens" } span { class: "metric-value", "{completion_text}" } } div { class: "metric-icon tone-green", Icon { name: "models" } } }
-                    div { class: "card metric", div { class: "metric-copy", span { class: "metric-label", "Total Cost" } span { class: "metric-value", "{cost_text}" } } div { class: "metric-icon tone-amber", Icon { name: "dollar" } } }
+                div { class: "card card-pad stack",
+                    strong { class: "danger", "Billing could not be loaded" }
+                    code { class: "terminal", "{message}" }
+                    button { class: "button button-primary", onclick: move |_| summary_resource.restart(), "Retry" }
                 }
-                div { class: "card table-card",
-                    if data.models.is_empty() {
-                        div { class: "card-pad small muted", "No billed model usage is available for this account and period." }
-                    } else {
+            } else {
+                div { class: "metrics",
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Spend" } span { class: "metric-value", "{cost_text}" } span { class: "metric-note", "current billing period" } }
+                        div { class: "metric-icon tone-amber", Icon { name: "dollar" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Requests" } span { class: "metric-value", "{request_text}" } span { class: "metric-note", "billed request activity" } }
+                        div { class: "metric-icon tone-blue", Icon { name: "activity" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Tokens" } span { class: "metric-value", "{token_text}" } span { class: "metric-note", "input + cache + output + reasoning" } }
+                        div { class: "metric-icon tone-purple", Icon { name: "models" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Models Used" } span { class: "metric-value", "{model_count}" } span { class: "metric-note", "models with billed usage" } }
+                        div { class: "metric-icon tone-green", Icon { name: "routes" } }
+                    }
+                }
+
+                if models.is_empty() {
+                    div { class: "card product-empty",
+                        div { class: "product-empty-inner",
+                            div { class: "product-empty-icon", Icon { name: "billing" } }
+                            h3 { "No billed usage yet" }
+                            p { "Once this account sends routed traffic, model-level spend and token usage will appear here." }
+                        }
+                    }
+                } else {
+                    div { class: "card table-card",
+                        div { class: "card-pad product-section-head",
+                            div {
+                                h3 { "Spend by model" }
+                                p { "Models are sorted by cost so the largest spend drivers are visible first." }
+                            }
+                        }
                         div { class: "table-wrap",
                             table { class: "data-table",
-                                thead { tr { th { "Model" } th { class: "right", "Requests" } th { class: "right", "Prompt" } th { class: "right", "Cache Read" } th { class: "right", "Completion" } th { class: "right", "Reasoning" } th { class: "right", "Cost" } } }
+                                thead { tr {
+                                    th { "Model" }
+                                    th { class: "right", "Spend" }
+                                    th { class: "right", "Share" }
+                                    th { class: "right", "Requests" }
+                                    th { class: "right", "Input" }
+                                    th { class: "right", "Cache Read" }
+                                    th { class: "right", "Output" }
+                                    th { class: "right", "Reasoning" }
+                                } }
                                 tbody {
-                                    for model in data.models {
+                                    for model in models {
                                         {
+                                            let spend = format!("${:.6}", model.cost_usd);
+                                            let share = if data.total_cost_usd > 0.0 {
+                                                model.cost_usd * 100.0 / data.total_cost_usd
+                                            } else {
+                                                0.0
+                                            };
+                                            let share_text = format!("{share:.1}%");
                                             let requests = compact(model.requests);
-                                            let prompt = compact(model.prompt_tokens);
+                                            let input = compact(model.prompt_tokens);
                                             let cache = compact(model.cache_read_tokens);
-                                            let completion = compact(model.completion_tokens);
+                                            let output = compact(model.completion_tokens);
                                             let reasoning = compact(model.reasoning_tokens);
-                                            let cost = format!("${:.6}", model.cost_usd);
                                             rsx! {
                                                 tr { key: "{model.model}",
                                                     td { class: "table-primary mono", "{model.model}" }
+                                                    td { class: "right strong tabular", "{spend}" }
+                                                    td { class: "right tabular", "{share_text}" }
                                                     td { class: "right tabular", "{requests}" }
-                                                    td { class: "right tabular", "{prompt}" }
+                                                    td { class: "right tabular", "{input}" }
                                                     td { class: "right tabular", "{cache}" }
-                                                    td { class: "right tabular", "{completion}" }
+                                                    td { class: "right tabular", "{output}" }
                                                     td { class: "right tabular", "{reasoning}" }
-                                                    td { class: "right strong tabular", "{cost}" }
                                                 }
                                             }
                                         }
@@ -93,87 +169,10 @@ pub fn Billing() -> Element {
                         }
                     }
                 }
-            }
-        }
-    }
-}
 
-#[derive(Default, Clone)]
-struct ModelEval {
-    requests: i64,
-    success: i64,
-    latency_sum: i64,
-    tokens: i64,
-    cost: f64,
-    upstreams: std::collections::BTreeSet<String>,
-}
-
-#[component]
-pub fn Evaluation() -> Element {
-    let mut logs = use_resource(move || async move { LogService::list(500).await });
-    let result = logs.read().clone();
-    let loading = result.is_none();
-    let load_error = result.as_ref().and_then(|r| r.as_ref().err().cloned());
-    let list: Vec<RouterLog> = result.and_then(Result::ok).unwrap_or_default();
-    let mut models: BTreeMap<String, ModelEval> = BTreeMap::new();
-    for log in &list {
-        let model_name = log.model.clone().unwrap_or_else(|| "unattributed".to_string());
-        let entry = models.entry(model_name).or_default();
-        entry.requests += 1;
-        if log.status_code < 400 { entry.success += 1; }
-        entry.latency_sum += log.latency_ms;
-        entry.tokens += log.total_tokens();
-        entry.cost += log.cost_usd();
-        if let Some(upstream) = &log.upstream_id { entry.upstreams.insert(upstream.clone()); }
-    }
-
-    rsx! {
-        div { class: "page",
-            div { class: "page-header",
-                div { h2 { class: "page-title", "Evaluation" } p { class: "page-subtitle", "Operational model evaluation derived from real router logs — success rate, latency, token volume and cost. No synthetic benchmark scores." } }
-                button { class: "button button-secondary", onclick: move |_| logs.restart(), "Refresh" }
-            }
-            if loading {
-                div { class: "card card-pad", "Loading operational evaluation…" }
-            } else if let Some(message) = load_error {
-                div { class: "terminal auth-status auth-status-error", "{message}" }
-            } else {
-                div { class: "card table-card",
-                    if models.is_empty() {
-                        div { class: "card-pad small muted", "No router-log model data is available yet." }
-                    } else {
-                        div { class: "table-wrap",
-                            table { class: "data-table",
-                                thead { tr { th { "Model" } th { class: "right", "Requests" } th { class: "right", "Success" } th { class: "right", "Avg Latency" } th { class: "right", "Tokens" } th { class: "right", "Cost" } th { "Observed Upstreams" } } }
-                                tbody {
-                                    for (model, eval) in models {
-                                        {
-                                            let success_rate = if eval.requests == 0 { 0.0 } else { eval.success as f64 * 100.0 / eval.requests as f64 };
-                                            let success_text = format!("{success_rate:.1}%");
-                                            let avg_latency = if eval.requests == 0 { 0 } else { eval.latency_sum / eval.requests };
-                                            let latency_text = format!("{avg_latency}ms");
-                                            let token_text = compact(eval.tokens);
-                                            let cost_text = format!("${:.6}", eval.cost);
-                                            let upstream_text = eval.upstreams.into_iter().collect::<Vec<_>>().join(", ");
-                                            rsx! {
-                                                tr { key: "{model}",
-                                                    td { class: "table-primary mono", "{model}" }
-                                                    td { class: "right tabular", "{eval.requests}" }
-                                                    td { class: "right strong tabular", "{success_text}" }
-                                                    td { class: "right tabular", "{latency_text}" }
-                                                    td { class: "right tabular", "{token_text}" }
-                                                    td { class: "right tabular", "{cost_text}" }
-                                                    td { class: "muted", "{upstream_text}" }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                if data.pre_migration_requests > 0 {
+                    div { class: "product-note", "{data.pre_migration_requests} requests predate the current model-level billing breakdown and are included in the total request count without model attribution." }
                 }
-                div { class: "card card-pad tiny subtle", "Evaluation is intentionally based on observed production routing data. A quality/accuracy benchmark needs a dedicated evaluation backend, which BurnCloud does not currently expose." }
             }
         }
     }

--- a/crates/client/src/functional_pages/analytics_full.rs
+++ b/crates/client/src/functional_pages/analytics_full.rs
@@ -2,13 +2,22 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use dioxus::prelude::*;
 
-use crate::observability::{full_logs, FullRouterLog};
+use crate::{
+    app::Route,
+    components::Icon,
+    observability::{full_logs, FullRouterLog},
+};
 
 fn compact(n: i64) -> String {
-    if n.abs() >= 1_000_000_000 { format!("{:.2}B", n as f64 / 1_000_000_000.0) }
-    else if n.abs() >= 1_000_000 { format!("{:.2}M", n as f64 / 1_000_000.0) }
-    else if n.abs() >= 1_000 { format!("{:.2}K", n as f64 / 1_000.0) }
-    else { n.to_string() }
+    if n.abs() >= 1_000_000_000 {
+        format!("{:.2}B", n as f64 / 1_000_000_000.0)
+    } else if n.abs() >= 1_000_000 {
+        format!("{:.2}M", n as f64 / 1_000_000.0)
+    } else if n.abs() >= 1_000 {
+        format!("{:.2}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
 }
 
 #[derive(Default, Clone)]
@@ -27,7 +36,7 @@ pub fn Evaluation() -> Element {
     let mut resource = use_resource(move || async move { full_logs(500).await });
     let snapshot = resource.read().clone();
     let loading = snapshot.is_none();
-    let load_error = snapshot.as_ref().and_then(|r| r.as_ref().err().cloned());
+    let load_error = snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
     let logs: Vec<FullRouterLog> = snapshot.and_then(Result::ok).unwrap_or_default();
 
     let mut models: BTreeMap<String, ModelEval> = BTreeMap::new();
@@ -35,7 +44,9 @@ pub fn Evaluation() -> Element {
         let model_name = log.model.clone().unwrap_or_else(|| "unattributed".to_string());
         let entry = models.entry(model_name).or_default();
         entry.requests += 1;
-        if log.status_code < 400 { entry.success += 1; }
+        if log.status_code < 400 {
+            entry.success += 1;
+        }
         entry.latency_sum += log.latency_ms;
         entry.tokens += log.total_tokens();
         entry.cost += log.cost_usd();
@@ -52,58 +63,150 @@ pub fn Evaluation() -> Element {
         }
     }
 
+    let total_requests = logs.len() as i64;
+    let successful_requests = logs.iter().filter(|log| log.status_code < 400).count() as i64;
+    let total_latency = logs.iter().map(|log| log.latency_ms).sum::<i64>();
+    let overall_success = if total_requests == 0 {
+        0.0
+    } else {
+        successful_requests as f64 * 100.0 / total_requests as f64
+    };
+    let overall_success_text = format!("{overall_success:.1}%");
+    let avg_latency = if total_requests == 0 { 0 } else { total_latency / total_requests };
+    let avg_latency_text = format!("{avg_latency}ms");
+    let model_count = models.len();
+    let models_with_errors = models.values().filter(|model| model.success < model.requests).count();
+    let single_upstream_models = models.values().filter(|model| model.upstreams.len() <= 1).count();
+
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
                     h2 { class: "page-title", "Evaluation" }
-                    p { class: "page-subtitle", "Operational evaluation derived from the full current router log schema, including multimodal token types." }
+                    p { class: "page-subtitle", "Compare observed model reliability and latency from real routed traffic. This is operational evaluation, not synthetic model-quality scoring." }
                 }
-                button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
+                div { class: "header-actions",
+                    button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
+                    Link { class: "button button-secondary", to: Route::Logs {}, "Inspect Logs" }
+                }
             }
 
             if loading {
                 div { class: "card card-pad", "Loading operational evaluation…" }
             } else if let Some(message) = load_error {
-                div { class: "terminal auth-status auth-status-error", "{message}" }
+                div { class: "card card-pad stack",
+                    strong { class: "danger", "Evaluation data could not be loaded" }
+                    code { class: "terminal", "{message}" }
+                    button { class: "button button-primary", onclick: move |_| resource.restart(), "Retry" }
+                }
+            } else if models.is_empty() {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "chart" } }
+                        h3 { "No model traffic to evaluate yet" }
+                        p { "Evaluation is built from observed router logs. Send representative requests through Playground or production clients first." }
+                        Link { class: "button button-primary", to: Route::Playground {}, "Run a Test Request" }
+                    }
+                }
             } else {
+                div { class: "metrics",
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Observed Requests" } span { class: "metric-value", "{total_requests}" } span { class: "metric-note", "latest evaluation sample" } }
+                        div { class: "metric-icon tone-blue", Icon { name: "activity" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Success Rate" } span { class: "metric-value", "{overall_success_text}" } span { class: "metric-note", "HTTP success across sample" } }
+                        div { class: "metric-icon tone-green", Icon { name: "shield" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Average Latency" } span { class: "metric-value", "{avg_latency_text}" } span { class: "metric-note", "end-to-end observed" } }
+                        div { class: "metric-icon tone-purple", Icon { name: "chart" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Models With Errors" } span { class: "metric-value", "{models_with_errors}" } span { class: "metric-note", "of {model_count} observed models" } }
+                        div { class: "metric-icon tone-amber", Icon { name: "models" } }
+                    }
+                }
+
+                if models_with_errors > 0 || single_upstream_models > 0 {
+                    div { class: "card card-pad stack",
+                        div { class: "product-section-head",
+                            div {
+                                h3 { "Operational attention" }
+                                p { "These signals do not prove model quality, but they indicate where routing or upstream reliability deserves investigation." }
+                            }
+                        }
+                        if models_with_errors > 0 {
+                            div { class: "readiness-strip blocked",
+                                span { class: "readiness-dot" }
+                                strong { "{models_with_errors} models have at least one failed request in the loaded sample." }
+                                Link { class: "button button-ghost button-sm", to: Route::Logs {}, "Inspect failures" }
+                            }
+                        }
+                        if single_upstream_models > 0 {
+                            div { class: "readiness-strip blocked",
+                                span { class: "readiness-dot" }
+                                strong { "{single_upstream_models} observed models were served by one or fewer upstreams in this sample." }
+                                Link { class: "button button-ghost button-sm", to: Route::Models {}, "Review redundancy" }
+                            }
+                        }
+                    }
+                }
+
                 div { class: "card table-card",
-                    if models.is_empty() {
-                        div { class: "card-pad small muted", "No router-log model data is available yet." }
-                    } else {
-                        div { class: "table-wrap",
-                            table { class: "data-table",
-                                thead { tr {
-                                    th { "Model" }
-                                    th { class: "right", "Requests" }
-                                    th { class: "right", "Success" }
-                                    th { class: "right", "Avg Latency" }
-                                    th { class: "right", "All Tokens" }
-                                    th { class: "right", "Multimodal" }
-                                    th { class: "right", "Cost" }
-                                    th { "Observed Upstreams" }
-                                } }
-                                tbody {
-                                    for (model, eval) in models {
-                                        {
-                                            let success_rate = if eval.requests == 0 { 0.0 } else { eval.success as f64 * 100.0 / eval.requests as f64 };
-                                            let success_text = format!("{success_rate:.1}%");
-                                            let avg_latency = if eval.requests == 0 { 0 } else { eval.latency_sum / eval.requests };
-                                            let latency_text = format!("{avg_latency}ms");
-                                            let token_text = compact(eval.tokens);
-                                            let cost_text = format!("${:.6}", eval.cost);
-                                            let upstream_text = eval.upstreams.into_iter().collect::<Vec<_>>().join(", ");
-                                            rsx! {
-                                                tr { key: "{model}",
-                                                    td { class: "table-primary mono", "{model}" }
-                                                    td { class: "right tabular", "{eval.requests}" }
-                                                    td { class: "right strong tabular", "{success_text}" }
-                                                    td { class: "right tabular", "{latency_text}" }
-                                                    td { class: "right tabular", "{token_text}" }
-                                                    td { class: "right tabular", "{eval.multimodal_requests}" }
-                                                    td { class: "right tabular", "{cost_text}" }
-                                                    td { class: "muted", "{upstream_text}" }
-                                                }
+                    div { class: "card-pad product-section-head",
+                        div {
+                            h3 { "Model performance" }
+                            p { "Use this table to identify failures, slow models, high-cost models, and single-upstream observations." }
+                        }
+                    }
+                    div { class: "table-wrap",
+                        table { class: "data-table",
+                            thead { tr {
+                                th { "Model" }
+                                th { "Health" }
+                                th { class: "right", "Requests" }
+                                th { class: "right", "Success" }
+                                th { class: "right", "Avg Latency" }
+                                th { class: "right", "Tokens" }
+                                th { class: "right", "Multimodal" }
+                                th { class: "right", "Cost" }
+                                th { "Upstreams" }
+                            } }
+                            tbody {
+                                for (model_name, evaluation) in models {
+                                    {
+                                        let failures = evaluation.requests - evaluation.success;
+                                        let success_rate = if evaluation.requests == 0 {
+                                            0.0
+                                        } else {
+                                            evaluation.success as f64 * 100.0 / evaluation.requests as f64
+                                        };
+                                        let success_text = format!("{success_rate:.1}%");
+                                        let avg_latency = if evaluation.requests == 0 { 0 } else { evaluation.latency_sum / evaluation.requests };
+                                        let latency_text = format!("{avg_latency}ms");
+                                        let token_text = compact(evaluation.tokens);
+                                        let cost_text = format!("${:.6}", evaluation.cost);
+                                        let upstream_count = evaluation.upstreams.len();
+                                        let upstream_text = evaluation.upstreams.into_iter().collect::<Vec<_>>().join(", ");
+                                        let (health_class, health_text) = if failures > 0 {
+                                            ("badge badge-error", "Errors observed")
+                                        } else if upstream_count <= 1 {
+                                            ("badge badge-warning", "Single upstream")
+                                        } else {
+                                            ("badge badge-success", "Stable sample")
+                                        };
+                                        rsx! {
+                                            tr { key: "{model_name}",
+                                                td { class: "table-primary mono", "{model_name}" }
+                                                td { span { class: "{health_class}", "{health_text}" } }
+                                                td { class: "right tabular", "{evaluation.requests}" }
+                                                td { class: "right strong tabular", "{success_text}" }
+                                                td { class: "right tabular", "{latency_text}" }
+                                                td { class: "right tabular", "{token_text}" }
+                                                td { class: "right tabular", "{evaluation.multimodal_requests}" }
+                                                td { class: "right tabular", "{cost_text}" }
+                                                td { class: "muted", "{upstream_text}" }
                                             }
                                         }
                                     }
@@ -112,7 +215,8 @@ pub fn Evaluation() -> Element {
                         }
                     }
                 }
-                div { class: "card card-pad tiny subtle", "Evaluation is production-observability based. Quality/accuracy benchmarks still require a dedicated evaluation backend, which BurnCloud does not currently expose." }
+
+                div { class: "product-note", "Evaluation uses observed production/request-log data. Accuracy, hallucination rate, task quality, and benchmark scores require a dedicated evaluation backend and are intentionally not inferred here." }
             }
         }
     }

--- a/crates/client/src/functional_pages/catalog.rs
+++ b/crates/client/src/functional_pages/catalog.rs
@@ -5,71 +5,146 @@ use dioxus::prelude::*;
 use crate::{
     app::Route,
     backend::{Channel, ChannelService},
+    components::Icon,
 };
 
 fn status_label(channel: &Channel) -> &'static str {
     if channel.status == 1 { "Active" } else { "Down" }
 }
 
+#[derive(Default)]
+struct ModelAvailability {
+    providers: BTreeSet<String>,
+    active_providers: BTreeSet<String>,
+    groups: BTreeSet<String>,
+}
+
 #[component]
 pub fn Models() -> Element {
     let mut resource = use_resource(move || async move { ChannelService::list(100).await });
     let snapshot = resource.read().clone();
-    let error = snapshot.as_ref().and_then(|r| r.as_ref().err().cloned());
+    let load_error = snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
     let channels = snapshot.and_then(Result::ok).unwrap_or_default();
-    let no_channels = channels.is_empty();
 
-    let mut model_map: BTreeMap<String, (usize, usize, BTreeSet<String>)> = BTreeMap::new();
+    let mut model_map: BTreeMap<String, ModelAvailability> = BTreeMap::new();
     for channel in &channels {
-        for model in channel.models.split(',').map(str::trim).filter(|m| !m.is_empty()) {
-            let entry = model_map
-                .entry(model.to_string())
-                .or_insert((0, 0, BTreeSet::new()));
-            entry.0 += 1;
+        for model in channel.models.split(',').map(str::trim).filter(|model| !model.is_empty()) {
+            let entry = model_map.entry(model.to_string()).or_default();
+            entry.providers.insert(channel.name.clone());
             if channel.status == 1 {
-                entry.1 += 1;
+                entry.active_providers.insert(channel.name.clone());
             }
-            entry.2.insert(channel.name.clone());
+            for group in channel.group.split(',').map(str::trim).filter(|group| !group.is_empty()) {
+                entry.groups.insert(group.to_string());
+            }
         }
     }
+
+    let total_models = model_map.len();
+    let available_models = model_map.values().filter(|model| !model.active_providers.is_empty()).count();
+    let redundant_models = model_map.values().filter(|model| model.active_providers.len() >= 2).count();
+    let unavailable_models = total_models.saturating_sub(available_models);
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
                     h2 { class: "page-title", "Models" }
-                    p { class: "page-subtitle", "Derived from real Channel.models. The server has no independent model CRUD API." }
+                    p { class: "page-subtitle", "See which model IDs BurnCloud can actually serve and whether each model has upstream redundancy." }
                 }
-                button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
+                div { class: "header-actions",
+                    button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
+                    Link { class: "button button-primary", to: Route::Providers {}, "Manage Providers" }
+                }
             }
 
-            if let Some(message) = error {
-                div { class: "terminal auth-status auth-status-error", "{message}" }
+            div { class: "metrics",
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Models" } span { class: "metric-value", "{total_models}" } span { class: "metric-note", "derived from providers" } }
+                    div { class: "metric-icon tone-blue", Icon { name: "models" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Available" } span { class: "metric-value", "{available_models}" } span { class: "metric-note", "at least one active upstream" } }
+                    div { class: "metric-icon tone-green", Icon { name: "activity" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Redundant" } span { class: "metric-value", "{redundant_models}" } span { class: "metric-note", "2+ active upstreams" } }
+                    div { class: "metric-icon tone-purple", Icon { name: "routes" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Unavailable" } span { class: "metric-value", "{unavailable_models}" } span { class: "metric-note", "needs provider attention" } }
+                    div { class: "metric-icon tone-amber", Icon { name: "shield" } }
+                }
+            }
+
+            if let Some(message) = load_error {
+                div { class: "card card-pad stack",
+                    strong { class: "danger", "Model catalog could not be built" }
+                    code { class: "terminal", "{message}" }
+                    button { class: "button button-primary", onclick: move |_| resource.restart(), "Retry" }
+                }
+            } else if model_map.is_empty() {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "models" } }
+                        h3 { "No models are exposed yet" }
+                        p { "BurnCloud derives the model catalog from provider configuration. Add a provider or add model IDs to an existing provider." }
+                        Link { class: "button button-primary", to: Route::Providers {}, "Configure Providers" }
+                    }
+                }
             } else {
                 div { class: "card table-card",
-                    if no_channels {
-                        div { class: "card-pad small muted", "No channels configured." }
-                    } else {
-                        div { class: "table-wrap",
-                            table { class: "data-table",
-                                thead { tr {
-                                    th { "Model" }
-                                    th { class: "right", "Providers" }
-                                    th { class: "right", "Active" }
-                                    th { "Source Channels" }
-                                    th { "Management" }
-                                } }
-                                tbody {
-                                    for (model, (providers, active, sources)) in model_map {
-                                        {
-                                            let source_text = sources.into_iter().collect::<Vec<_>>().join(", ");
-                                            rsx! {
-                                                tr { key: "{model}",
-                                                    td { class: "table-primary mono", "{model}" }
-                                                    td { class: "right tabular", "{providers}" }
-                                                    td { class: "right tabular", "{active}" }
-                                                    td { "{source_text}" }
-                                                    td { Link { class: "button button-ghost button-sm", to: Route::Providers {}, "Edit Providers" } }
+                    div { class: "card-pad product-section-head",
+                        div {
+                            h3 { "Model availability" }
+                            p { "Availability reflects active providers now; redundancy highlights models that can survive one upstream failure." }
+                        }
+                    }
+                    div { class: "table-wrap",
+                        table { class: "data-table",
+                            thead { tr {
+                                th { "Model" }
+                                th { "Availability" }
+                                th { "Active Upstreams" }
+                                th { "Routing Groups" }
+                                th { class: "right", "Action" }
+                            } }
+                            tbody {
+                                for (model_name, availability) in model_map {
+                                    {
+                                        let active_count = availability.active_providers.len();
+                                        let total_count = availability.providers.len();
+                                        let active_text = availability.active_providers.iter().cloned().collect::<Vec<_>>().join(", ");
+                                        let group_text = availability.groups.iter().cloned().collect::<Vec<_>>().join(", ");
+                                        let (badge_class, badge_text, note) = if active_count == 0 {
+                                            ("badge badge-error", "Unavailable", "No active upstream")
+                                        } else if active_count == 1 {
+                                            ("badge badge-warning", "Single upstream", "No failover redundancy")
+                                        } else {
+                                            ("badge badge-success", "Redundant", "Failover available")
+                                        };
+                                        rsx! {
+                                            tr { key: "{model_name}",
+                                                td {
+                                                    div { class: "two-line",
+                                                        strong { class: "table-primary mono", "{model_name}" }
+                                                        small { class: "muted", "{total_count} configured providers" }
+                                                    }
+                                                }
+                                                td {
+                                                    div { class: "two-line",
+                                                        span { class: "{badge_class}", "{badge_text}" }
+                                                        small { class: "muted", "{note}" }
+                                                    }
+                                                }
+                                                td { class: "small", if active_text.is_empty() { "—" } else { "{active_text}" } }
+                                                td { class: "mono muted", "{group_text}" }
+                                                td { class: "right",
+                                                    if active_count > 0 {
+                                                        Link { class: "button button-ghost button-sm", to: Route::Playground {}, "Test" }
+                                                    } else {
+                                                        Link { class: "button button-ghost button-sm", to: Route::Providers {}, "Fix Provider" }
+                                                    }
                                                 }
                                             }
                                         }
@@ -88,69 +163,139 @@ pub fn Models() -> Element {
 pub fn Routes() -> Element {
     let mut resource = use_resource(move || async move { ChannelService::list(100).await });
     let snapshot = resource.read().clone();
-    let error = snapshot.as_ref().and_then(|r| r.as_ref().err().cloned());
+    let load_error = snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
     let channels = snapshot.and_then(Result::ok).unwrap_or_default();
 
     let mut groups: BTreeMap<String, Vec<Channel>> = BTreeMap::new();
     for channel in channels {
-        groups.entry(channel.group.clone()).or_default().push(channel);
+        for group in channel.group.split(',').map(str::trim).filter(|group| !group.is_empty()) {
+            groups.entry(group.to_string()).or_default().push(channel.clone());
+        }
     }
     for rows in groups.values_mut() {
         rows.sort_by_key(|channel| (channel.priority, -channel.weight));
     }
+
+    let route_groups = groups.len();
+    let healthy_groups = groups
+        .values()
+        .filter(|rows| rows.iter().any(|channel| channel.status == 1))
+        .count();
+    let redundant_groups = groups
+        .values()
+        .filter(|rows| rows.iter().filter(|channel| channel.status == 1).count() >= 2)
+        .count();
+    let unavailable_groups = route_groups.saturating_sub(healthy_groups);
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
                     h2 { class: "page-title", "Routes" }
-                    p { class: "page-subtitle", "Derived from Channel.group, priority and weight — the routing configuration BurnCloud actually stores." }
+                    p { class: "page-subtitle", "Understand how traffic groups choose providers and where a routing group still depends on a single upstream." }
                 }
-                button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
+                div { class: "header-actions",
+                    button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
+                    Link { class: "button button-primary", to: Route::Providers {}, "Manage Routing Inputs" }
+                }
             }
 
-            if let Some(message) = error {
-                div { class: "terminal auth-status auth-status-error", "{message}" }
+            div { class: "metrics",
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Routing Groups" } span { class: "metric-value", "{route_groups}" } span { class: "metric-note", "traffic policies" } }
+                    div { class: "metric-icon tone-blue", Icon { name: "routes" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Available" } span { class: "metric-value", "{healthy_groups}" } span { class: "metric-note", "has an active provider" } }
+                    div { class: "metric-icon tone-green", Icon { name: "activity" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Redundant" } span { class: "metric-value", "{redundant_groups}" } span { class: "metric-note", "2+ active candidates" } }
+                    div { class: "metric-icon tone-purple", Icon { name: "shield" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Unavailable" } span { class: "metric-value", "{unavailable_groups}" } span { class: "metric-note", "no active candidate" } }
+                    div { class: "metric-icon tone-amber", Icon { name: "providers" } }
+                }
+            }
+
+            if let Some(message) = load_error {
+                div { class: "card card-pad stack",
+                    strong { class: "danger", "Routes could not be derived" }
+                    code { class: "terminal", "{message}" }
+                    button { class: "button button-primary", onclick: move |_| resource.restart(), "Retry" }
+                }
             } else if groups.is_empty() {
-                div { class: "card card-pad small muted", "No routing groups can be derived until provider channels are configured." }
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "routes" } }
+                        h3 { "No routing groups yet" }
+                        p { "Routing groups come from provider configuration. Connect a provider and assign it to a group before traffic can be evaluated here." }
+                        Link { class: "button button-primary", to: Route::Providers {}, "Configure Providers" }
+                    }
+                }
             } else {
                 div { class: "stack-lg",
                     for (group_name, rows) in groups {
-                        div { class: "card card-pad stack",
-                            div { class: "row between",
-                                div {
-                                    h3 { "{group_name}" }
-                                    span { class: "small muted", "{rows.len()} channel candidates" }
-                                }
-                                Link { class: "button button-secondary button-sm", to: Route::Providers {}, "Manage Channels" }
-                            }
-                            div { class: "table-wrap",
-                                table { class: "data-table",
-                                    thead { tr {
-                                        th { "Order" }
-                                        th { "Provider" }
-                                        th { "Models" }
-                                        th { class: "right", "Priority" }
-                                        th { class: "right", "Weight" }
-                                        th { "Status" }
-                                    } }
-                                    tbody {
-                                        for (index, channel) in rows.iter().enumerate() {
-                                            {
-                                                let order = index + 1;
-                                                let status = status_label(channel);
-                                                rsx! {
-                                                    tr { key: "{channel.id}",
-                                                        td { class: "mono", "#{order}" }
-                                                        td { class: "table-primary", "{channel.name}" }
-                                                        td { class: "mono muted", "{channel.models}" }
-                                                        td { class: "right tabular", "{channel.priority}" }
-                                                        td { class: "right tabular", "{channel.weight}" }
-                                                        td { span { class: if channel.status == 1 { "badge badge-success" } else { "badge badge-error" }, "{status}" } }
+                        {
+                            let active_count = rows.iter().filter(|channel| channel.status == 1).count();
+                            let model_count = rows
+                                .iter()
+                                .flat_map(|channel| channel.models.split(',').map(str::trim).filter(|model| !model.is_empty()).map(str::to_string))
+                                .collect::<BTreeSet<_>>()
+                                .len();
+                            let (health_class, health_text) = if active_count == 0 {
+                                ("badge badge-error", "Unavailable")
+                            } else if active_count == 1 {
+                                ("badge badge-warning", "Single upstream")
+                            } else {
+                                ("badge badge-success", "Redundant")
+                            };
+                            rsx! {
+                                div { class: "card card-pad stack",
+                                    div { class: "product-section-head",
+                                        div {
+                                            div { class: "row gap-2",
+                                                h3 { "{group_name}" }
+                                                span { class: "{health_class}", "{health_text}" }
+                                            }
+                                            p { "{active_count} active of {rows.len()} candidates • {model_count} model IDs available" }
+                                        }
+                                        Link { class: "button button-secondary button-sm", to: Route::Providers {}, "Edit Providers" }
+                                    }
+                                    div { class: "table-wrap",
+                                        table { class: "data-table",
+                                            thead { tr {
+                                                th { "Preference" }
+                                                th { "Provider" }
+                                                th { "Status" }
+                                                th { "Models" }
+                                                th { class: "right", "Priority" }
+                                                th { class: "right", "Weight" }
+                                            } }
+                                            tbody {
+                                                for (index, channel) in rows.iter().enumerate() {
+                                                    {
+                                                        let preference = index + 1;
+                                                        let status = status_label(channel);
+                                                        let model_count = channel.models.split(',').map(str::trim).filter(|model| !model.is_empty()).count();
+                                                        rsx! {
+                                                            tr { key: "{channel.id}",
+                                                                td { class: "mono", "#{preference}" }
+                                                                td { class: "table-primary", "{channel.name}" }
+                                                                td { span { class: if channel.status == 1 { "badge badge-success" } else { "badge badge-error" }, "{status}" } }
+                                                                td { "{model_count} models" }
+                                                                td { class: "right tabular", "{channel.priority}" }
+                                                                td { class: "right tabular", "{channel.weight}" }
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
                                         }
+                                    }
+                                    if active_count == 1 {
+                                        div { class: "product-note", "This routing group currently has a single active upstream. Adding a second provider with overlapping model coverage improves failover resilience." }
                                     }
                                 }
                             }

--- a/crates/client/src/functional_pages/guardrails_live.rs
+++ b/crates/client/src/functional_pages/guardrails_live.rs
@@ -1,35 +1,320 @@
 use dioxus::prelude::*;
-use crate::{components::Icon,functional_api::{circuit_breaker_status,emergency_circuit_break,risk_events,save_security_filters,security_filters,security_summary,RiskEventPage,SecurityFilters,SecuritySummary}};
+
+use crate::{
+    components::Icon,
+    functional_api::{
+        circuit_breaker_status, emergency_circuit_break, risk_events, save_security_filters,
+        security_filters, security_summary, RiskEventPage, SecurityFilters, SecuritySummary,
+    },
+};
 
 #[component]
-pub fn Guardrails()->Element{
-    let mut summary_res=use_resource(move||async move{security_summary().await});
-    let mut filters_res=use_resource(move||async move{security_filters().await});
-    let mut events_res=use_resource(move||async move{risk_events().await});
-    let mut breaker_res=use_resource(move||async move{circuit_breaker_status().await});
-    let mut filter_state=use_signal(SecurityFilters::default);let mut synced=use_signal(||false);let mut new_rule=use_signal(String::new);let mut reason=use_signal(String::new);let mut busy=use_signal(||false);let mut notice=use_signal(String::new);let mut error=use_signal(String::new);
-    let filters_snapshot=filters_res.read().clone();
-    if !synced(){if let Some(Ok(server))=filters_snapshot.clone(){filter_state.set(server);synced.set(true);}}
-    let summary_snapshot=summary_res.read().clone();let summary:SecuritySummary=summary_snapshot.clone().and_then(Result::ok).unwrap_or_default();
-    let events_snapshot=events_res.read().clone();let events:RiskEventPage=events_snapshot.clone().and_then(Result::ok).unwrap_or_default();
-    let breaker_text=match breaker_res.read().clone(){Some(Ok(v))=>serde_json::to_string_pretty(&v).unwrap_or_else(|_|v.to_string()),Some(Err(e))=>format!("Unavailable: {e}"),None=>"Loading circuit breaker status…".to_string()};
-    let state=filter_state();let content_enabled=state.content_filter_enabled;let blacklist_enabled=state.blacklist_enabled;let rules=state.custom_rules.clone();
-    let mut load_errors=Vec::new();if let Some(Err(e))=summary_snapshot{load_errors.push(format!("Security summary: {e}"));}if let Some(Err(e))=filters_snapshot{load_errors.push(format!("Filters: {e}"));}if let Some(Err(e))=events_snapshot{load_errors.push(format!("Risk events: {e}"));}
-    rsx!{
-        div{class:"page",
-            div{class:"page-header",div{h2{class:"page-title","Guardrails"}p{class:"page-subtitle","Live security score, persisted filters, router-derived risk events and the real circuit breaker."}}button{class:"button button-secondary",onclick:move |_|{synced.set(false);summary_res.restart();filters_res.restart();events_res.restart();breaker_res.restart();},"Refresh"}}
-            if !notice().is_empty(){div{class:"terminal auth-status","{notice}"}}if !error().is_empty(){div{class:"terminal auth-status auth-status-error","{error}"}}if !load_errors.is_empty(){div{class:"card card-pad stack",for message in load_errors{code{class:"terminal","{message}"}}}}
-            div{class:"metrics",div{class:"card metric",div{class:"metric-copy",span{class:"metric-label","Security Score"}span{class:"metric-value","{summary.score}/100"}}div{class:"metric-icon tone-green",Icon{name:"shield"}}}div{class:"card metric",div{class:"metric-copy",span{class:"metric-label","Blocked / Error Events"}span{class:"metric-value","{summary.blocked_count}"}}}div{class:"card metric",div{class:"metric-copy",span{class:"metric-label","Threat Sources"}span{class:"metric-value","{summary.threat_source_count}"}}}}
-            div{class:"grid-2",
-                div{class:"card card-pad stack-lg",h3{"Security Filters"}
-                    label{class:"row between",span{div{class:"strong","Content Filter"}small{class:"muted","Persisted in BurnCloud security_filters"}}input{r#type:"checkbox",checked:content_enabled,onchange:move |_|{let mut next=filter_state();next.content_filter_enabled=!next.content_filter_enabled;filter_state.set(next);}}}
-                    label{class:"row between",span{div{class:"strong","Blacklist"}small{class:"muted","Persisted in BurnCloud security_filters"}}input{r#type:"checkbox",checked:blacklist_enabled,onchange:move |_|{let mut next=filter_state();next.blacklist_enabled=!next.blacklist_enabled;filter_state.set(next);}}}
-                    div{class:"field",label{"Custom Rules"}for(index,rule)in rules.iter().enumerate(){{let idx=index;rsx!{div{class:"row between card card-pad",key:"{idx}",code{"{rule}"}button{class:"button button-ghost button-sm danger",onclick:move |_|{let mut next=filter_state();if idx<next.custom_rules.len(){next.custom_rules.remove(idx);}filter_state.set(next);},"Remove"}}}}}div{class:"row gap-2",input{class:"input",value:"{new_rule}",placeholder:"Add custom security rule",oninput:move|e|new_rule.set(e.value())}button{class:"button button-secondary",onclick:move |_|{let rule=new_rule().trim().to_string();if !rule.is_empty(){let mut next=filter_state();next.custom_rules.push(rule);filter_state.set(next);new_rule.set(String::new());}},"Add"}}}
-                    button{class:"button button-primary",disabled:busy(),onclick:move |_|{let payload=filter_state();busy.set(true);error.set(String::new());spawn(async move{match save_security_filters(&payload).await{Ok(saved)=>{filter_state.set(saved);notice.set("Security filters saved.".to_string());filters_res.restart();},Err(e)=>error.set(format!("Save failed: {e}"))}busy.set(false);});},"Save Guardrails"}
+pub fn Guardrails() -> Element {
+    let mut summary_resource = use_resource(move || async move { security_summary().await });
+    let mut filters_resource = use_resource(move || async move { security_filters().await });
+    let mut events_resource = use_resource(move || async move { risk_events().await });
+    let mut breaker_resource = use_resource(move || async move { circuit_breaker_status().await });
+
+    let mut filter_state = use_signal(SecurityFilters::default);
+    let mut synced = use_signal(|| false);
+    let mut new_rule = use_signal(String::new);
+    let mut reason = use_signal(String::new);
+    let mut confirm_trip = use_signal(|| false);
+    let mut busy = use_signal(|| false);
+    let mut notice = use_signal(String::new);
+    let mut error = use_signal(String::new);
+
+    let filter_snapshot = filters_resource.read().clone();
+    if !synced() {
+        if let Some(Ok(server_filters)) = filter_snapshot.clone() {
+            filter_state.set(server_filters);
+            synced.set(true);
+        }
+    }
+
+    let summary_snapshot = summary_resource.read().clone();
+    let event_snapshot = events_resource.read().clone();
+    let summary: SecuritySummary = summary_snapshot.clone().and_then(Result::ok).unwrap_or_default();
+    let events: RiskEventPage = event_snapshot.clone().and_then(Result::ok).unwrap_or_default();
+    let breaker_text = match breaker_resource.read().clone() {
+        Some(Ok(value)) => serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+        Some(Err(message)) => format!("Unavailable: {message}"),
+        None => "Loading circuit breaker state…".to_string(),
+    };
+
+    let filters = filter_state();
+    let content_enabled = filters.content_filter_enabled;
+    let blacklist_enabled = filters.blacklist_enabled;
+    let rules = filters.custom_rules.clone();
+    let enabled_controls = usize::from(content_enabled) + usize::from(blacklist_enabled) + rules.len();
+
+    let mut load_errors = Vec::new();
+    if let Some(Err(message)) = summary_snapshot {
+        load_errors.push(format!("Security summary: {message}"));
+    }
+    if let Some(Err(message)) = filter_snapshot {
+        load_errors.push(format!("Filters: {message}"));
+    }
+    if let Some(Err(message)) = event_snapshot {
+        load_errors.push(format!("Risk events: {message}"));
+    }
+
+    rsx! {
+        div { class: "page",
+            div { class: "page-header",
+                div {
+                    h2 { class: "page-title", "Guardrails" }
+                    p { class: "page-subtitle", "Set normal traffic protections, review security events, and keep emergency shutdown separate from routine configuration." }
                 }
-                div{class:"stack-lg",div{class:"card card-pad stack",div{class:"row between",h3{"Circuit Breaker Status"}button{class:"button button-ghost button-sm",onclick:move |_|breaker_res.restart(),"Refresh"}}pre{class:"terminal",style:"max-height:240px;overflow:auto;white-space:pre-wrap","{breaker_text}"}}div{class:"card card-pad stack",h3{class:"danger","Emergency Circuit Break"}p{class:"small muted","Operational action: trip all router circuits. A reason is required."}textarea{class:"textarea",rows:"3",value:"{reason}",placeholder:"Reason for emergency stop",oninput:move|e|reason.set(e.value())}button{class:"button button-primary",disabled:busy()||reason().trim().is_empty(),onclick:move |_|{let why=reason().trim().to_string();busy.set(true);error.set(String::new());spawn(async move{match emergency_circuit_break(&why).await{Ok(v)=>{notice.set(format!("Emergency circuit break accepted: {v}"));breaker_res.restart();},Err(e)=>error.set(format!("Circuit break failed: {e}"))}busy.set(false);});},"Trip All Circuits"}}}
+                button {
+                    class: "button button-secondary",
+                    onclick: move |_| {
+                        synced.set(false);
+                        summary_resource.restart();
+                        filters_resource.restart();
+                        events_resource.restart();
+                        breaker_resource.restart();
+                    },
+                    "Refresh"
+                }
             }
-            div{class:"card table-card",div{class:"card-pad row between",h3{"Risk Events"}span{class:"small muted","{events.total} events"}}if events.data.is_empty(){div{class:"card-pad small muted","No HTTP 4xx/5xx risk events derived from router logs."}}else{div{class:"table-wrap",table{class:"data-table",thead{tr{th{"Time"}th{"Source"}th{"Target"}th{"Type"}th{"Severity"}th{"Status"}th{"Detail"}}}tbody{for event in events.data{tr{key:"{event.id}",td{class:"mono muted","{event.time}"}td{class:"mono","{event.source}"}td{class:"mono","{event.target}"}td{"{event.event_type}"}td{span{class:if event.severity=="critical"{"badge badge-error"}else{"badge badge-warning"},"{event.severity}"}}td{"{event.status}"}td{"{event.detail}"}}}}}}}}
+
+            if !notice().is_empty() { div { class: "terminal auth-status", "{notice}" } }
+            if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
+            if !load_errors.is_empty() {
+                div { class: "card card-pad stack",
+                    strong { class: "danger", "Some security data is unavailable" }
+                    for message in load_errors { code { class: "terminal", "{message}" } }
+                }
+            }
+
+            div { class: "metrics",
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Security Score" } span { class: "metric-value", "{summary.score}/100" } span { class: "metric-note", "server-calculated posture" } }
+                    div { class: "metric-icon tone-green", Icon { name: "shield" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Blocked / Error Events" } span { class: "metric-value", "{summary.blocked_count}" } span { class: "metric-note", "observed risk events" } }
+                    div { class: "metric-icon tone-amber", Icon { name: "logs" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Threat Sources" } span { class: "metric-value", "{summary.threat_source_count}" } span { class: "metric-note", "distinct sources" } }
+                    div { class: "metric-icon tone-red", Icon { name: "users" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Policy Controls" } span { class: "metric-value", "{enabled_controls}" } span { class: "metric-note", "enabled toggles + rules" } }
+                    div { class: "metric-icon tone-purple", Icon { name: "settings" } }
+                }
+            }
+
+            div { class: "grid-2",
+                div { class: "card card-pad stack-lg",
+                    div { class: "product-section-head",
+                        div {
+                            h3 { "Traffic protection policy" }
+                            p { "Routine safeguards belong here. Changes are staged locally until Save Guardrails is pressed." }
+                        }
+                    }
+
+                    label { class: "row between",
+                        span {
+                            div { class: "strong", "Content Filter" }
+                            small { class: "muted", "Apply the server's content-filtering policy to routed traffic." }
+                        }
+                        input {
+                            r#type: "checkbox",
+                            checked: content_enabled,
+                            onchange: move |_| {
+                                let mut next = filter_state();
+                                next.content_filter_enabled = !next.content_filter_enabled;
+                                filter_state.set(next);
+                            },
+                        }
+                    }
+
+                    label { class: "row between",
+                        span {
+                            div { class: "strong", "Blacklist" }
+                            small { class: "muted", "Enable the persisted blacklist protection." }
+                        }
+                        input {
+                            r#type: "checkbox",
+                            checked: blacklist_enabled,
+                            onchange: move |_| {
+                                let mut next = filter_state();
+                                next.blacklist_enabled = !next.blacklist_enabled;
+                                filter_state.set(next);
+                            },
+                        }
+                    }
+
+                    div { class: "field",
+                        label { "Custom rules" }
+                        if rules.is_empty() {
+                            div { class: "product-note", "No custom rules. BurnCloud will rely on the enabled built-in protections." }
+                        }
+                        for (index, rule) in rules.iter().enumerate() {
+                            {
+                                let rule_index = index;
+                                rsx! {
+                                    div { class: "row between card card-pad", key: "{rule_index}",
+                                        code { "{rule}" }
+                                        button {
+                                            class: "button button-ghost button-sm danger",
+                                            onclick: move |_| {
+                                                let mut next = filter_state();
+                                                if rule_index < next.custom_rules.len() {
+                                                    next.custom_rules.remove(rule_index);
+                                                }
+                                                filter_state.set(next);
+                                            },
+                                            "Remove"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        div { class: "row gap-2",
+                            input { class: "input", value: "{new_rule}", placeholder: "Add a custom security rule", oninput: move |event| new_rule.set(event.value()) }
+                            button {
+                                class: "button button-secondary",
+                                onclick: move |_| {
+                                    let rule = new_rule().trim().to_string();
+                                    if !rule.is_empty() {
+                                        let mut next = filter_state();
+                                        next.custom_rules.push(rule);
+                                        filter_state.set(next);
+                                        new_rule.set(String::new());
+                                    }
+                                },
+                                "Add Rule"
+                            }
+                        }
+                    }
+
+                    button {
+                        class: "button button-primary",
+                        disabled: busy(),
+                        onclick: move |_| {
+                            let payload = filter_state();
+                            busy.set(true);
+                            error.set(String::new());
+                            spawn(async move {
+                                match save_security_filters(&payload).await {
+                                    Ok(saved) => {
+                                        filter_state.set(saved);
+                                        notice.set("Guardrail policy saved.".to_string());
+                                        filters_resource.restart();
+                                    }
+                                    Err(message) => error.set(format!("Save guardrails failed: {message}")),
+                                }
+                                busy.set(false);
+                            });
+                        },
+                        "Save Guardrails"
+                    }
+                }
+
+                div { class: "card card-pad stack-lg",
+                    div { class: "product-section-head",
+                        div {
+                            h3 { "Protection state" }
+                            p { "Operational circuit-breaker state is visible here without mixing it with emergency actions." }
+                        }
+                        button { class: "button button-ghost button-sm", onclick: move |_| breaker_resource.restart(), "Refresh" }
+                    }
+                    div { class: "readiness-strip ready",
+                        span { class: "readiness-dot" }
+                        strong { "Circuit breaker telemetry connected" }
+                    }
+                    details {
+                        summary { class: "small strong", style: "cursor:pointer", "View raw circuit breaker state" }
+                        pre { class: "terminal", style: "margin-top:12px;max-height:260px;overflow:auto;white-space:pre-wrap", "{breaker_text}" }
+                    }
+                    div { class: "product-note", "The server currently returns circuit-breaker state as structured operational data. This UI keeps the raw payload available for diagnosis rather than guessing at fields it does not own." }
+                }
+            }
+
+            div { class: "card table-card",
+                div { class: "card-pad product-section-head",
+                    div {
+                        h3 { "Risk events" }
+                        p { "Recent HTTP error and security-related events derived by the server from router activity." }
+                    }
+                    span { class: "small muted", "{events.total} events" }
+                }
+                if events.data.is_empty() {
+                    div { class: "product-empty", style: "min-height:170px",
+                        div { class: "product-empty-inner",
+                            div { class: "product-empty-icon", Icon { name: "shield" } }
+                            h3 { "No risk events in this view" }
+                            p { "No HTTP 4xx/5xx security events were returned by the current server query." }
+                        }
+                    }
+                } else {
+                    div { class: "table-wrap",
+                        table { class: "data-table",
+                            thead { tr { th { "Time" } th { "Severity" } th { "Type" } th { "Source" } th { "Target" } th { "Status" } th { "Detail" } } }
+                            tbody {
+                                for event in events.data {
+                                    tr { key: "{event.id}",
+                                        td { class: "mono muted", "{event.time}" }
+                                        td { span { class: if event.severity == "critical" { "badge badge-error" } else { "badge badge-warning" }, "{event.severity}" } }
+                                        td { "{event.event_type}" }
+                                        td { class: "mono", "{event.source}" }
+                                        td { class: "mono", "{event.target}" }
+                                        td { "{event.status}" }
+                                        td { "{event.detail}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            div { class: "card card-pad stack-lg danger-zone",
+                div { class: "product-section-head",
+                    div {
+                        h3 { class: "danger", "Emergency traffic stop" }
+                        p { "Use only when continuing upstream traffic is more dangerous than an immediate outage." }
+                    }
+                    span { class: "badge badge-error", "DANGER ZONE" }
+                }
+                p { class: "small muted", "Trip All Circuits is a real operational command. It can stop upstream routing across the environment. This action is deliberately separated from normal guardrail editing." }
+                div { class: "field",
+                    label { "Incident reason" }
+                    textarea { class: "textarea", rows: "3", value: "{reason}", placeholder: "Describe why all routing must be stopped now", oninput: move |event| reason.set(event.value()) }
+                }
+                label { class: "row gap-2 small", style: "align-items:flex-start",
+                    input { r#type: "checkbox", checked: confirm_trip(), onchange: move |_| confirm_trip.set(!confirm_trip()) }
+                    span { "I understand this can interrupt all routed traffic in the environment." }
+                }
+                div { class: "row",
+                    button {
+                        class: "button button-primary",
+                        disabled: busy() || reason().trim().is_empty() || !confirm_trip(),
+                        onclick: move |_| {
+                            let incident_reason = reason().trim().to_string();
+                            busy.set(true);
+                            error.set(String::new());
+                            spawn(async move {
+                                match emergency_circuit_break(&incident_reason).await {
+                                    Ok(value) => {
+                                        notice.set(format!("Emergency circuit break accepted: {value}"));
+                                        reason.set(String::new());
+                                        confirm_trip.set(false);
+                                        breaker_resource.restart();
+                                    }
+                                    Err(message) => error.set(format!("Emergency circuit break failed: {message}")),
+                                }
+                                busy.set(false);
+                            });
+                        },
+                        if busy() { "Stopping Traffic…" } else { "Trip All Circuits" }
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/client/src/functional_pages/logs_full.rs
+++ b/crates/client/src/functional_pages/logs_full.rs
@@ -61,9 +61,9 @@ pub fn Logs() -> Element {
 
     let snapshot = resource.read().clone();
     let loading = snapshot.is_none();
-    let load_error = snapshot.as_ref().and_then(|r| r.as_ref().err().cloned());
+    let load_error = snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
     let rows = snapshot.and_then(Result::ok).unwrap_or_default();
-    let q = query().to_lowercase();
+    let search = query().to_lowercase();
     let filter_value = filter();
 
     let visible: Vec<FullRouterLog> = rows
@@ -71,38 +71,51 @@ pub fn Logs() -> Element {
         .filter(|log| {
             let status = log.status_label();
             let status_match = filter_value == "all" || status.to_lowercase() == filter_value;
-            let text_match = q.is_empty()
-                || log.request_id.to_lowercase().contains(&q)
-                || log.path.to_lowercase().contains(&q)
-                || log.user_id.as_deref().unwrap_or("").to_lowercase().contains(&q)
-                || log.model.as_deref().unwrap_or("").to_lowercase().contains(&q)
-                || log.upstream_id.as_deref().unwrap_or("").to_lowercase().contains(&q)
-                || log.error_type.as_deref().unwrap_or("").to_lowercase().contains(&q);
+            let text_match = search.is_empty()
+                || log.request_id.to_lowercase().contains(&search)
+                || log.path.to_lowercase().contains(&search)
+                || log.user_id.as_deref().unwrap_or("").to_lowercase().contains(&search)
+                || log.model.as_deref().unwrap_or("").to_lowercase().contains(&search)
+                || log.upstream_id.as_deref().unwrap_or("").to_lowercase().contains(&search)
+                || log.error_type.as_deref().unwrap_or("").to_lowercase().contains(&search);
             status_match && text_match
         })
         .cloned()
         .collect();
 
-    let success = rows.iter().filter(|r| r.status_label() == "Success").count();
-    let fallback = rows.iter().filter(|r| r.status_label() == "Fallback").count();
+    let success = rows.iter().filter(|log| log.status_label() == "Success").count();
+    let fallback = rows.iter().filter(|log| log.status_label() == "Fallback").count();
     let failures = rows.len().saturating_sub(success + fallback);
-    let avg_latency = if rows.is_empty() { 0 } else { rows.iter().map(|r| r.latency_ms).sum::<i64>() / rows.len() as i64 };
-    let token_total = rows.iter().map(FullRouterLog::total_tokens).sum::<i64>();
+    let avg_latency = if rows.is_empty() {
+        0
+    } else {
+        rows.iter().map(|log| log.latency_ms).sum::<i64>() / rows.len() as i64
+    };
+    let failure_rate = if rows.is_empty() {
+        0.0
+    } else {
+        failures as f64 * 100.0 / rows.len() as f64
+    };
+    let failure_rate_text = format!("{failure_rate:.1}% of loaded requests");
+    let total_cost = rows.iter().map(FullRouterLog::cost_usd).sum::<f64>();
+    let total_cost_text = format!("${total_cost:.4}");
+    let visible_count = visible.len();
+    let row_count = rows.len();
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
                     h2 { class: "page-title", "Logs" }
-                    p { class: "page-subtitle", "Full router_logs schema including multimodal token and per-type cost fields." }
+                    p { class: "page-subtitle", "Find failed, slow, or fallback requests first, then inspect the exact routing and usage metadata behind each request." }
                 }
                 div { class: "header-actions",
                     div { class: "search-field", style: "width:300px",
                         Icon { name: "search" }
-                        input { class: "input", placeholder: "Request, user, model, upstream, error…", value: "{query}", oninput: move |e| query.set(e.value()) }
+                        input { class: "input", placeholder: "Request, model, upstream, user…", value: "{query}", oninput: move |event| query.set(event.value()) }
                     }
-                    select { class: "select", value: "{filter}", onchange: move |e| filter.set(e.value()),
-                        option { value: "all", "All statuses" }
+                    select { class: "select", value: "{filter}", onchange: move |event| filter.set(event.value()),
+                        option { value: "all", "All outcomes" }
                         option { value: "success", "Success" }
                         option { value: "fallback", "Fallback" }
                         option { value: "timeout", "Timeout" }
@@ -113,42 +126,84 @@ pub fn Logs() -> Element {
             }
 
             div { class: "metrics",
-                div { class: "card metric", div { class: "metric-copy", span { class: "metric-label", "Loaded Requests" } span { class: "metric-value", "{rows.len()}" } } div { class: "metric-icon tone-blue", Icon { name: "logs" } } }
-                div { class: "card metric", div { class: "metric-copy", span { class: "metric-label", "Success" } span { class: "metric-value", "{success}" } } div { class: "metric-icon tone-green", Icon { name: "shield" } } }
-                div { class: "card metric", div { class: "metric-copy", span { class: "metric-label", "Fallback / Failures" } span { class: "metric-value", "{fallback} / {failures}" } } div { class: "metric-icon tone-amber", Icon { name: "routes" } } }
-                div { class: "card metric", div { class: "metric-copy", span { class: "metric-label", "All Token Types" } span { class: "metric-value", "{token_total}" } span { class: "metric-note mono", "avg latency {avg_latency}ms" } } div { class: "metric-icon tone-purple", Icon { name: "models" } } }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Requests Loaded" } span { class: "metric-value", "{row_count}" } span { class: "metric-note", "latest router activity" } }
+                    div { class: "metric-icon tone-blue", Icon { name: "logs" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Failures" } span { class: "metric-value", "{failures}" } span { class: "metric-note", "{failure_rate_text}" } }
+                    div { class: "metric-icon tone-red", Icon { name: "shield" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Fallbacks" } span { class: "metric-value", "{fallback}" } span { class: "metric-note", "alternate route used" } }
+                    div { class: "metric-icon tone-amber", Icon { name: "routes" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Loaded Cost" } span { class: "metric-value", "{total_cost_text}" } span { class: "metric-note mono", "avg latency {avg_latency}ms" } }
+                    div { class: "metric-icon tone-purple", Icon { name: "dollar" } }
+                }
             }
 
             if loading {
-                div { class: "card card-pad", "Loading router logs…" }
+                div { class: "card card-pad", "Loading request logs…" }
             } else if let Some(message) = load_error {
-                div { class: "card card-pad stack", strong { class: "danger", "Unable to load router logs" } code { class: "terminal", "{message}" } button { class: "button button-primary", onclick: move |_| resource.restart(), "Retry" } }
+                div { class: "card card-pad stack",
+                    strong { class: "danger", "Request logs could not be loaded" }
+                    code { class: "terminal", "{message}" }
+                    button { class: "button button-primary", onclick: move |_| resource.restart(), "Retry" }
+                }
             } else {
                 div { class: "card table-card",
+                    div { class: "card-pad product-section-head",
+                        div {
+                            h3 { "Request activity" }
+                            p { "Showing {visible_count} of {row_count} loaded requests. Select a row for routing and cost detail." }
+                        }
+                    }
                     if visible.is_empty() {
-                        div { class: "card-pad small muted", "No log rows match this search/filter." }
+                        div { class: "product-empty", style: "min-height:170px",
+                            div { class: "product-empty-inner",
+                                h3 { "No requests match this view" }
+                                p { "Change the outcome filter or search text. If the environment has no traffic yet, use Playground for a controlled test." }
+                            }
+                        }
                     } else {
                         div { class: "table-wrap",
                             table { class: "data-table",
-                                thead { tr { th { "Timestamp" } th { "Request ID" } th { "User" } th { "Path / Model" } th { "Route" } th { "Status" } th { class: "right", "Latency" } th { class: "right", "All Tokens" } th { class: "right", "Cost" } } }
+                                thead { tr {
+                                    th { "Time" }
+                                    th { "Request" }
+                                    th { "Model / Upstream" }
+                                    th { "Outcome" }
+                                    th { class: "right", "Latency" }
+                                    th { class: "right", "Tokens" }
+                                    th { class: "right", "Cost" }
+                                } }
                                 tbody {
                                     for log in visible {
                                         {
                                             let status = log.status_label();
                                             let timestamp = log.created_at.clone().unwrap_or_else(|| "-".to_string());
-                                            let user = log.user_id.clone().unwrap_or_else(|| "anonymous".to_string());
                                             let model = log.model.clone().unwrap_or_else(|| "-".to_string());
                                             let upstream = log.upstream_id.clone().unwrap_or_else(|| "-".to_string());
-                                            let decision = log.layer_decision.clone().unwrap_or_else(|| "direct".to_string());
+                                            let user = log.user_id.clone().unwrap_or_else(|| "anonymous".to_string());
                                             let tokens = log.total_tokens();
                                             let cost = format!("${:.6}", log.cost_usd());
                                             rsx! {
                                                 tr { key: "{log.id}-{log.request_id}", style: "cursor:pointer", onclick: move |_| selected.set(Some(log.clone())),
                                                     td { class: "mono muted", "{timestamp}" }
-                                                    td { class: "mono table-primary", "{log.request_id}" }
-                                                    td { "{user}" }
-                                                    td { div { class: "two-line", span { class: "table-primary mono", "{log.path}" } small { "{model} • {upstream}" } } }
-                                                    td { class: "mono muted", "{decision}" }
+                                                    td {
+                                                        div { class: "two-line",
+                                                            strong { class: "mono table-primary", "{log.request_id}" }
+                                                            small { class: "muted", "{user} • {log.path}" }
+                                                        }
+                                                    }
+                                                    td {
+                                                        div { class: "two-line",
+                                                            strong { class: "mono", "{model}" }
+                                                            small { class: "muted", "{upstream}" }
+                                                        }
+                                                    }
                                                     td { Badge { text: status, tone: status_tone(status) } }
                                                     td { class: "right tabular", "{log.latency_ms}ms" }
                                                     td { class: "right tabular", "{tokens}" }
@@ -164,57 +219,78 @@ pub fn Logs() -> Element {
                 }
             }
 
-            Drawer { title: "Request Detail", open: selected().is_some(), on_close: move |_| selected.set(None),
+            Drawer {
+                title: "Request Detail",
+                open: selected().is_some(),
+                on_close: move |_| selected.set(None),
                 if let Some(log) = selected() {
                     {
                         let status = log.status_label().to_string();
                         let model = log.model.clone().unwrap_or_else(|| "-".to_string());
                         let upstream = log.upstream_id.clone().unwrap_or_else(|| "-".to_string());
-                        let decision = log.layer_decision.clone().unwrap_or_else(|| "-".to_string());
+                        let user = log.user_id.clone().unwrap_or_else(|| "anonymous".to_string());
+                        let decision = log.layer_decision.clone().unwrap_or_else(|| "direct".to_string());
                         let traffic = log.traffic_color.clone().unwrap_or_else(|| "-".to_string());
                         let error_type = log.error_type.clone().unwrap_or_else(|| "none".to_string());
                         let cost_status = log.cost_status.clone().unwrap_or_else(|| "-".to_string());
                         let pricing = log.pricing_region.clone().unwrap_or_else(|| "-".to_string());
                         let total_cost = format!("${:.9}", log.cost_usd());
+                        let is_problem = log.status_code >= 400 || log.status_label() != "Success";
                         rsx! {
                             div { class: "stack-lg",
-                                div { class: "card card-pad", style: "display:grid;grid-template-columns:repeat(3,1fr);gap:16px",
-                                    {detail_stat("Request ID", log.request_id.clone())}
-                                    {detail_stat("Status", status)}
-                                    {detail_stat("Total Cost", total_cost)}
-                                    {detail_stat("Latency", format!("{}ms", log.latency_ms))}
-                                    {detail_stat("Model", model)}
-                                    {detail_stat("Upstream", upstream)}
+                                div { class: if is_problem { "readiness-strip blocked" } else { "readiness-strip ready" },
+                                    span { class: "readiness-dot" }
+                                    strong { "{status}" }
+                                    span { class: "muted", if is_problem { "Review routing and error metadata below." } else { "Request completed without an observed router error." } }
                                 }
+
                                 div { class: "card card-pad stack",
-                                    h3 { class: "section-label", "Routing / Billing Metadata" }
+                                    div { class: "product-section-head", div { h3 { "Outcome" } p { "The first facts needed to understand this request." } } }
                                     div { class: "grid-2",
-                                        {detail_stat("Layer Decision", decision)}
-                                        {detail_stat("Traffic Color", traffic)}
-                                        {detail_stat("Error Type", error_type)}
-                                        {detail_stat("Cost Status", cost_status)}
-                                        {detail_stat("Pricing Region", pricing)}
+                                        {detail_stat("Request ID", log.request_id.clone())}
                                         {detail_stat("HTTP Status", log.status_code.to_string())}
+                                        {detail_stat("Model", model)}
+                                        {detail_stat("Upstream", upstream)}
+                                        {detail_stat("Latency", format!("{}ms", log.latency_ms))}
+                                        {detail_stat("Error Type", error_type)}
                                     }
                                 }
+
                                 div { class: "card card-pad stack",
-                                    h3 { class: "section-label", "Token Breakdown" }
+                                    div { class: "product-section-head", div { h3 { "Routing" } p { "How BurnCloud classified and routed the request." } } }
+                                    div { class: "grid-2",
+                                        {detail_stat("User", user)}
+                                        {detail_stat("Path", log.path.clone())}
+                                        {detail_stat("Layer Decision", decision)}
+                                        {detail_stat("Traffic Color", traffic)}
+                                        {detail_stat("Pricing Region", pricing)}
+                                        {detail_stat("Cost Status", cost_status)}
+                                    }
+                                }
+
+                                div { class: "card card-pad stack",
+                                    div { class: "product-section-head", div { h3 { "Usage" } p { "Only token types that were actually used are shown." } } }
                                     div { class: "grid-2",
                                         for (label, value) in token_breakdown(&log) {
                                             if value != 0 { {detail_stat(label, value.to_string())} }
                                         }
                                     }
-                                    {detail_stat("Total Across Token Types", log.total_tokens().to_string())}
+                                    {detail_stat("Total Tokens", log.total_tokens().to_string())}
                                 }
+
                                 div { class: "card card-pad stack",
-                                    h3 { class: "section-label", "Cost Breakdown" }
+                                    div { class: "product-section-head", div { h3 { "Cost" } p { "Available component costs plus the stored request total." } } }
+                                    {detail_stat("Total Cost", total_cost)}
                                     div { class: "grid-2",
                                         for (label, value) in cost_breakdown(&log) {
-                                            if value != 0 { {detail_stat(label, format!("${:.9}", FullRouterLog::cost_component_usd(value)))} }
+                                            if value != 0 {
+                                                {detail_stat(label, format!("${:.9}", FullRouterLog::cost_component_usd(value)))}
+                                            }
                                         }
                                     }
                                 }
-                                div { class: "terminal", "Request bodies/prompts are not stored in router_logs, so the UI intentionally does not fabricate them." }
+
+                                div { class: "product-note", "BurnCloud does not store request prompt/body content in router_logs. This detail view shows only persisted operational metadata instead of fabricating request content." }
                             }
                         }
                     }

--- a/crates/client/src/functional_pages/playground_live.rs
+++ b/crates/client/src/functional_pages/playground_live.rs
@@ -1,27 +1,277 @@
 use std::collections::BTreeSet;
+
 use dioxus::prelude::*;
-use crate::{backend::{chat_completion, first_active_api_token, ChannelService, ChatMessage, RouteTrace}, components::Icon};
+
+use crate::{
+    app::Route,
+    backend::{
+        chat_completion, first_active_api_token, ChannelService, ChatMessage, RouteTrace, TokenDto,
+        TokenService,
+    },
+    components::Icon,
+};
 
 #[component]
-pub fn Playground()->Element{
-    let mut channels=use_resource(move||async move{ChannelService::list(100).await});
-    let channel_rows=channels.read().clone().and_then(Result::ok).unwrap_or_default();
-    let mut available=BTreeSet::new();for c in &channel_rows{if c.status==1{for m in c.models.split(',').map(str::trim).filter(|m|!m.is_empty()){available.insert(m.to_string());}}}
-    let mut model=use_signal(String::new);let mut prompt=use_signal(String::new);let mut messages=use_signal(||Vec::<ChatMessage>::new());let mut temperature=use_signal(||0.7f64);let mut max_tokens=use_signal(||1024i64);let mut loading=use_signal(||false);let mut error=use_signal(String::new);let mut trace=use_signal(RouteTrace::default);let mut usage=use_signal(String::new);
-    let trace_value=trace();let trace_channel=trace_value.channel_id.unwrap_or_else(||"-".to_string());let trace_model=trace_value.model_id.unwrap_or_else(||"-".to_string());
-    rsx!{
-        div{class:"page",
-            div{class:"page-header",div{h2{class:"page-title","Playground"}p{class:"page-subtitle","Real non-streaming /v1/chat/completions requests using an active BurnCloud API key."}}button{class:"button button-secondary",onclick:move |_|channels.restart(),"Refresh Models"}}
-            div{class:"grid-2",style:"grid-template-columns:minmax(0,1fr) 360px;align-items:start",
-                div{class:"card stack",style:"min-height:620px",
-                    div{class:"card-pad row between",style:"border-bottom:1px solid var(--border)",div{class:"field",style:"flex:1",label{"Model"}input{class:"input mono",value:"{model}",placeholder:"Exact configured model ID",oninput:move|e|model.set(e.value())}}button{class:"button button-secondary button-sm",onclick:move |_|{messages.set(Vec::new());trace.set(RouteTrace::default());usage.set(String::new());error.set(String::new());},"Clear"}}
-                    if !available.is_empty(){div{class:"card-pad row gap-2",style:"border-bottom:1px solid var(--border);flex-wrap:wrap",span{class:"tiny subtle","Available:"}for choice in available{{let selected=choice.clone();rsx!{button{class:"button button-ghost button-sm mono",onclick:move |_|model.set(selected.clone()),"{choice}"}}}}}}
-                    div{class:"card-pad stack",style:"flex:1;overflow:auto;max-height:430px",if messages().is_empty(){div{class:"small muted",style:"margin:auto;text-align:center","Choose a configured model and send a prompt."}}else{for(index,msg)in messages().iter().enumerate(){div{key:"{index}",class:if msg.role=="user"{"card card-pad"}else{"terminal"},div{class:"tiny subtle mono","{msg.role}"}div{style:"white-space:pre-wrap","{msg.content}"}}}}}
-                    if !error().is_empty(){div{class:"terminal auth-status auth-status-error",style:"margin:0 20px","{error}"}}if !usage().is_empty(){div{class:"tiny muted mono",style:"padding:0 20px","{usage}"}}
-                    div{class:"card-pad stack",style:"border-top:1px solid var(--border)",textarea{class:"textarea",rows:"4",value:"{prompt}",placeholder:"Ask BurnCloud something…",disabled:loading(),oninput:move|e|prompt.set(e.value())}div{class:"row between",span{class:"tiny subtle","Uses the first active bc_live_* key from API Keys."}button{class:"button button-primary",disabled:loading(),onclick:move |_|{
-                        let model_id=model().trim().to_string();let text=prompt().trim().to_string();if model_id.is_empty()||text.is_empty(){error.set("Model and prompt are required.".to_string());return;}let mut request=messages();request.push(ChatMessage{role:"user".to_string(),content:text});messages.set(request.clone());prompt.set(String::new());loading.set(true);error.set(String::new());usage.set("Routing request…".to_string());let temp=temperature();let max=max_tokens();spawn(async move{let result=async{let api_key=first_active_api_token().await?;chat_completion(&request,&model_id,&api_key,temp,max).await}.await;match result{Ok(response)=>{let mut next=request;next.push(ChatMessage{role:"assistant".to_string(),content:response.content});messages.set(next);trace.set(response.trace);usage.set(format!("prompt={} • completion={} • total={}",response.usage.prompt_tokens,response.usage.completion_tokens,response.usage.total_tokens));},Err(e)=>{error.set(format!("Chat request failed: {e}"));usage.set(String::new());}}loading.set(false);});},Icon{name:"play"}if loading(){"Sending…"}else{"Send Request"}}}}
+pub fn Playground() -> Element {
+    let mut channels_resource = use_resource(move || async move { ChannelService::list(100).await });
+    let mut keys_resource = use_resource(move || async move { TokenService::list().await });
+
+    let channel_snapshot = channels_resource.read().clone();
+    let key_snapshot = keys_resource.read().clone();
+    let channel_error = channel_snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
+    let key_error = key_snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
+    let channels = channel_snapshot.and_then(Result::ok).unwrap_or_default();
+    let keys: Vec<TokenDto> = key_snapshot.and_then(Result::ok).unwrap_or_default();
+
+    let active_channels = channels.iter().filter(|channel| channel.status == 1).count();
+    let active_keys = keys.iter().filter(|key| key.status == "active").count();
+    let mut model_set = BTreeSet::new();
+    for channel in &channels {
+        if channel.status == 1 {
+            for model in channel.models.split(',').map(str::trim).filter(|model| !model.is_empty()) {
+                model_set.insert(model.to_string());
+            }
+        }
+    }
+    let available_models: Vec<String> = model_set.into_iter().collect();
+    let model_count = available_models.len();
+    let ready = active_channels > 0 && model_count > 0 && active_keys > 0;
+
+    let mut model = use_signal(String::new);
+    let mut prompt = use_signal(String::new);
+    let mut messages = use_signal(|| Vec::<ChatMessage>::new());
+    let mut temperature = use_signal(|| 0.7f64);
+    let mut max_tokens = use_signal(|| 1024i64);
+    let mut loading = use_signal(|| false);
+    let mut error = use_signal(String::new);
+    let mut trace = use_signal(RouteTrace::default);
+    let mut usage = use_signal(String::new);
+
+    let trace_value = trace();
+    let trace_channel = trace_value.channel_id.unwrap_or_else(|| "-".to_string());
+    let trace_model = trace_value.model_id.unwrap_or_else(|| "-".to_string());
+    let has_response = messages().iter().any(|message| message.role == "assistant");
+
+    rsx! {
+        div { class: "page",
+            div { class: "page-header",
+                div {
+                    h2 { class: "page-title", "Playground" }
+                    p { class: "page-subtitle", "Verify the complete path from API access to model routing and upstream response before sending real traffic." }
                 }
-                div{class:"stack-lg",div{class:"card card-pad stack",span{class:"section-label","Generation Controls"}div{class:"field",label{"Temperature: {temperature}"}input{r#type:"range",min:"0",max:"2",step:"0.1",value:"{temperature}",oninput:move|e|temperature.set(e.value().parse().unwrap_or(0.7))}}div{class:"field",label{"Max Tokens"}input{class:"input",r#type:"number",min:"1",value:"{max_tokens}",oninput:move|e|max_tokens.set(e.value().parse().unwrap_or(1024))}}}div{class:"card card-pad stack",span{class:"section-label","Last Router Trace"}div{class:"receipt-row",label{"Channel"}strong{class:"mono","{trace_channel}"}}div{class:"receipt-row",label{"Model Header"}strong{class:"mono","{trace_model}"}}p{class:"tiny subtle","Trace values come from X-Channel-Id and X-Model-Id when emitted by the router."}}}
+                div { class: "header-actions",
+                    button {
+                        class: "button button-secondary",
+                        onclick: move |_| {
+                            channels_resource.restart();
+                            keys_resource.restart();
+                        },
+                        "Refresh readiness"
+                    }
+                    if has_response {
+                        Link { class: "button button-secondary", to: Route::Logs {}, "Open request logs" }
+                    }
+                }
+            }
+
+            if let Some(message) = channel_error {
+                div { class: "terminal auth-status auth-status-error", "Providers could not be loaded: {message}" }
+            }
+            if let Some(message) = key_error {
+                div { class: "terminal auth-status auth-status-error", "API keys could not be loaded: {message}" }
+            }
+
+            div { class: if ready { "readiness-strip ready" } else { "readiness-strip blocked" },
+                span { class: "readiness-dot" }
+                if ready {
+                    strong { "Ready for an end-to-end test" }
+                    span { class: "muted", "{active_channels} active providers • {model_count} models • {active_keys} active API keys" }
+                } else {
+                    strong { "Playground is not ready yet" }
+                    span { class: "muted", "Complete the missing setup item below before sending a request." }
+                }
+            }
+
+            if active_channels == 0 {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "providers" } }
+                        h3 { "Connect an active provider first" }
+                        p { "Playground can only test real routing. Add an upstream provider and make sure it is active before choosing a model." }
+                        Link { class: "button button-primary", to: Route::Providers {}, "Go to Providers" }
+                    }
+                }
+            } else if model_count == 0 {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "models" } }
+                        h3 { "No models are exposed" }
+                        p { "Your provider exists, but it does not expose any model IDs. Add models to the provider configuration before testing traffic." }
+                        Link { class: "button button-primary", to: Route::Providers {}, "Edit Provider Models" }
+                    }
+                }
+            } else if active_keys == 0 {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "key" } }
+                        h3 { "Create an API key for the test" }
+                        p { "Playground uses the same BurnCloud API access path as an external client. Create an active API key before sending the request." }
+                        Link { class: "button button-primary", to: Route::APIKeys {}, "Create API Key" }
+                    }
+                }
+            } else {
+                div { class: "grid-2", style: "grid-template-columns:minmax(0,1fr) 340px;align-items:start",
+                    div { class: "card stack", style: "min-height:620px",
+                        div { class: "card-pad row between", style: "border-bottom:1px solid var(--border);gap:16px",
+                            div { class: "field", style: "flex:1",
+                                label { "Model to test" }
+                                select {
+                                    class: "select mono",
+                                    value: "{model}",
+                                    onchange: move |event| model.set(event.value()),
+                                    option { value: "", "Select a configured model…" }
+                                    for available_model in available_models.iter() {
+                                        option { value: "{available_model}", "{available_model}" }
+                                    }
+                                }
+                            }
+                            button {
+                                class: "button button-secondary button-sm",
+                                onclick: move |_| {
+                                    messages.set(Vec::new());
+                                    trace.set(RouteTrace::default());
+                                    usage.set(String::new());
+                                    error.set(String::new());
+                                },
+                                "Clear conversation"
+                            }
+                        }
+
+                        div { class: "card-pad stack", style: "flex:1;overflow:auto;max-height:430px",
+                            if messages().is_empty() {
+                                div { class: "product-empty", style: "min-height:280px",
+                                    div { class: "product-empty-inner",
+                                        div { class: "product-empty-icon", Icon { name: "play" } }
+                                        h3 { "Run a controlled routing test" }
+                                        p { "Choose a model, send a representative prompt, then verify which provider served it and inspect the resulting request log." }
+                                    }
+                                }
+                            } else {
+                                for (index, message) in messages().iter().enumerate() {
+                                    div {
+                                        key: "{index}",
+                                        class: if message.role == "user" { "card card-pad" } else { "terminal" },
+                                        div { class: "tiny subtle mono", "{message.role}" }
+                                        div { style: "white-space:pre-wrap;line-height:1.55", "{message.content}" }
+                                    }
+                                }
+                            }
+                        }
+
+                        if !error().is_empty() {
+                            div { class: "terminal auth-status auth-status-error", style: "margin:0 20px", "{error}" }
+                        }
+                        if !usage().is_empty() {
+                            div { class: "tiny muted mono", style: "padding:0 20px", "{usage}" }
+                        }
+
+                        div { class: "card-pad stack", style: "border-top:1px solid var(--border)",
+                            textarea {
+                                class: "textarea",
+                                rows: "4",
+                                value: "{prompt}",
+                                placeholder: "Enter a prompt that represents real traffic…",
+                                disabled: loading(),
+                                oninput: move |event| prompt.set(event.value()),
+                            }
+                            div { class: "row between",
+                                span { class: "tiny subtle", "Request goes through the same BurnCloud router and API-key path used by external clients." }
+                                button {
+                                    class: "button button-primary",
+                                    disabled: loading() || model().trim().is_empty() || prompt().trim().is_empty(),
+                                    onclick: move |_| {
+                                        let model_id = model().trim().to_string();
+                                        let text = prompt().trim().to_string();
+                                        if model_id.is_empty() || text.is_empty() {
+                                            error.set("Choose a model and enter a prompt.".to_string());
+                                            return;
+                                        }
+                                        let mut request_messages = messages();
+                                        request_messages.push(ChatMessage { role: "user".to_string(), content: text });
+                                        messages.set(request_messages.clone());
+                                        prompt.set(String::new());
+                                        loading.set(true);
+                                        error.set(String::new());
+                                        usage.set("Routing request through BurnCloud…".to_string());
+                                        let temp = temperature();
+                                        let max = max_tokens();
+                                        spawn(async move {
+                                            let result = async {
+                                                let api_key = first_active_api_token().await?;
+                                                chat_completion(&request_messages, &model_id, &api_key, temp, max).await
+                                            }
+                                            .await;
+                                            match result {
+                                                Ok(response) => {
+                                                    let mut next = request_messages;
+                                                    next.push(ChatMessage { role: "assistant".to_string(), content: response.content });
+                                                    messages.set(next);
+                                                    trace.set(response.trace);
+                                                    usage.set(format!(
+                                                        "prompt={} • completion={} • total={}",
+                                                        response.usage.prompt_tokens,
+                                                        response.usage.completion_tokens,
+                                                        response.usage.total_tokens
+                                                    ));
+                                                }
+                                                Err(message) => {
+                                                    error.set(format!("Request failed: {message}"));
+                                                    usage.set(String::new());
+                                                }
+                                            }
+                                            loading.set(false);
+                                        });
+                                    },
+                                    Icon { name: "play" }
+                                    if loading() { "Sending…" } else { "Send Test Request" }
+                                }
+                            }
+                        }
+                    }
+
+                    div { class: "stack-lg",
+                        div { class: "card card-pad stack",
+                            div { class: "product-section-head",
+                                div { h3 { "Request settings" } p { "Keep defaults unless your test needs specific generation behavior." } }
+                            }
+                            div { class: "field",
+                                label { "Temperature: {temperature}" }
+                                input { r#type: "range", min: "0", max: "2", step: "0.1", value: "{temperature}", oninput: move |event| temperature.set(event.value().parse().unwrap_or(0.7)) }
+                            }
+                            div { class: "field",
+                                label { "Max output tokens" }
+                                input { class: "input", r#type: "number", min: "1", value: "{max_tokens}", oninput: move |event| max_tokens.set(event.value().parse().unwrap_or(1024)) }
+                            }
+                        }
+
+                        div { class: "card card-pad stack",
+                            div { class: "product-section-head",
+                                div { h3 { "Last route" } p { "Confirm which upstream handled the test." } }
+                            }
+                            div { class: "receipt-row", label { "Channel" } strong { class: "mono", "{trace_channel}" } }
+                            div { class: "receipt-row", label { "Model" } strong { class: "mono", "{trace_model}" } }
+                            if has_response {
+                                Link { class: "button button-secondary", to: Route::Logs {}, "Inspect this request in Logs" }
+                            } else {
+                                p { class: "tiny subtle", "Route metadata appears after the first successful request when the router emits trace headers." }
+                            }
+                        }
+
+                        div { class: "product-note",
+                            "Playground is an operational smoke test, not a separate inference path. A successful response here is evidence that provider configuration, model exposure, API access and routing all work together."
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/client/src/functional_pages/providers.rs
+++ b/crates/client/src/functional_pages/providers.rs
@@ -479,12 +479,13 @@ pub fn Providers() -> Element {
                                         class: "button button-primary danger-zone",
                                         disabled: busy(),
                                         onclick: move |_| {
+                                            let deleted_name = target_name.clone();
                                             busy.set(true);
                                             error.set(String::new());
                                             spawn(async move {
                                                 match ChannelService::delete(target_id).await {
                                                     Ok(()) => {
-                                                        notice.set(format!("Provider {target_name} deleted."));
+                                                        notice.set(format!("Provider {deleted_name} deleted."));
                                                         pending_delete.set(None);
                                                         resource.restart();
                                                     }

--- a/crates/client/src/functional_pages/providers.rs
+++ b/crates/client/src/functional_pages/providers.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use dioxus::prelude::*;
 
 use crate::{
@@ -6,10 +8,62 @@ use crate::{
     functional_api::update_channel_preserving_reservations,
 };
 
+const PROVIDER_TYPES: &[(i32, &str)] = &[
+    (1, "OpenAI"),
+    (3, "Azure OpenAI"),
+    (4, "Ollama"),
+    (8, "OpenAI-Compatible / Custom"),
+    (14, "Anthropic"),
+    (20, "OpenRouter"),
+    (24, "Google Gemini"),
+    (25, "Moonshot / Kimi"),
+    (33, "AWS"),
+    (40, "SiliconFlow"),
+    (41, "Google Vertex AI"),
+    (42, "Mistral"),
+    (43, "DeepSeek"),
+    (45, "VolcEngine"),
+    (48, "xAI"),
+    (58, "New API Compatible"),
+];
+
+fn provider_label(type_id: i32) -> String {
+    PROVIDER_TYPES
+        .iter()
+        .find(|(id, _)| *id == type_id)
+        .map(|(_, label)| (*label).to_string())
+        .unwrap_or_else(|| format!("Provider type {type_id}"))
+}
+
+fn known_provider_type(type_id: i32) -> bool {
+    PROVIDER_TYPES.iter().any(|(id, _)| *id == type_id)
+}
+
+fn provider_mark(label: &str) -> String {
+    label
+        .split(|c: char| c.is_whitespace() || c == '-' || c == '/')
+        .filter(|part| !part.is_empty())
+        .take(2)
+        .filter_map(|part| part.chars().next())
+        .collect::<String>()
+        .to_ascii_uppercase()
+}
+
+fn model_list(channel: &Channel) -> Vec<String> {
+    channel
+        .models
+        .split(',')
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
 #[component]
 pub fn Providers() -> Element {
     let mut resource = use_resource(move || async move { ChannelService::list(100).await });
     let mut editing = use_signal(|| None::<Channel>);
+    let mut pending_delete = use_signal(|| None::<Channel>);
     let mut busy = use_signal(|| false);
     let mut notice = use_signal(String::new);
     let mut error = use_signal(String::new);
@@ -26,17 +80,30 @@ pub fn Providers() -> Element {
     let mut tpm_cap = use_signal(String::new);
 
     let snapshot = resource.read().clone();
-    let load_error = snapshot.as_ref().and_then(|r| r.as_ref().err().cloned());
+    let load_error = snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
     let channels = snapshot.and_then(Result::ok).unwrap_or_default();
     let total = channels.len();
-    let active = channels.iter().filter(|c| c.status == 1).count();
+    let active = channels.iter().filter(|channel| channel.status == 1).count();
+    let attention = total.saturating_sub(active);
+    let mut unique_models = BTreeSet::new();
+    let mut routing_groups = BTreeSet::new();
+    for channel in &channels {
+        for model in model_list(channel) {
+            unique_models.insert(model);
+        }
+        for route_group in channel.group.split(',').map(str::trim).filter(|group| !group.is_empty()) {
+            routing_groups.insert(route_group.to_string());
+        }
+    }
+    let model_count = unique_models.len();
+    let group_count = routing_groups.len();
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
                     h2 { class: "page-title", "Providers" }
-                    p { class: "page-subtitle", "Direct Channel CRUD. Edits preserve existing L2 reservation thresholds even though those advanced fields are not exposed in this form." }
+                    p { class: "page-subtitle", "Connect upstream model supply, choose what each provider serves, and control how the router should use it." }
                 }
                 div { class: "header-actions",
                     button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
@@ -54,6 +121,7 @@ pub fn Providers() -> Element {
                             priority.set(0);
                             rpm_cap.set(String::new());
                             tpm_cap.set(String::new());
+                            notice.set(String::new());
                             error.set(String::new());
                         },
                         Icon { name: "plus" }
@@ -64,12 +132,20 @@ pub fn Providers() -> Element {
 
             div { class: "metrics",
                 div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Providers" } span { class: "metric-value", "{total}" } }
+                    div { class: "metric-copy", span { class: "metric-label", "Configured" } span { class: "metric-value", "{total}" } span { class: "metric-note", "upstream providers" } }
                     div { class: "metric-icon tone-blue", Icon { name: "providers" } }
                 }
                 div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Active" } span { class: "metric-value", "{active}" } }
+                    div { class: "metric-copy", span { class: "metric-label", "Active" } span { class: "metric-value", "{active}" } span { class: "metric-note", "available to route" } }
                     div { class: "metric-icon tone-green", Icon { name: "activity" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Models Served" } span { class: "metric-value", "{model_count}" } span { class: "metric-note", "unique model IDs" } }
+                    div { class: "metric-icon tone-purple", Icon { name: "models" } }
+                }
+                div { class: "card metric",
+                    div { class: "metric-copy", span { class: "metric-label", "Needs Attention" } span { class: "metric-value", "{attention}" } span { class: "metric-note", "across {group_count} routing groups" } }
+                    div { class: "metric-icon tone-amber", Icon { name: "routes" } }
                 }
             }
 
@@ -77,89 +153,128 @@ pub fn Providers() -> Element {
             if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
 
             if let Some(message) = load_error {
-                div { class: "terminal auth-status auth-status-error", "{message}" }
+                div { class: "card card-pad stack",
+                    strong { class: "danger", "Providers could not be loaded" }
+                    code { class: "terminal", "{message}" }
+                    button { class: "button button-primary", onclick: move |_| resource.restart(), "Retry" }
+                }
+            } else if channels.is_empty() {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "providers" } }
+                        h3 { "Connect your first upstream provider" }
+                        p { "A provider supplies the model endpoint and credentials BurnCloud needs before Models, Routes, Playground, and real traffic can work." }
+                        button {
+                            class: "button button-primary",
+                            onclick: move |_| {
+                                editing.set(Some(Channel::default()));
+                                name.set(String::new());
+                                provider_type.set(1);
+                                credential.set(String::new());
+                                base_url.set(String::new());
+                                models.set(String::new());
+                                group.set("default".to_string());
+                                weight.set(100);
+                                priority.set(0);
+                                rpm_cap.set(String::new());
+                                tpm_cap.set(String::new());
+                                error.set(String::new());
+                            },
+                            Icon { name: "plus" }
+                            "Add first provider"
+                        }
+                    }
+                }
             } else {
                 div { class: "card table-card",
-                    if channels.is_empty() {
-                        div { class: "card-pad small muted", "No provider channels are configured." }
-                    } else {
-                        div { class: "table-wrap",
-                            table { class: "data-table",
-                                thead { tr {
-                                    th { "Provider" }
-                                    th { "Type" }
-                                    th { "Models" }
-                                    th { "Group" }
-                                    th { class: "right", "Priority" }
-                                    th { class: "right", "Weight" }
-                                    th { "Capacity" }
-                                    th { "Status" }
-                                    th { "Actions" }
-                                } }
-                                tbody {
-                                    for channel in channels {
-                                        {
-                                            let edit_channel = channel.clone();
-                                            let delete_id = channel.id;
-                                            let base = channel.base_url.clone().unwrap_or_else(|| "default base URL".to_string());
-                                            let rpm = channel.rpm_cap.map(|v| v.to_string()).unwrap_or_else(|| "unlimited".to_string());
-                                            let tpm = channel.tpm_cap.map(|v| v.to_string()).unwrap_or_else(|| "unlimited".to_string());
-                                            let capacity = format!("RPM {rpm} • TPM {tpm}");
-                                            let status = if channel.status == 1 { "Active" } else { "Down" };
-                                            rsx! {
-                                                tr { key: "{channel.id}",
-                                                    td {
-                                                        div { class: "two-line",
-                                                            span { class: "table-primary", "{channel.name}" }
-                                                            small { class: "mono", "{base}" }
+                    div { class: "card-pad product-section-head",
+                        div {
+                            h3 { "Provider inventory" }
+                            p { "Status, model coverage and routing policy at a glance. Technical connection details stay secondary." }
+                        }
+                    }
+                    div { class: "table-wrap",
+                        table { class: "data-table",
+                            thead { tr {
+                                th { "Provider" }
+                                th { "Status" }
+                                th { "Models" }
+                                th { "Routing" }
+                                th { "Capacity" }
+                                th { class: "right", "Actions" }
+                            } }
+                            tbody {
+                                for channel in channels {
+                                    {
+                                        let edit_channel = channel.clone();
+                                        let delete_channel = channel.clone();
+                                        let type_label = provider_label(channel.type_);
+                                        let mark = provider_mark(&type_label);
+                                        let base = channel.base_url.clone().unwrap_or_else(|| "Default provider endpoint".to_string());
+                                        let served_models = model_list(&channel);
+                                        let served_count = served_models.len();
+                                        let model_preview = served_models.iter().take(3).cloned().collect::<Vec<_>>().join(", ");
+                                        let model_text = if served_count > 3 { format!("{model_preview} +{} more", served_count - 3) } else { model_preview };
+                                        let routing_text = format!("{} • P{} • W{}", channel.group, channel.priority, channel.weight);
+                                        let rpm = channel.rpm_cap.map(|value| value.to_string()).unwrap_or_else(|| "∞".to_string());
+                                        let tpm = channel.tpm_cap.map(|value| value.to_string()).unwrap_or_else(|| "∞".to_string());
+                                        let capacity = format!("{rpm} RPM • {tpm} TPM");
+                                        let status = if channel.status == 1 { "Active" } else { "Down" };
+                                        rsx! {
+                                            tr { key: "{channel.id}",
+                                                td {
+                                                    div { class: "product-table-primary",
+                                                        div { class: "provider-mark", "{mark}" }
+                                                        div { class: "provider-name-block",
+                                                            strong { "{channel.name}" }
+                                                            small { "{type_label} • {base}" }
                                                         }
                                                     }
-                                                    td { class: "mono", "{channel.type_}" }
-                                                    td { class: "mono muted", "{channel.models}" }
-                                                    td { "{channel.group}" }
-                                                    td { class: "right tabular", "{channel.priority}" }
-                                                    td { class: "right tabular", "{channel.weight}" }
-                                                    td { class: "small muted", "{capacity}" }
-                                                    td { span { class: if channel.status == 1 { "badge badge-success" } else { "badge badge-error" }, "{status}" } }
-                                                    td {
-                                                        div { class: "row gap-2",
-                                                            button {
-                                                                class: "button button-ghost button-sm",
-                                                                onclick: move |_| {
-                                                                    name.set(edit_channel.name.clone());
-                                                                    provider_type.set(edit_channel.type_);
-                                                                    credential.set(edit_channel.key.clone());
-                                                                    base_url.set(edit_channel.base_url.clone().unwrap_or_default());
-                                                                    models.set(edit_channel.models.clone());
-                                                                    group.set(edit_channel.group.clone());
-                                                                    weight.set(edit_channel.weight);
-                                                                    priority.set(edit_channel.priority);
-                                                                    rpm_cap.set(edit_channel.rpm_cap.map(|v| v.to_string()).unwrap_or_default());
-                                                                    tpm_cap.set(edit_channel.tpm_cap.map(|v| v.to_string()).unwrap_or_default());
-                                                                    error.set(String::new());
-                                                                    editing.set(Some(edit_channel.clone()));
-                                                                },
-                                                                "Edit"
-                                                            }
-                                                            button {
-                                                                class: "button button-ghost button-sm danger",
-                                                                disabled: busy(),
-                                                                onclick: move |_| {
-                                                                    busy.set(true);
-                                                                    error.set(String::new());
-                                                                    spawn(async move {
-                                                                        match ChannelService::delete(delete_id).await {
-                                                                            Ok(()) => {
-                                                                                notice.set("Provider deleted.".to_string());
-                                                                                resource.restart();
-                                                                            }
-                                                                            Err(message) => error.set(format!("Delete provider failed: {message}")),
-                                                                        }
-                                                                        busy.set(false);
-                                                                    });
-                                                                },
-                                                                "Delete"
-                                                            }
+                                                }
+                                                td {
+                                                    span { class: if channel.status == 1 { "badge badge-success" } else { "badge badge-error" }, "{status}" }
+                                                }
+                                                td {
+                                                    div { class: "two-line",
+                                                        strong { class: "small", "{served_count} models" }
+                                                        small { class: "mono muted", "{model_text}" }
+                                                    }
+                                                }
+                                                td {
+                                                    div { class: "two-line",
+                                                        strong { class: "small", "{channel.group}" }
+                                                        small { class: "mono muted", "{routing_text}" }
+                                                    }
+                                                }
+                                                td { class: "small muted mono", "{capacity}" }
+                                                td { class: "right",
+                                                    div { class: "action-menu",
+                                                        button {
+                                                            class: "button button-ghost button-sm",
+                                                            title: if channel.status == 1 { "Edit provider" } else { "Inactive providers are protected from edits because the current server update would reactivate them" },
+                                                            disabled: channel.status != 1,
+                                                            onclick: move |_| {
+                                                                name.set(edit_channel.name.clone());
+                                                                provider_type.set(edit_channel.type_);
+                                                                credential.set(String::new());
+                                                                base_url.set(edit_channel.base_url.clone().unwrap_or_default());
+                                                                models.set(edit_channel.models.clone());
+                                                                group.set(edit_channel.group.clone());
+                                                                weight.set(edit_channel.weight);
+                                                                priority.set(edit_channel.priority);
+                                                                rpm_cap.set(edit_channel.rpm_cap.map(|value| value.to_string()).unwrap_or_default());
+                                                                tpm_cap.set(edit_channel.tpm_cap.map(|value| value.to_string()).unwrap_or_default());
+                                                                notice.set(String::new());
+                                                                error.set(String::new());
+                                                                editing.set(Some(edit_channel.clone()));
+                                                            },
+                                                            "Edit"
+                                                        }
+                                                        button {
+                                                            class: "button button-ghost button-sm danger",
+                                                            disabled: busy(),
+                                                            onclick: move |_| pending_delete.set(Some(delete_channel.clone())),
+                                                            "Delete"
                                                         }
                                                     }
                                                 }
@@ -177,80 +292,209 @@ pub fn Providers() -> Element {
                 {
                     let current_id = current.id;
                     let current_status = current.status;
+                    let current_key = current.key.clone();
                     let current_param_override = current.param_override.clone();
                     let current_header_override = current.header_override.clone();
                     let current_api_version = current.api_version.clone();
                     let current_model_mapping = current.model_mapping.clone();
+                    let current_type_known = known_provider_type(provider_type());
+                    let current_type_label = provider_label(provider_type());
+                    let is_new = current_id == 0;
                     rsx! {
                         div { class: "drawer-backdrop", onclick: move |_| editing.set(None) }
                         aside { class: "drawer",
                             div { class: "drawer-head",
-                                h2 { if current_id > 0 { "Edit Provider" } else { "Add Provider" } }
+                                div {
+                                    h2 { if is_new { "Add Provider" } else { "Edit Provider" } }
+                                    p { class: "small muted", if is_new { "Connect an upstream and define the models it can serve." } else { "Update connection, model coverage, or routing policy." } }
+                                }
                                 button { class: "close-button", onclick: move |_| editing.set(None), "×" }
                             }
                             div { class: "drawer-body stack-lg",
-                                div { class: "grid-2",
-                                    div { class: "field", label { "Name" } input { class: "input", value: "{name}", oninput: move |e| name.set(e.value()) } }
-                                    div { class: "field", label { "Provider Type ID" } input { class: "input", r#type: "number", value: "{provider_type}", oninput: move |e| provider_type.set(e.value().parse().unwrap_or(1)) } }
-                                }
-                                div { class: "field", label { "API Key / Credential" } input { class: "input mono", r#type: "password", value: "{credential}", oninput: move |e| credential.set(e.value()) } }
-                                div { class: "field", label { "Base URL" } input { class: "input mono", value: "{base_url}", oninput: move |e| base_url.set(e.value()) } }
-                                div { class: "field", label { "Models (comma-separated)" } textarea { class: "textarea mono", rows: "4", value: "{models}", oninput: move |e| models.set(e.value()) } }
-                                div { class: "grid-2",
-                                    div { class: "field", label { "Group" } input { class: "input", value: "{group}", oninput: move |e| group.set(e.value()) } }
-                                    div { class: "field", label { "Weight" } input { class: "input", r#type: "number", value: "{weight}", oninput: move |e| weight.set(e.value().parse().unwrap_or(100)) } }
-                                    div { class: "field", label { "Priority" } input { class: "input", r#type: "number", value: "{priority}", oninput: move |e| priority.set(e.value().parse().unwrap_or(0)) } }
-                                    div { class: "field", label { "RPM Cap" } input { class: "input", r#type: "number", value: "{rpm_cap}", oninput: move |e| rpm_cap.set(e.value()) } }
-                                    div { class: "field", label { "TPM Cap" } input { class: "input", r#type: "number", value: "{tpm_cap}", oninput: move |e| tpm_cap.set(e.value()) } }
-                                }
-                                p { class: "tiny subtle", "Existing reservation_green / reservation_yellow / reservation_red values are fetched from the server and preserved during edits." }
-                                button {
-                                    class: "button button-primary",
-                                    disabled: busy(),
-                                    onclick: move |_| {
-                                        let item = Channel {
-                                            id: current_id,
-                                            type_: provider_type(),
-                                            key: credential(),
-                                            name: name().trim().to_string(),
-                                            base_url: if base_url().trim().is_empty() { None } else { Some(base_url().trim().to_string()) },
-                                            models: models().trim().to_string(),
-                                            group: group().trim().to_string(),
-                                            status: if current_id > 0 { current_status } else { 1 },
-                                            weight: weight(),
-                                            priority: priority(),
-                                            param_override: current_param_override.clone(),
-                                            header_override: current_header_override.clone(),
-                                            api_version: current_api_version.clone(),
-                                            model_mapping: current_model_mapping.clone(),
-                                            rpm_cap: rpm_cap().trim().parse().ok(),
-                                            tpm_cap: tpm_cap().trim().parse().ok(),
-                                        };
-                                        if item.name.is_empty() || item.key.is_empty() || item.models.is_empty() {
-                                            error.set("Name, credential and models are required.".to_string());
-                                            return;
+                                div { class: "form-section",
+                                    div { class: "form-section-head",
+                                        strong { "Provider" }
+                                        small { "Name the upstream and select the adapter BurnCloud should use." }
+                                    }
+                                    div { class: "grid-2",
+                                        div { class: "field",
+                                            label { "Display name" }
+                                            input { class: "input", value: "{name}", placeholder: "e.g. Anthropic Production", oninput: move |event| name.set(event.value()) }
                                         }
-                                        let updating = item.id > 0;
-                                        busy.set(true);
-                                        error.set(String::new());
-                                        spawn(async move {
-                                            let result = if updating {
-                                                update_channel_preserving_reservations(&item).await
-                                            } else {
-                                                ChannelService::create(&item).await
-                                            };
-                                            match result {
-                                                Ok(()) => {
-                                                    notice.set(if updating { "Provider updated without clearing L2 reservations.".to_string() } else { "Provider created.".to_string() });
-                                                    editing.set(None);
-                                                    resource.restart();
+                                        div { class: "field",
+                                            label { "Provider type" }
+                                            select { class: "select", value: "{provider_type}", onchange: move |event| provider_type.set(event.value().parse().unwrap_or(8)),
+                                                if !current_type_known {
+                                                    option { value: "{provider_type}", "{current_type_label}" }
                                                 }
-                                                Err(message) => error.set(format!("Provider save failed: {message}")),
+                                                for (type_id, label) in PROVIDER_TYPES {
+                                                    option { value: "{type_id}", "{label}" }
+                                                }
                                             }
-                                            busy.set(false);
-                                        });
-                                    },
-                                    if busy() { "Saving…" } else { "Save Provider" }
+                                        }
+                                    }
+                                }
+
+                                div { class: "form-section",
+                                    div { class: "form-section-head",
+                                        strong { "Connection" }
+                                        small { if is_new { "Provide the credential BurnCloud will use to call this upstream." } else { "The stored credential is never shown here. Leave the field blank to keep it unchanged." } }
+                                    }
+                                    div { class: "field",
+                                        label { if is_new { "API key / credential" } else { "Replace credential (optional)" } }
+                                        input {
+                                            class: "input mono",
+                                            r#type: "password",
+                                            value: "{credential}",
+                                            placeholder: if is_new { "Paste provider credential" } else { "Leave blank to keep stored credential" },
+                                            oninput: move |event| credential.set(event.value()),
+                                        }
+                                    }
+                                    div { class: "field",
+                                        label { "Base URL (optional)" }
+                                        input { class: "input mono", value: "{base_url}", placeholder: "Use provider default when blank", oninput: move |event| base_url.set(event.value()) }
+                                    }
+                                }
+
+                                div { class: "form-section",
+                                    div { class: "form-section-head",
+                                        strong { "Models served" }
+                                        small { "These model IDs become available to Models, Routes, and Playground." }
+                                    }
+                                    textarea { class: "textarea mono", rows: "5", value: "{models}", placeholder: "claude-sonnet-4-5, claude-opus-4-1", oninput: move |event| models.set(event.value()) }
+                                    div { class: "product-note", "Use exact upstream model IDs separated by commas. BurnCloud derives its model catalog from this list." }
+                                }
+
+                                details { class: "form-section",
+                                    summary { class: "strong", style: "cursor:pointer", "Advanced routing & capacity" }
+                                    div { class: "form-section-head", style: "margin-top:12px",
+                                        small { "Most providers can keep the defaults. Change these only when you intentionally control route preference or capacity." }
+                                    }
+                                    div { class: "grid-2",
+                                        div { class: "field", label { "Routing group" } input { class: "input", value: "{group}", oninput: move |event| group.set(event.value()) } }
+                                        div { class: "field", label { "Weight" } input { class: "input", r#type: "number", value: "{weight}", oninput: move |event| weight.set(event.value().parse().unwrap_or(100)) } }
+                                        div { class: "field", label { "Priority" } input { class: "input", r#type: "number", value: "{priority}", oninput: move |event| priority.set(event.value().parse().unwrap_or(0)) } }
+                                        div { class: "field", label { "RPM limit" } input { class: "input", r#type: "number", value: "{rpm_cap}", placeholder: "Unlimited", oninput: move |event| rpm_cap.set(event.value()) } }
+                                        div { class: "field", label { "TPM limit" } input { class: "input", r#type: "number", value: "{tpm_cap}", placeholder: "Unlimited", oninput: move |event| tpm_cap.set(event.value()) } }
+                                    }
+                                    if !is_new {
+                                        div { class: "product-note", "Existing green / yellow / red reservation thresholds are preserved automatically when this provider is saved." }
+                                    }
+                                }
+
+                                if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
+
+                                div { class: "row customer-form-actions",
+                                    button { class: "button button-secondary", disabled: busy(), onclick: move |_| editing.set(None), "Cancel" }
+                                    button {
+                                        class: "button button-primary",
+                                        disabled: busy(),
+                                        onclick: move |_| {
+                                            let entered_credential = credential();
+                                            let effective_credential = if current_id > 0 && entered_credential.trim().is_empty() {
+                                                current_key.clone()
+                                            } else {
+                                                entered_credential
+                                            };
+                                            let item = Channel {
+                                                id: current_id,
+                                                type_: provider_type(),
+                                                key: effective_credential,
+                                                name: name().trim().to_string(),
+                                                base_url: if base_url().trim().is_empty() { None } else { Some(base_url().trim().to_string()) },
+                                                models: models().trim().to_string(),
+                                                group: group().trim().to_string(),
+                                                status: if current_id > 0 { current_status } else { 1 },
+                                                weight: weight(),
+                                                priority: priority(),
+                                                param_override: current_param_override.clone(),
+                                                header_override: current_header_override.clone(),
+                                                api_version: current_api_version.clone(),
+                                                model_mapping: current_model_mapping.clone(),
+                                                rpm_cap: rpm_cap().trim().parse().ok(),
+                                                tpm_cap: tpm_cap().trim().parse().ok(),
+                                            };
+                                            if item.name.is_empty() {
+                                                error.set("Provider name is required.".to_string());
+                                                return;
+                                            }
+                                            if item.key.trim().is_empty() {
+                                                error.set("A provider credential is required.".to_string());
+                                                return;
+                                            }
+                                            if item.models.is_empty() {
+                                                error.set("Add at least one model this provider can serve.".to_string());
+                                                return;
+                                            }
+                                            let updating = item.id > 0;
+                                            busy.set(true);
+                                            error.set(String::new());
+                                            spawn(async move {
+                                                let result = if updating {
+                                                    update_channel_preserving_reservations(&item).await
+                                                } else {
+                                                    ChannelService::create(&item).await
+                                                };
+                                                match result {
+                                                    Ok(()) => {
+                                                        notice.set(if updating { "Provider updated.".to_string() } else { "Provider connected. Review Models and Routes before sending traffic.".to_string() });
+                                                        editing.set(None);
+                                                        resource.restart();
+                                                    }
+                                                    Err(message) => error.set(format!("Provider save failed: {message}")),
+                                                }
+                                                busy.set(false);
+                                            });
+                                        },
+                                        if busy() { "Saving…" } else if is_new { "Connect Provider" } else { "Save Changes" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some(target) = pending_delete() {
+                {
+                    let target_id = target.id;
+                    let target_name = target.name.clone();
+                    let target_models = model_list(&target).len();
+                    rsx! {
+                        div { class: "drawer-backdrop", onclick: move |_| pending_delete.set(None) }
+                        aside { class: "drawer",
+                            div { class: "drawer-head",
+                                h2 { class: "danger", "Delete Provider" }
+                                button { class: "close-button", onclick: move |_| pending_delete.set(None), "×" }
+                            }
+                            div { class: "drawer-body stack-lg",
+                                div { class: "form-section danger-zone",
+                                    strong { "Delete {target_name}?" }
+                                    p { class: "small muted", "This provider currently exposes {target_models} model entries. Deleting it removes this upstream from routing immediately and cannot be undone from the console." }
+                                }
+                                div { class: "product-note", "If you only need to pause traffic, do not use Delete. This action permanently removes the channel record." }
+                                div { class: "row customer-form-actions",
+                                    button { class: "button button-secondary", disabled: busy(), onclick: move |_| pending_delete.set(None), "Cancel" }
+                                    button {
+                                        class: "button button-primary danger-zone",
+                                        disabled: busy(),
+                                        onclick: move |_| {
+                                            busy.set(true);
+                                            error.set(String::new());
+                                            spawn(async move {
+                                                match ChannelService::delete(target_id).await {
+                                                    Ok(()) => {
+                                                        notice.set(format!("Provider {target_name} deleted."));
+                                                        pending_delete.set(None);
+                                                        resource.restart();
+                                                    }
+                                                    Err(message) => error.set(format!("Delete provider failed: {message}")),
+                                                }
+                                                busy.set(false);
+                                            });
+                                        },
+                                        if busy() { "Deleting…" } else { "Delete Provider" }
+                                    }
                                 }
                             }
                         }

--- a/crates/client/src/functional_pages/settings.rs
+++ b/crates/client/src/functional_pages/settings.rs
@@ -2,8 +2,8 @@ use dioxus::prelude::*;
 
 use crate::{
     backend::{server_root, system_metrics, use_auth, SystemMetrics},
-    functional_api::{cache_stats, clear_cache},
     components::Icon,
+    functional_api::{cache_stats, clear_cache},
 };
 
 #[component]
@@ -13,6 +13,7 @@ pub fn Settings() -> Element {
     let api_root = server_root();
     let mut metrics_resource = use_resource(move || async move { system_metrics().await });
     let mut cache_resource = use_resource(move || async move { cache_stats().await });
+    let mut confirm_clear = use_signal(|| false);
     let mut busy = use_signal(|| false);
     let mut notice = use_signal(String::new);
     let mut error = use_signal(String::new);
@@ -20,36 +21,36 @@ pub fn Settings() -> Element {
     let metrics_result = metrics_resource.read().clone();
     let cache_result = cache_resource.read().clone();
     let metrics: SystemMetrics = metrics_result.clone().and_then(Result::ok).unwrap_or_default();
-    let metrics_error = metrics_result.as_ref().and_then(|r| r.as_ref().err().cloned());
+    let metrics_error = metrics_result.as_ref().and_then(|result| result.as_ref().err().cloned());
     let cache_text = match cache_result {
         Some(Ok(value)) => serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
         Some(Err(message)) => format!("Cache statistics unavailable: {message}"),
         None => "Loading cache statistics…".to_string(),
     };
-    let roles = user.as_ref().map(|u| u.roles.join(", ")).unwrap_or_else(|| "-".to_string());
-    let username = user.as_ref().map(|u| u.username.clone()).unwrap_or_else(|| "-".to_string());
-    let user_id = user.as_ref().map(|u| u.id.clone()).unwrap_or_else(|| "-".to_string());
+
+    let roles = user.as_ref().map(|user| user.roles.join(", ")).unwrap_or_else(|| "-".to_string());
+    let username = user.as_ref().map(|user| user.username.clone()).unwrap_or_else(|| "-".to_string());
+    let user_id = user.as_ref().map(|user| user.id.clone()).unwrap_or_else(|| "-".to_string());
     let memory_used_gib = metrics.memory.used as f64 / 1024.0 / 1024.0 / 1024.0;
     let memory_total_gib = metrics.memory.total as f64 / 1024.0 / 1024.0 / 1024.0;
     let memory_text = format!("{memory_used_gib:.1} / {memory_total_gib:.1} GiB");
     let cpu_text = format!("{:.1}%", metrics.cpu.usage_percent);
+    let memory_percent = format!("{:.1}%", metrics.memory.usage_percent);
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
                     h2 { class: "page-title", "Settings" }
-                    p { class: "page-subtitle", "Only settings and maintenance operations backed by the current BurnCloud server are shown as actionable." }
+                    p { class: "page-subtitle", "Inspect the connected BurnCloud environment and perform the maintenance operations the server actually supports." }
                 }
-                div { class: "header-actions",
-                    button {
-                        class: "button button-secondary",
-                        onclick: move |_| {
-                            metrics_resource.restart();
-                            cache_resource.restart();
-                        },
-                        "Refresh"
-                    }
+                button {
+                    class: "button button-secondary",
+                    onclick: move |_| {
+                        metrics_resource.restart();
+                        cache_resource.restart();
+                    },
+                    "Refresh"
                 }
             }
 
@@ -58,74 +59,102 @@ pub fn Settings() -> Element {
 
             div { class: "grid-2",
                 div { class: "card card-pad stack-lg",
-                    div { class: "row between",
-                        h3 { "Server Connection" }
-                        span { class: "badge badge-success", "CONNECTED CONFIG" }
+                    div { class: "product-section-head",
+                        div {
+                            h3 { "Environment" }
+                            p { "The server endpoint and identity this console is currently using." }
+                        }
+                        span { class: "badge badge-success", "CONNECTED" }
                     }
-                    div { class: "receipt-row", label { "API Root" } strong { class: "mono", "{api_root}" } }
-                    div { class: "receipt-row", label { "Username" } strong { "{username}" } }
-                    div { class: "receipt-row", label { "User ID" } strong { class: "mono", "{user_id}" } }
+                    div { class: "receipt-row", label { "Server" } strong { class: "mono", "{api_root}" } }
+                    div { class: "receipt-row", label { "Signed in as" } strong { "{username}" } }
                     div { class: "receipt-row", label { "Roles" } strong { "{roles}" } }
-                    p { class: "tiny subtle", "Override the local server root with BURNCLOUD_API_BASE. Otherwise the client uses 127.0.0.1 and BurnCloud's PORT/default port." }
+                    details {
+                        summary { class: "small strong", style: "cursor:pointer", "Connection details" }
+                        div { class: "stack", style: "margin-top:12px",
+                            div { class: "receipt-row", label { "User ID" } strong { class: "mono", "{user_id}" } }
+                            div { class: "product-note", "Set BURNCLOUD_API_BASE to point the client at a different BurnCloud server. Otherwise the client uses the configured local host/port behavior." }
+                        }
+                    }
                 }
 
                 div { class: "card card-pad stack-lg",
-                    div { class: "row between",
-                        h3 { "Runtime Health" }
+                    div { class: "product-section-head",
+                        div {
+                            h3 { "Runtime health" }
+                            p { "Host pressure can explain latency or capacity issues, but it is not the same as routing health." }
+                        }
                         Icon { name: "activity" }
                     }
                     if let Some(message) = metrics_error {
                         code { class: "terminal", "{message}" }
                     } else {
-                        div { class: "receipt-row", label { "CPU" } strong { "{cpu_text}" } }
-                        div { class: "receipt-row", label { "CPU Cores" } strong { "{metrics.cpu.core_count}" } }
-                        div { class: "receipt-row", label { "Memory" } strong { "{memory_text}" } }
-                        div { class: "receipt-row", label { "Disks" } strong { "{metrics.disks.len()} mounted entries" } }
+                        div { class: "grid-2",
+                            div { class: "receipt-row", label { "CPU" } strong { class: "mono", "{cpu_text}" } }
+                            div { class: "receipt-row", label { "Memory" } strong { class: "mono", "{memory_percent}" } }
+                        }
+                        div { class: "receipt-row", label { "CPU cores" } strong { "{metrics.cpu.core_count}" } }
+                        div { class: "receipt-row", label { "Memory used" } strong { "{memory_text}" } }
+                        div { class: "receipt-row", label { "Mounted disks" } strong { "{metrics.disks.len()}" } }
                     }
                 }
             }
 
-            div { class: "grid-2",
-                div { class: "card card-pad stack",
-                    div { class: "row between",
-                        h3 { "Router Cache" }
-                        button { class: "button button-ghost button-sm", onclick: move |_| cache_resource.restart(), "Refresh Stats" }
+            div { class: "card card-pad stack-lg",
+                div { class: "product-section-head",
+                    div {
+                        h3 { "Application cache" }
+                        p { "Cache is an operational implementation detail, so raw server statistics are available on demand instead of dominating the page." }
                     }
-                    pre { class: "terminal", style: "white-space:pre-wrap;max-height:300px;overflow:auto", "{cache_text}" }
+                    button { class: "button button-ghost button-sm", onclick: move |_| cache_resource.restart(), "Refresh cache" }
                 }
+                details {
+                    summary { class: "small strong", style: "cursor:pointer", "View raw cache statistics" }
+                    pre { class: "terminal", style: "margin-top:12px;white-space:pre-wrap;max-height:300px;overflow:auto", "{cache_text}" }
+                }
+            }
 
-                div { class: "card card-pad stack",
-                    h3 { class: "danger", "Cache Maintenance" }
-                    p { class: "small muted", "Clear all BurnCloud application cache through the real /console/api/cache/clear endpoint. This does not delete users, channels, API keys or router logs." }
-                    button {
-                        class: "button button-primary",
-                        disabled: busy(),
-                        onclick: move |_| {
-                            busy.set(true);
-                            error.set(String::new());
-                            notice.set("Clearing BurnCloud cache…".to_string());
-                            spawn(async move {
-                                match clear_cache().await {
-                                    Ok(()) => {
-                                        notice.set("BurnCloud cache cleared successfully.".to_string());
-                                        cache_resource.restart();
-                                    }
-                                    Err(message) => {
-                                        notice.set(String::new());
-                                        error.set(format!("Cache clear failed: {message}"));
-                                    }
+            div { class: "card card-pad stack-lg danger-zone",
+                div { class: "product-section-head",
+                    div {
+                        h3 { class: "danger", "Cache maintenance" }
+                        p { "Clear application cache only when you are troubleshooting stale runtime state or following an operational procedure." }
+                    }
+                    span { class: "badge badge-error", "MAINTENANCE" }
+                }
+                p { class: "small muted", "Clearing cache does not delete customers, providers, API keys, or router logs, but it can temporarily change runtime behavior while caches warm again." }
+                label { class: "row gap-2 small", style: "align-items:flex-start",
+                    input { r#type: "checkbox", checked: confirm_clear(), onchange: move |_| confirm_clear.set(!confirm_clear()) }
+                    span { "I understand this is a live maintenance operation on the connected BurnCloud server." }
+                }
+                button {
+                    class: "button button-primary",
+                    disabled: busy() || !confirm_clear(),
+                    onclick: move |_| {
+                        busy.set(true);
+                        error.set(String::new());
+                        notice.set("Clearing BurnCloud application cache…".to_string());
+                        spawn(async move {
+                            match clear_cache().await {
+                                Ok(()) => {
+                                    notice.set("BurnCloud application cache cleared.".to_string());
+                                    confirm_clear.set(false);
+                                    cache_resource.restart();
                                 }
-                                busy.set(false);
-                            });
-                        },
-                        if busy() { "Clearing…" } else { "Clear Application Cache" }
-                    }
+                                Err(message) => {
+                                    notice.set(String::new());
+                                    error.set(format!("Cache clear failed: {message}"));
+                                }
+                            }
+                            busy.set(false);
+                        });
+                    },
+                    if busy() { "Clearing…" } else { "Clear Application Cache" }
                 }
             }
 
-            div { class: "card card-pad stack",
-                h3 { "Unavailable Configuration" }
-                p { class: "small muted", "The current BurnCloud server does not expose a general system-settings CRUD endpoint. Appearance, arbitrary gateway defaults, notification preferences and similar prototype controls are therefore not shown as fake save actions." }
+            div { class: "product-note",
+                "General appearance preferences, arbitrary gateway defaults, and notification settings are intentionally absent because the current BurnCloud server does not expose a general settings CRUD API. The console only presents settings it can actually read or change."
             }
         }
     }

--- a/crates/client/src/product_ui.css
+++ b/crates/client/src/product_ui.css
@@ -1,0 +1,263 @@
+.product-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(300px, .8fr);
+  gap: 18px;
+  align-items: stretch;
+}
+
+.product-status-card {
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.product-status-card.status-ready {
+  border-color: color-mix(in srgb, #22c55e 30%, var(--border));
+  background: linear-gradient(135deg, color-mix(in srgb, #22c55e 7%, var(--panel)), var(--panel));
+}
+
+.product-status-card.status-attention {
+  border-color: color-mix(in srgb, #f59e0b 34%, var(--border));
+  background: linear-gradient(135deg, color-mix(in srgb, #f59e0b 8%, var(--panel)), var(--panel));
+}
+
+.product-status-card.status-blocked {
+  border-color: color-mix(in srgb, #ef4444 30%, var(--border));
+  background: linear-gradient(135deg, color-mix(in srgb, #ef4444 7%, var(--panel)), var(--panel));
+}
+
+.product-status-title {
+  font-size: 22px;
+  line-height: 1.25;
+  font-weight: 720;
+  letter-spacing: -0.02em;
+}
+
+.product-status-copy {
+  max-width: 720px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.product-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.setup-card {
+  padding: 20px;
+}
+
+.setup-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.setup-step {
+  display: grid;
+  grid-template-columns: 26px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.setup-step:last-child {
+  border-bottom: 0;
+}
+
+.setup-step-dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  font-weight: 800;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  background: var(--panel);
+}
+
+.setup-step.complete .setup-step-dot {
+  background: color-mix(in srgb, #22c55e 15%, var(--panel));
+  color: #22c55e;
+  border-color: color-mix(in srgb, #22c55e 40%, var(--border));
+}
+
+.setup-step strong {
+  display: block;
+  font-size: 13px;
+}
+
+.setup-step small {
+  display: block;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.product-section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.product-section-head h3 {
+  margin: 0;
+}
+
+.product-section-head p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.product-empty {
+  min-height: 220px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 36px 24px;
+}
+
+.product-empty-inner {
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.product-empty-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: var(--surface-subtle, rgba(127,127,127,.08));
+}
+
+.product-empty h3 {
+  margin: 4px 0 0;
+}
+
+.product-empty p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.product-table-primary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.provider-mark {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: 12px;
+  background: var(--surface-subtle, rgba(127,127,127,.08));
+  border: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+.provider-name-block strong,
+.provider-name-block small {
+  display: block;
+}
+
+.provider-name-block small {
+  margin-top: 3px;
+  color: var(--muted);
+}
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--panel);
+}
+
+.form-section-head strong,
+.form-section-head small {
+  display: block;
+}
+
+.form-section-head small {
+  color: var(--muted);
+  margin-top: 4px;
+  line-height: 1.45;
+}
+
+.danger-zone {
+  border-color: color-mix(in srgb, #ef4444 30%, var(--border));
+  background: color-mix(in srgb, #ef4444 5%, var(--panel));
+}
+
+.readiness-strip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-size: 13px;
+}
+
+.readiness-strip.ready {
+  border-color: color-mix(in srgb, #22c55e 32%, var(--border));
+  background: color-mix(in srgb, #22c55e 7%, var(--panel));
+}
+
+.readiness-strip.blocked {
+  border-color: color-mix(in srgb, #f59e0b 34%, var(--border));
+  background: color-mix(in srgb, #f59e0b 7%, var(--panel));
+}
+
+.readiness-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #f59e0b;
+  flex: 0 0 auto;
+}
+
+.readiness-strip.ready .readiness-dot {
+  background: #22c55e;
+}
+
+.product-note {
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: var(--surface-subtle, rgba(127,127,127,.06));
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.action-menu {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+@media (max-width: 1100px) {
+  .product-hero {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Goal

This PR is a product/UX rationalization pass on top of merged #394. It keeps the real backend wiring introduced there, but changes the console so it follows how an operator actually sets up, verifies, observes, and safely manages BurnCloud.

The product rule for this pass is simple: every page should answer **why am I here, what is the current state, and what should I do next?** Backend implementation details should stay secondary unless they are genuinely needed for an advanced operation.

## Product principles applied

- show system conclusions before implementation details
- order navigation by real task sequence
- make prerequisites and next actions explicit
- translate backend fields into user-facing concepts
- separate customer accounts from staff/operator identities
- keep dangerous operations away from routine actions and require confirmation
- use empty states to guide users into the next valid setup step
- preserve real BurnCloud API behavior instead of inventing unsupported features
- never claim a runtime state that the UI has not actually verified

## Main changes

### Navigation / console chrome

- reorganized around **Workspace → Traffic Setup → Observe → Access & Customers → Security & System**
- Traffic Setup now follows **Providers → Models → Routes → Playground**, matching the real setup/test sequence
- Observe follows **Logs → Evaluation → Billing**
- top environment chip now says **Server Configured**, not Server Connected; live health belongs on Overview
- global search remains a page-jump tool rather than pretending to search business data it does not index

### Overview

- changed from a technical dashboard into an operator home page
- added a clear system conclusion: ready, setup required, provider attention, or data-source error
- added **Setup & readiness** checklist: Provider → Model → API Key → First Request
- primary CTA changes to the next missing prerequisite
- business/traffic KPIs come before CPU/memory
- provider health, latest request, runtime, and spend are separated by purpose
- guided empty states point directly to the next valid page

### Authentication

- removed the visible Passkey mode because the current server has no passkey challenge endpoint
- removed registration tier selection and Company/Team fields because the registration API does not persist them
- registration now contains only username, optional/recommended email, password, and terms
- password recovery now has its own account-email field instead of overloading the username field
- login/register remain connected to the real AuthService/JWT flow from #394

### Providers

- replaced raw numeric **Provider Type ID** with named provider choices based on the actual ChannelType values
- unknown existing provider types remain preservable/editable
- stored credentials are no longer echoed back into the edit form; blank means keep the current secret
- split the form into **Provider / Connection / Models served / Advanced routing & capacity**
- priority, weight, RPM, TPM and routing group are demoted to advanced controls
- table prioritizes provider status, model coverage, routing policy and capacity
- explicit delete confirmation explains routing impact
- existing L2 reservation preservation and inactive-channel edit safety from #394 remain intact

### Models

- no longer just mirrors Channel.models fields
- shows **Unavailable / Single upstream / Redundant** states
- highlights whether a model has failover capacity
- provides direct Test or Fix Provider actions

### Routes

- routing groups show **Available / Single upstream / Redundant / Unavailable** operational meaning
- group cards expose active candidates and model coverage before raw priority/weight values
- single-upstream groups explicitly warn about resilience risk

### Playground

- repositioned as an **end-to-end smoke test**, not a raw API debugging form
- checks for an active provider, available model, and active API key before allowing a request
- impossible states point the user to Providers/API Keys instead of exposing a broken form
- model is selected from actual configured active models rather than manually typed
- a successful test links directly to Logs for verification
- request still goes through the real BurnCloud API-key/router path

### API Keys

- shows owner usernames instead of leading with raw user IDs
- key creation chooses an owner account
- newly created full credential is shown in a dedicated one-time panel, then only masked in the table
- status, quota, network restriction and version are separated into understandable columns
- Rotate and Delete now require explicit confirmation flows
- IP whitelist is treated as a separate network-access operation

### Customers / Team

- **Customers** now excludes root/admin/operator-style staff accounts and focuses on business accounts, wallet balances and funding
- role/group implementation details are removed from the primary customer table
- customer creation and Add Funds are the clear primary actions
- **Team** now focuses on administrative/operator identities instead of duplicating Customers
- Team explicitly remains read-only until the server exposes safe invite/role-management endpoints

### Logs

- prioritizes **failures, fallbacks, latency and cost** instead of presenting every router field as equally important
- simplified main table to Time / Request / Model+Upstream / Outcome / Latency / Tokens / Cost
- request drawer is organized as **Outcome → Routing → Usage → Cost**
- full multimodal token/cost data from #394 remains available in the detail view

### Evaluation

- adds overall observed requests, success rate, average latency and models-with-errors metrics
- explicitly highlights models with failed requests and single-upstream observations
- per-model table adds a product-level Health state before raw metrics
- remains clearly described as operational evaluation, not synthetic model-quality/accuracy scoring

### Billing

- makes **Spend** the primary metric
- models are sorted by cost so the largest spend drivers are visible first
- adds spend share per model
- retains request/token breakdown without giving every token field equal visual weight
- removed the obsolete duplicate Evaluation implementation from analytics.rs

### Guardrails

- routine protection policy is separated from emergency operations
- content filter, blacklist and custom rules stay together as normal editable policy
- raw circuit-breaker payload is available under expandable diagnostics
- **Trip All Circuits** is isolated in a Danger Zone
- emergency stop now requires both an incident reason and an explicit acknowledgement checkbox

### Settings

- separates Environment identity from Runtime health
- raw cache statistics are collapsed into diagnostic details
- **Clear Application Cache** is isolated as maintenance, not a routine settings button
- cache clear requires explicit acknowledgement
- unsupported general settings are still not faked

## Product UX regression guard

Added `crates/client/scripts/check-product-ux.sh` and wired it into `Client UI Conventions` CI.

It prevents common product regressions such as:

- changing Traffic Setup away from Providers → Models → Routes → Playground
- bringing back fake registration tiers, Company/Team fields, or Passkey tabs
- exposing Provider Type ID again
- removing setup/readiness guidance from Overview
- turning Playground back into a model-ID free-text form without prerequisite checks
- mixing staff back into Customers
- removing confirmation from destructive provider/API-key/security/cache operations
- changing the chrome back to the unverified `Server Connected` claim

This is in addition to the existing functional-wiring guard from #394, so both **real backend behavior** and **product workflow logic** now have CI protection.

## Validation

Latest head `85633f55653f768a6c523b4db345939de670c46d` passes the full client validation matrix:

- ✅ `bash scripts/check-ui-conventions.sh`
- ✅ `bash scripts/check-functional-wiring.sh`
- ✅ `bash scripts/check-product-ux.sh`
- ✅ `cargo check --no-default-features --features liveview`
- ✅ `cargo check -p burncloud`
- ✅ Windows: `cargo check -p burncloud-client`

## Verification scope

This PR validates product contracts statically and validates Linux LiveView/root integration plus the Windows Desktop compile path. It has not yet been visually exercised against a separately running BurnCloud deployment with browser/Desktop interaction, so final pixel/layout and runtime interaction QA should still be performed in a real staging/local environment before treating screenshots and interaction polish as finished.