### PR TITLE
Define BurnCloud agent docs v1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,73 +1,151 @@
 # BurnCloud Agent Instructions
 
-This file is the repository entrypoint for coding agents. Keep it short. Detailed rules live under `docs/`.
+This file is the repository-level constitution and router for coding agents. Keep it compact. Detailed execution knowledge belongs under `docs/agent/`, while architecture/runtime truth belongs in the existing `docs/architecture/`, `docs/contracts/`, and `docs/runtime/` trees.
+
+## Mission
+
+An agent working on BurnCloud must safely modify the real system, not merely generate plausible code.
+
+Core principles:
+
+- **Understand before change.**
+- **Evidence before assumption.**
+- **Invariants before implementation.**
+- **Verification before completion.**
 
 ## Authority
 
 When sources disagree, use this order:
 
-`current source code > executable tests > current contracts/invariants > current architecture/runtime docs > engineering standards > historical/external docs`
+`runtime evidence > executable tests > current source code > database schema/migrations > configuration > source-derived contracts/invariants > architecture/runtime docs > engineering standards > comments > assumptions`
 
-A document never makes behavior true. Re-confirm the relevant code before changing it.
+A document never makes behavior true. Re-confirm the relevant source before changing it. Tests are evidence of covered behavior, not automatic proof that the test itself defines the intended contract.
 
 ## Required bootstrap
 
-Before making a repository change:
+Before making a non-trivial repository change:
 
 1. Read `docs/CLAUDE.md`.
 2. Read `docs/agent/START_HERE.md`.
-3. Route the requested behavior with `docs/agent/TASK_ROUTER.md`.
-4. Read the smallest real execution path needed for the task.
-5. Check `docs/agent/INVARIANTS.md`.
-6. Select verification from `docs/agent/TEST_MATRIX.md`.
-7. Follow `docs/agent/CHANGE_PROTOCOL.md`.
+3. Route the behavior with `docs/agent/TASK_ROUTER.md`.
+4. Create the minimum task contract described in `docs/agent/TASK_CONTRACT.md`.
+5. Read the smallest real execution path required for the task.
+6. Check `docs/agent/INVARIANTS.md` and `docs/agent/INVARIANT_STANDARD.md`.
+7. Select verification from `docs/agent/TEST_MATRIX.md` and `docs/agent/verification/VERIFICATION_STANDARD.md`.
+8. Follow `docs/agent/CHANGE_PROTOCOL.md` and the relevant playbook under `docs/agent/playbooks/`.
 
-For data-plane behavior, also open `docs/runtime/README.md` and the relevant runtime flow document if one exists.
+For data-plane behavior, also open `docs/runtime/README.md` and the relevant runtime-flow document if one exists.
 
-## Execution contract
+## Agent constitution
 
-For every non-trivial change, establish these facts before editing:
+### RULE-001 — Code First
+Confirm current behavior from the repository and runtime evidence. Do not infer behavior from filenames, comments, old docs, or framework conventions.
 
-- **Behavior** — the user/operator-visible behavior being changed.
-- **Entry** — route, CLI command, UI event, background trigger, or other real entrypoint.
-- **Execution path** — `entry -> branch -> callee -> state/external effect -> return/error`.
-- **Impact** — files, crates, persistence, external calls, billing/accounting, auth, routing, and tests affected.
-- **Invariants** — existing truths that must remain true.
-- **Acceptance** — observable conditions that prove the task is complete.
+### RULE-002 — No Architecture Guessing
+Never replace an unverified edge with what a conventional system would probably do.
 
-Classify important execution claims as:
+### RULE-003 — Trace Before Change
+For runtime changes, trace at least `entry -> branch -> callee -> state/external effect -> return/error` before editing.
 
-- **STATIC CONFIRMED** — directly visible in current source/tests.
-- **DYNAMIC** — runtime configuration, trait/adaptor/provider/channel selection, environment, or data controls the next target.
-- **INFERRED** — plausible but not fully proven from the inspected path.
+### RULE-004 — Identify the Domain
+Classify the task into the smallest stable ownership domain and read its contract when one exists.
 
-Never turn a DYNAMIC or INFERRED edge into a fixed architecture claim.
+### RULE-005 — Check Invariants
+Determine which verified truths must remain true. A green build does not prove semantic correctness.
 
-## Change discipline
+### RULE-006 — Smallest Correct Change
+Prefer the smallest coherent change that fixes the root cause or implements the requested behavior.
 
-- Prefer one runtime behavior per change.
-- Make the smallest coherent change that satisfies the acceptance criteria.
-- Do not perform opportunistic refactors unless they are required for correctness or testability.
-- Do not infer behavior from filenames or crate names.
-- Do not hide uncertainty: mark it and identify the source needed to resolve it.
-- Do not declare completion while required verification is failing.
+### RULE-007 — Root Cause Before Patch
+Do not hide failures with default values, swallowed errors, skipped checks, or unrelated fallbacks unless that behavior is explicitly part of the contract.
+
+### RULE-008 — Preserve Existing Behavior
+Unless requested otherwise, preserve public APIs, response/error semantics, persistence, billing, routing, authentication, streaming, and provider compatibility.
+
+### RULE-009 — No Silent Business Logic Change
+Pricing, quota, usage, billing, provider/channel selection, auth, authorization, and provenance are high-risk behavior and must not change incidentally during refactors.
+
+### RULE-010 — Do Not Hide Failure
+Never make a task look green by deleting assertions, weakening tests, converting failure into success, or suppressing errors.
+
+### RULE-011 — Tests Are Evidence, Not Absolute Truth
+If a relevant test conflicts with source-derived contracts or requested behavior, investigate the contradiction before changing either side.
+
+### RULE-012 — New Behavior Requires Verification
+Every new or changed observable behavior must have a concrete verification path.
+
+### RULE-013 — High-Risk Changes Need Regression Checks
+Billing, usage, provider adapters, streaming, auth, routing, migrations, provenance, concurrency, and transaction changes require adjacent regression verification.
+
+### RULE-014 — Never Invent APIs
+Confirm SDK calls, provider parameters, internal functions, schema fields, environment variables, and configuration keys from authoritative definitions.
+
+### RULE-015 — Respect Existing Architecture
+Use established interfaces/adapters/services/repositories/registries unless changing the architecture is required and justified.
+
+### RULE-016 — Search Is Discovery, Not Proof
+A text or symbol search identifies candidates; only the verified execution path establishes runtime ownership.
+
+### RULE-017 — Runtime Flows Must Be Traceable
+Important flow nodes must map to a real route, symbol, file, configuration, schema, or dynamically selected boundary.
+
+### RULE-018 — Distinguish Fact, Dynamic Edge, Inference, and Unknown
+Use `STATIC CONFIRMED`, `DYNAMIC`, `INFERRED`, and `UNKNOWN` precisely. Never present a dynamic or inferred edge as a fixed architecture fact.
+
+### RULE-019 — Inspect the Final Diff
+Check for unrelated changes, accidental deletions, public-contract changes, secrets, debug code, generated noise, and temporary hacks.
+
+### RULE-020 — Verification Before Completion
+Do not declare completion because code was written, compilation succeeded, or one test passed. Meet the task's Definition of Done.
+
+## Standard execution loop
+
+`DISCOVER -> UNDERSTAND -> TRACE -> CONTRACT -> PLAN -> CHANGE -> VERIFY -> INSPECT -> REPORT`
+
+For documentation-only work, TRACE may mean verifying the source/doc ownership being described rather than tracing a runtime request.
+
+## Required task contract
+
+Before editing a non-trivial behavior, establish:
+
+- **Goal** — requested user/operator-visible outcome.
+- **Current behavior** — what current evidence proves.
+- **Expected behavior** — observable target state.
+- **Entry** — route, CLI command, UI event, background trigger, or document ownership point.
+- **Execution path** — smallest relevant path.
+- **Scope** — files/domains allowed and boundaries intentionally avoided.
+- **Impact** — persistence, external calls, billing, auth, routing, concurrency, tests.
+- **Invariants** — truths that must remain true.
+- **Verification** — checks that will prove the change.
+- **Done when** — explicit completion criteria.
+
+See `docs/agent/TASK_CONTRACT.md`.
+
+## Documentation router
+
+- Agent operating model: `docs/agent/README.md`
+- Start workflow: `docs/agent/START_HERE.md`
+- Behavior-to-source routing: `docs/agent/TASK_ROUTER.md`
+- Task contract: `docs/agent/TASK_CONTRACT.md`
+- Current verified invariants: `docs/agent/INVARIANTS.md`
+- Invariant authoring standard: `docs/agent/INVARIANT_STANDARD.md`
+- Domain contract standard: `docs/agent/domains/README.md`
+- Task playbooks: `docs/agent/playbooks/`
+- Test ownership: `docs/agent/TEST_MATRIX.md`
+- Verification levels: `docs/agent/verification/VERIFICATION_STANDARD.md`
+- Definition of Done: `docs/agent/verification/DEFINITION_OF_DONE.md`
+- Change/report discipline: `docs/agent/CHANGE_PROTOCOL.md`
 
 ## Runtime documentation rule
 
 If a change alters observable routing, authentication/admission, provider dispatch, failover, persistence, billing/accounting, response behavior, or a documented invariant, update the corresponding repository-local runtime/contract document in the same change.
 
-Runtime documents are navigation and evidence maps, not replacements for source code. Prefer stable evidence references in the form:
+Runtime documents are navigation and evidence maps, not replacements for source code. Prefer stable references such as:
 
 `path/to/file.rs :: SymbolName`
 
-Use line numbers only for point-in-time review comments.
+Use line numbers only for point-in-time review evidence.
 
 ## Definition of done
 
-A task is complete only when:
-
-- the intended behavior is implemented;
-- affected error/failure paths were considered;
-- relevant tests/checks from `docs/agent/TEST_MATRIX.md` pass, or any un-runnable check is explicitly reported;
-- observable behavior changes are reflected in docs;
-- the final diff contains no unrelated changes.
+A task is complete only when the applicable checklist in `docs/agent/verification/DEFINITION_OF_DONE.md` is satisfied, required checks pass (or un-runnable checks are explicitly reported), documentation reflects changed truths, and the final diff contains no unrelated changes.

--- a/docs/agent/INVARIANT_STANDARD.md
+++ b/docs/agent/INVARIANT_STANDARD.md
@@ -1,0 +1,102 @@
+---
+doc_id: agent.invariant-standard
+doc_type: engineering-standard
+truth: normative
+status: active
+---
+
+# Invariant Standard
+
+An invariant is a high-value truth that must remain valid across legitimate implementation changes unless the product/architecture contract intentionally changes.
+
+`INVARIANTS.md` is the current inventory. This document defines how that inventory is maintained.
+
+## What qualifies as an invariant
+
+A useful invariant is:
+
+- stable across ordinary refactors;
+- meaningful to correctness, safety, compatibility, or system semantics;
+- source-derived or contract-backed;
+- verifiable through code/tests/runtime evidence;
+- important enough that a future agent should check it before changing the area.
+
+Do not convert incidental implementation detail into an invariant.
+
+## Naming
+
+Use stable IDs:
+
+`INV-<DOMAIN>-NNN`
+
+Examples:
+
+- `INV-AUTH-001`
+- `INV-ROUTER-001`
+- `INV-BILLING-001`
+- `INV-PROVIDER-001`
+- `INV-TRACE-001`
+
+IDs should not be recycled after removal.
+
+## Risk levels
+
+- **Critical** — violation can cause security boundary failure, incorrect charging, tenant/user isolation failure, false provenance, secret exposure, or destructive persistence errors.
+- **High** — violation can materially change routing/provider execution, quota/usage, public API semantics, retry/streaming behavior, or migrations.
+- **Medium** — violation can break a bounded feature or operational contract.
+- **Low** — stable engineering convention with limited runtime blast radius.
+
+## Recommended invariant format
+
+```md
+### INV-DOMAIN-001 — Short name
+
+**Risk:** High
+
+**Rule:**
+A precise statement that should remain true.
+
+**Why:**
+Why the rule matters.
+
+**Applies to:**
+- affected runtime modes / routes / providers / data paths
+
+**Evidence:**
+- `path/to/file.rs :: SymbolName`
+- `path/to/test.rs :: test_name`
+
+**Verification:**
+How an agent can prove the invariant after a change.
+
+**Dynamic boundaries:**
+Any runtime-selected edge that must not be represented as static.
+```
+
+## Candidate invariant process
+
+When an agent discovers a potentially important rule:
+
+1. verify that it is not merely a local implementation accident;
+2. find stable evidence;
+3. assess its blast radius;
+4. add a stable ID only if future changes should explicitly preserve/check it;
+5. add/identify verification where possible.
+
+If evidence is incomplete, document the claim elsewhere as INFERRED/UNKNOWN instead of promoting it to a verified invariant.
+
+## Changing an invariant
+
+An intentional invariant change requires coordinated review of:
+
+- implementation;
+- tests;
+- runtime/architecture/contracts that describe the behavior;
+- `INVARIANTS.md`;
+- downstream compatibility/risk.
+
+Do not edit an invariant merely to make a conflicting implementation appear compliant.
+
+## Non-invariants
+
+Keep explicit non-invariants in `INVARIANTS.md` when an outdated architectural belief is likely to mislead future agents. This is especially valuable when historical docs or familiar patterns strongly suggest behavior that current source does not implement.

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -1,0 +1,156 @@
+---
+doc_id: agent.overview
+doc_type: agent-protocol
+truth: normative
+status: active
+---
+
+# BurnCloud Agent Docs
+
+BurnCloud Agent Docs define how autonomous software-engineering agents understand, change, verify, and report work in this repository.
+
+They are not a repository encyclopedia. They are an execution system that routes an agent from a user-visible behavior to the minimum authoritative context required to work safely.
+
+## Operating model
+
+```text
+User Task
+   |
+   v
+Task Contract
+   |
+   v
+AGENTS.md (Constitution + Router)
+   |
+   +----------------------+----------------------+
+   |                      |                      |
+   v                      v                      v
+Domain Contract       Runtime / Contract      Playbook
+   |                      |                      |
+   +----------------------+----------------------+
+                          |
+                          v
+                     Invariants
+                          |
+                          v
+                      Source Code
+                          |
+                          v
+                        Change
+                          |
+                          v
+                    Verification
+                          |
+                          v
+                   Invariant Check
+                          |
+                          v
+                    Evidence Report
+```
+
+## Documentation layers
+
+### 1. Constitution and routing
+
+- `AGENTS.md` — highest repository-level agent rules and document router.
+- `START_HERE.md` — required execution loop.
+- `TASK_ROUTER.md` — recurring behavior -> source/test starting points.
+- `TASK_CONTRACT.md` — minimum contract before non-trivial edits.
+
+### 2. Domain contracts
+
+`domains/` defines how domain documents must express responsibility, boundaries, sources of truth, side effects, invariants, risks, and verification.
+
+Domain docs must be source-audited before they claim implementation facts. Do not manufacture a domain document merely to fill a directory.
+
+### 3. Runtime, architecture, and contracts
+
+Existing repository trees remain authoritative navigation/evidence layers:
+
+- `docs/runtime/`
+- `docs/architecture/`
+- `docs/contracts/`
+
+Agent Docs route into those trees; they do not duplicate them.
+
+### 4. Invariants
+
+- `INVARIANTS.md` contains current source-derived engineering invariants.
+- `INVARIANT_STANDARD.md` defines how invariants are identified, named, reviewed, and verified.
+
+### 5. Playbooks
+
+`playbooks/` defines task-specific execution protocols such as bug fixes, features, refactors, provider integrations, and database changes.
+
+A playbook is about **how to work**, not about current business facts.
+
+### 6. Verification
+
+- `TEST_MATRIX.md` maps areas to concrete repository tests.
+- `verification/VERIFICATION_STANDARD.md` defines verification levels.
+- `verification/DEFINITION_OF_DONE.md` defines when an agent may claim completion.
+
+## Progressive disclosure
+
+Do not load the entire documentation tree by default.
+
+Use this path:
+
+```text
+Task
+ -> AGENTS.md
+ -> START_HERE.md
+ -> TASK_ROUTER.md
+ -> relevant domain/runtime/contract docs
+ -> relevant invariants
+ -> relevant source/tests
+```
+
+Only open additional documents when the current task crosses that boundary.
+
+## Evidence vocabulary
+
+Use these labels consistently:
+
+- **STATIC CONFIRMED** — directly visible in current source/tests.
+- **DYNAMIC** — runtime configuration, trait/adaptor/provider/channel selection, environment, data, or state controls the next target.
+- **INFERRED** — plausible but not fully proven by inspected evidence.
+- **UNKNOWN** — evidence has not yet established the fact.
+- **RUNTIME VERIFIED** — directly observed in an executed runtime/integration/E2E path.
+
+Do not turn DYNAMIC, INFERRED, or UNKNOWN into fixed architecture statements.
+
+## Generated vs curated documentation
+
+Prefer generation for facts that can be reliably extracted from source, such as:
+
+- route inventories;
+- symbol/package indexes;
+- call/reference maps;
+- provider registries;
+- test indexes.
+
+Human/agent-curated docs should primarily preserve what static extraction cannot safely infer:
+
+- responsibility and ownership;
+- business semantics;
+- architectural boundaries;
+- invariants;
+- risk;
+- change protocol;
+- verification requirements;
+- rationale.
+
+## Maintenance loop
+
+When source behavior changes, ask:
+
+```text
+Did ownership change?
+Did a runtime path change?
+Did an invariant change?
+Did verification ownership change?
+Did a contract/architecture fact change?
+```
+
+Update only the documents whose declared truth changed. Avoid documentation churn for refactors that preserve all externally relevant truths.

--- a/docs/agent/START_HERE.md
+++ b/docs/agent/START_HERE.md
@@ -3,18 +3,21 @@ doc_id: agent.start-here
 doc_type: agent-protocol
 truth: normative
 status: active
-audited_against: c7107382b8479deb44f992e9e5ae8dcac5efb417
 ---
 
 # Start Here — AI Agent Workflow
 
 ## Goal
 
-Reduce repository search, guessing, and accidental cross-flow regressions. Start from the requested behavior, not the directory tree.
+Reduce repository search, guessing, and accidental cross-flow regressions. Start from requested behavior, not the directory tree.
 
-## Required workflow
+The standard loop is:
 
-### 1. Restate the task as a user/runtime behavior
+`DISCOVER -> UNDERSTAND -> TRACE -> CONTRACT -> PLAN -> CHANGE -> VERIFY -> INSPECT -> REPORT`
+
+## 1. DISCOVER — restate the behavior
+
+Translate the request into a user/operator-visible behavior.
 
 Examples:
 
@@ -25,62 +28,109 @@ Examples:
 
 Do not begin with “edit file X” unless the user explicitly requires a file-level change.
 
-### 2. Route the task
+## 2. UNDERSTAND — route the task
 
-Open [`TASK_ROUTER.md`](TASK_ROUTER.md) and identify:
+Open `TASK_ROUTER.md` and identify:
 
-- primary source,
-- related source,
-- runtime flow,
-- relevant tests.
+- primary source;
+- related source;
+- runtime/contract docs;
+- tests/evidence to inspect;
+- likely ownership domain.
 
-### 3. Read the real entry point
+If a domain contract exists, read it. Do not create a fictional domain boundary from directory names alone.
+
+## 3. TRACE — read the real execution path
 
 Trace only as far as required to understand the change:
 
-`entry → branch → callee → state/external effect → return/error`.
+`entry -> branch -> callee -> state/external effect -> return/error`
 
-Do not build a giant repository-wide call graph.
+For important claims classify the edge as:
 
-### 4. Classify every important claim
+- **STATIC CONFIRMED** — directly visible in current code/tests;
+- **DYNAMIC** — runtime selection/configuration/state controls the target;
+- **INFERRED** — plausible but not fully proven;
+- **UNKNOWN** — not yet established.
 
-- **STATIC CONFIRMED** — directly visible in current code/tests.
-- **DYNAMIC** — trait object, runtime configuration, channel type, environment, or other runtime selection controls the target.
-- **INFERRED** — reasonable but not fully statically proven.
+Never present DYNAMIC, INFERRED, or UNKNOWN behavior as a fixed call path.
 
-Never present DYNAMIC/INFERRED behavior as a fixed call path.
+Do not build a repository-wide call graph when a smaller trace establishes the task boundary.
 
-### 5. Check invariants
+## 4. CONTRACT — establish the task contract
 
-Read [`INVARIANTS.md`](INVARIANTS.md). If the change would alter an invariant, call that out explicitly and update the invariant only together with code/tests.
+For every non-trivial task, create the minimum internal contract defined by `TASK_CONTRACT.md`:
 
-### 6. Make the smallest coherent change
+- goal;
+- current behavior;
+- expected behavior;
+- scope;
+- execution path;
+- impacts;
+- invariants;
+- verification;
+- done criteria.
 
-Prefer one runtime behavior per change. Avoid opportunistic refactors unless required to make the behavior correct/testable.
+The contract is a reasoning/control artifact. Do not commit one-off task contracts unless a long-lived repository workflow actually needs them.
 
-### 7. Run the relevant verification
+## 5. PLAN — plan from root cause / behavior gap
 
-Use [`TEST_MATRIX.md`](TEST_MATRIX.md). At minimum run targeted checks for the affected crate/flow; broader workspace checks are required when dependency/API boundaries change.
+A useful plan explains:
 
-### 8. Update docs only when the truth changed
+`problem -> root cause/behavior gap -> affected path -> required change -> verification strategy`
 
-Update docs when the code changes:
+A list of filenames is not a sufficient plan.
 
-- entry/routing behavior,
-- auth/admission behavior,
-- persistence/state mutation,
-- billing/accounting,
-- provider dispatch/failover,
-- a listed invariant,
-- task-routing ownership.
+## 6. CHANGE — make the smallest coherent modification
 
-Do not update docs for internal refactors that preserve these truths unless source locations/ownership changed materially.
+Prefer one runtime behavior per change. Avoid opportunistic refactors unless required for correctness or testability.
 
-## Evidence format for agent reasoning
+Follow the relevant task playbook under `playbooks/`.
 
-Prefer:
+## 7. VERIFY — prove function, regression, and invariants
+
+Read `INVARIANTS.md`, `TEST_MATRIX.md`, and `verification/VERIFICATION_STANDARD.md`.
+
+Verification answers three different questions:
+
+1. Does the requested behavior work?
+2. Did adjacent existing behavior remain intact?
+3. Do the relevant BurnCloud invariants still hold?
+
+One green test does not automatically answer all three.
+
+## 8. INSPECT — review the final diff
+
+Check for:
+
+- unrelated changes;
+- accidental deletion;
+- public API or business-semantic drift;
+- changed error/retry behavior;
+- debug or temporary code;
+- secrets;
+- weakened tests;
+- documentation that became stale.
+
+## 9. REPORT — provide evidence
+
+A completion report should separate:
+
+- result;
+- root cause or implementation rationale;
+- verified execution path;
+- changes;
+- verification actually run;
+- invariants checked;
+- known dynamic/unverified boundaries;
+- remaining risk;
+- unrelated changes (normally `None`).
+
+## Evidence references
+
+Prefer stable references:
 
 `path/to/file.rs :: SymbolName`  
 `path/to/test.rs :: test_name`
 
-Use line numbers only for point-in-time review evidence; they drift as code changes.
+Use line numbers only for point-in-time review evidence because they drift as code changes.

--- a/docs/agent/TASK_CONTRACT.md
+++ b/docs/agent/TASK_CONTRACT.md
@@ -1,0 +1,101 @@
+---
+doc_id: agent.task-contract
+doc_type: agent-protocol
+truth: normative
+status: active
+---
+
+# Task Contract
+
+A Task Contract converts a user request into an explicit engineering boundary before a non-trivial edit begins.
+
+It exists to prevent three common agent failures:
+
+1. editing before understanding current behavior;
+2. expanding scope while solving the task;
+3. declaring completion without an explicit proof target.
+
+## When required
+
+Use a Task Contract for any change that can affect runtime behavior, public/API behavior, persistence, routing, auth, billing, provider execution, concurrency, migrations, cross-crate APIs, or multiple files with coupled behavior.
+
+A trivial typo or purely local documentation correction does not require a formal contract.
+
+## Minimum template
+
+```yaml
+goal:
+  Observable user/operator outcome.
+
+current_behavior:
+  What current evidence proves today.
+
+expected_behavior:
+  Observable behavior after the change.
+
+entry:
+  Route, CLI command, UI event, background trigger, or other real entrypoint.
+
+execution_path:
+  Smallest verified path relevant to the change.
+
+scope:
+  allowed:
+    - Intended files/domains/components.
+  avoid:
+    - Boundaries that should not change unless new evidence requires it.
+
+domains:
+  - Relevant ownership domains.
+
+impact:
+  persistence: none | describe
+  external_calls: none | describe
+  billing_usage_quota: none | describe
+  auth_authorization: none | describe
+  routing_provider: none | describe
+  concurrency_transactions: none | describe
+
+invariants:
+  - IDs from INVARIANTS.md, or explicit candidate invariants requiring review.
+
+evidence:
+  - path/to/file.rs :: SymbolName
+  - path/to/test.rs :: test_name
+
+verification:
+  - Targeted checks.
+  - Regression checks.
+  - Runtime/E2E checks when needed.
+
+done_when:
+  - Observable completion criteria.
+```
+
+## Scope discipline
+
+`allowed` is not permission to blindly edit every listed file. It describes the anticipated boundary.
+
+`avoid` is not an absolute prohibition. If source evidence proves the root cause crosses that boundary, update the task contract before expanding the change.
+
+## Evidence discipline
+
+Classify material execution claims as:
+
+- STATIC CONFIRMED;
+- DYNAMIC;
+- INFERRED;
+- UNKNOWN;
+- RUNTIME VERIFIED.
+
+Do not list an inferred call path as evidence without labeling the uncertain edge.
+
+## Root-cause rule
+
+For bug fixes, the contract should contain the observed failure and the smallest evidence-backed root cause before implementation when the root cause can be established.
+
+Do not force a false root cause when evidence is incomplete. Mark it UNKNOWN and continue investigation.
+
+## Completion rule
+
+The task contract is satisfied only when the final diff remains within the evidence-backed scope, required verification has been run or explicitly reported as unavailable, and the applicable Definition of Done is met.

--- a/docs/agent/domains/README.md
+++ b/docs/agent/domains/README.md
@@ -1,0 +1,108 @@
+---
+doc_id: agent.domain-contract-standard
+doc_type: engineering-standard
+truth: normative
+status: active
+---
+
+# Domain Contracts
+
+A Domain Contract describes a stable ownership boundary that agents repeatedly need to reason about.
+
+Domain docs are not package summaries. A directory is not automatically a domain, and a domain may span multiple crates/modules.
+
+## When to create a domain document
+
+Create one only when all are true:
+
+1. the behavior recurs across engineering tasks;
+2. ownership can be established from current source/contracts;
+3. important invariants or side effects belong to the area;
+4. a dedicated document reduces repeated repository-wide search.
+
+Do not create placeholder domain facts that have not been audited.
+
+## Required structure
+
+```md
+---
+doc_id: agent.domain.<name>
+doc_type: domain-contract
+truth: source-derived
+status: active
+audited_against: <commit-sha>
+---
+
+# <Domain> Domain Contract
+
+## Responsibility
+What this domain owns.
+
+## Does not own
+Boundaries intentionally owned elsewhere.
+
+## Source of truth
+Current source/schema/configuration that defines behavior.
+
+## Entry points
+Real routes/events/callers entering the domain.
+
+## Core components
+Important symbols/modules after source verification.
+
+## Inputs
+Important inputs.
+
+## Outputs
+Important outputs.
+
+## Side effects
+Persistence, external calls, billing, logs, state, etc.
+
+## Dependencies
+Other stable domains/systems used.
+
+## Invariants
+Relevant `INV-*` IDs.
+
+## Runtime / contract docs
+Links to existing `docs/runtime/`, `docs/contracts/`, or `docs/architecture/` evidence maps.
+
+## Modification risks
+Likely blast radius and dangerous semantic changes.
+
+## Required verification
+Minimum verification for changes in this domain.
+
+## Related tests
+Stable tests/suites to inspect.
+
+## Dynamic boundaries
+Runtime-selected provider/channel/trait/config edges.
+
+## Known unknowns
+Facts intentionally not claimed because evidence is incomplete.
+```
+
+## Initial domain candidates
+
+Current `TASK_ROUTER.md` already identifies recurring engineering areas that may justify audited domain contracts over time:
+
+- router / channel selection;
+- provider execution/adapters;
+- billing / usage / quota;
+- authentication / authorization;
+- channel management;
+- API token/key management;
+- database behavior;
+- Console/UI workflows.
+
+This list is a documentation roadmap, not a claim that each boundary has already been formally audited.
+
+## Boundary rule
+
+A good Domain Contract helps answer:
+
+> “Is this the right layer to solve the problem?”
+
+It should make responsibility and non-responsibility equally clear so an agent does not solve a routing problem in billing, an auth problem in UI, or a provider-conversion problem by changing unrelated public API semantics.

--- a/docs/agent/playbooks/BUG_FIX.md
+++ b/docs/agent/playbooks/BUG_FIX.md
@@ -1,0 +1,74 @@
+---
+doc_id: agent.playbook.bug-fix
+doc_type: agent-playbook
+truth: normative
+status: active
+---
+
+# Bug Fix Playbook
+
+Use this for incorrect existing behavior.
+
+## Workflow
+
+```text
+REPRODUCE / ESTABLISH FAILURE
+        -> LOCATE ENTRY
+        -> TRACE EXECUTION
+        -> IDENTIFY ROOT CAUSE
+        -> IDENTIFY AFFECTED INVARIANTS
+        -> DESIGN SMALLEST FIX
+        -> IMPLEMENT
+        -> TARGETED VERIFY
+        -> REGRESSION VERIFY
+        -> DIFF INSPECTION
+        -> INVARIANT CHECK
+        -> EVIDENCE REPORT
+```
+
+## Required questions
+
+Before editing, answer:
+
+- What exact observable behavior is wrong?
+- Is the failure reproducible, test-proven, source-proven, or only reported?
+- What real entry point reaches the failing branch?
+- What is the smallest evidence-backed root cause?
+- Which adjacent success/error/retry/streaming paths can the fix affect?
+- Which invariants apply?
+
+## Root-cause discipline
+
+Do not treat these as default fixes:
+
+- swallowing an error;
+- inserting a zero/default value;
+- skipping validation;
+- disabling a test;
+- adding an unrelated retry/fallback;
+- catching a panic without fixing the invalid state.
+
+They are valid only when the intended contract explicitly requires that behavior.
+
+## Verification
+
+At minimum:
+
+1. prove the failing branch is corrected;
+2. run/inspect the closest regression tests;
+3. verify affected error/failure paths;
+4. verify relevant invariants;
+5. inspect the final diff for unrelated changes.
+
+For high-risk areas, raise the verification level according to `../verification/VERIFICATION_STANDARD.md` and `../TEST_MATRIX.md`.
+
+## Evidence report
+
+Report:
+
+- failure/root cause;
+- verified execution path;
+- changed symbols/files;
+- verification actually run;
+- invariants checked;
+- remaining dynamic/unverified boundaries.

--- a/docs/agent/playbooks/DATABASE_CHANGE.md
+++ b/docs/agent/playbooks/DATABASE_CHANGE.md
@@ -1,0 +1,57 @@
+---
+doc_id: agent.playbook.database-change
+doc_type: agent-playbook
+truth: normative
+status: active
+---
+
+# Database Change Playbook
+
+Use this for schema, migration, cross-dialect SQL, persistence semantics, or database API changes.
+
+## Before editing
+
+Inspect:
+
+- current schema and migrations;
+- database abstraction used by the affected crate;
+- existing rows/backfill implications;
+- NULL/default semantics;
+- indexes/constraints;
+- transactions and failure atomicity;
+- callers of changed persistence APIs;
+- SQLite/PostgreSQL compatibility where the repository supports both;
+- rollback/backward compatibility risk.
+
+Do not modify only an ORM/model structure if the real database schema/migration must also change.
+
+## Cross-dialect rule
+
+`INVARIANTS.md` currently documents the repository's placeholder abstraction for SQLite/PostgreSQL. Do not hard-code one placeholder dialect in code expected to support both databases without verifying the intended scope.
+
+## Workflow
+
+```text
+CONFIRM CURRENT SCHEMA
+ -> TRACE READ/WRITE CALLERS
+ -> DEFINE DATA COMPATIBILITY
+ -> DESIGN MIGRATION / API CHANGE
+ -> IMPLEMENT
+ -> VERIFY BOTH APPLICATION AND DATA BEHAVIOR
+ -> REGRESSION VERIFY
+ -> REVIEW ROLLBACK / FAILURE PATH
+```
+
+## Verification
+
+Depending on the change, verify:
+
+- migration application;
+- reads and writes with existing/new data;
+- defaults/NULL behavior;
+- constraints/index behavior;
+- transaction rollback/error paths;
+- affected service/API flow;
+- both supported SQL dialect paths when applicable.
+
+Schema changes generally require higher verification than a local query refactor. Use `../verification/VERIFICATION_STANDARD.md`.

--- a/docs/agent/playbooks/FEATURE.md
+++ b/docs/agent/playbooks/FEATURE.md
@@ -1,0 +1,57 @@
+---
+doc_id: agent.playbook.feature
+doc_type: agent-playbook
+truth: normative
+status: active
+---
+
+# Feature Playbook
+
+Use this for new observable behavior.
+
+## Workflow
+
+```text
+UNDERSTAND REQUEST
+ -> IDENTIFY DOMAIN
+ -> FIND EXISTING PATTERN
+ -> DEFINE EXPECTED BEHAVIOR
+ -> DEFINE INVARIANTS / COMPATIBILITY
+ -> DESIGN MINIMUM PATH
+ -> IMPLEMENT
+ -> VERIFY NEW BEHAVIOR
+ -> REGRESSION VERIFY
+ -> UPDATE CHANGED TRUTHS IN DOCS
+ -> REPORT
+```
+
+## Before implementation
+
+Establish:
+
+- user/operator outcome;
+- real entry point;
+- ownership domain;
+- existing nearby pattern that should be reused;
+- public API/data/config compatibility requirements;
+- persistence/external/billing/auth/routing impacts;
+- failure behavior;
+- acceptance criteria.
+
+Do not design from a hypothetical architecture if existing source already provides an extension point.
+
+## Implementation rule
+
+Prefer the minimum complete vertical slice that produces the requested behavior. Avoid constructing unused abstractions for imagined future features.
+
+## Verification
+
+Verify:
+
+1. requested behavior;
+2. invalid/error paths that are part of the feature contract;
+3. adjacent existing behavior;
+4. affected invariants;
+5. documentation whose declared truth changed.
+
+If the feature introduces a recurring ownership boundary or recurring engineering task, consider adding an audited Domain Contract or `TASK_ROUTER.md` entry. Do not add routing/docs merely because new files exist.

--- a/docs/agent/playbooks/PROVIDER_INTEGRATION.md
+++ b/docs/agent/playbooks/PROVIDER_INTEGRATION.md
@@ -1,0 +1,69 @@
+---
+doc_id: agent.playbook.provider-integration
+doc_type: agent-playbook
+truth: normative
+status: active
+---
+
+# Provider Integration Playbook
+
+Use this when adding or materially changing an upstream provider/adaptor execution path.
+
+Provider work is high risk because it can change request semantics, streaming, usage/billing, retries, errors, and provenance at once.
+
+## First: find the existing provider architecture
+
+Do not assume every provider follows the same static path.
+
+Identify from source:
+
+- registration/selection mechanism;
+- request conversion or passthrough boundary;
+- authentication/credential source;
+- endpoint construction;
+- streaming and non-streaming paths;
+- response/error conversion;
+- usage extraction;
+- retry/failover ownership;
+- billing/trace integration.
+
+Label runtime-selected edges `DYNAMIC`.
+
+## Integration checklist
+
+Inspect and define behavior for:
+
+- request conversion;
+- model mapping;
+- endpoint/versioning;
+- auth headers/signing;
+- headers/query parameters;
+- non-streaming response;
+- streaming response/chunk parsing;
+- tool/function calls if supported;
+- structured output if supported;
+- finish/stop reason mapping;
+- upstream errors/status codes;
+- timeout/cancellation;
+- retry/failover semantics;
+- usage/token parsing;
+- billing/cost settlement;
+- trace/provenance fields;
+- secrets/log redaction.
+
+Not every provider implements every capability. Unsupported behavior should be explicit rather than guessed.
+
+## Verification minimum
+
+A meaningful provider change should normally cover more than a happy path. Depending on capabilities, inspect/run:
+
+1. non-streaming success;
+2. streaming success;
+3. upstream error mapping;
+4. timeout/cancellation or retry path;
+5. usage parsing;
+6. billing/settlement implications;
+7. provider-specific regression tests;
+8. relevant end-to-end relay tests.
+
+Use `../TEST_MATRIX.md` to find current suites instead of inventing test paths.

--- a/docs/agent/playbooks/REFACTOR.md
+++ b/docs/agent/playbooks/REFACTOR.md
@@ -1,0 +1,50 @@
+---
+doc_id: agent.playbook.refactor
+doc_type: agent-playbook
+truth: normative
+status: active
+---
+
+# Refactor Playbook
+
+A refactor changes implementation structure while intentionally preserving defined behavior.
+
+Core contract:
+
+`observable behavior before == observable behavior after`
+
+If observable behavior is intentionally changing, the task is not a pure refactor and must include that behavior change explicitly in the Task Contract.
+
+## Before editing
+
+Define the behavior that must not change:
+
+- public interfaces;
+- success/error semantics;
+- persistence/state transitions;
+- billing/usage/quota semantics;
+- auth/authorization boundaries;
+- routing/provider selection behavior;
+- streaming/retry behavior;
+- concurrency/transaction behavior where relevant.
+
+Find the tests/evidence that currently protect those truths.
+
+## Workflow
+
+```text
+DEFINE PRESERVED BEHAVIOR
+ -> TRACE CURRENT OWNERSHIP
+ -> DEFINE REFACTOR BOUNDARY
+ -> CHANGE STRUCTURE
+ -> VERIFY PRESERVED BEHAVIOR
+ -> RUN RELEVANT REGRESSION
+ -> INSPECT DIFF
+```
+
+## Guardrails
+
+- Do not combine unrelated cleanup with the refactor.
+- Do not silently alter business logic to make the new structure easier.
+- Do not rewrite tests merely to match the new implementation shape if externally relevant behavior should remain identical.
+- Update runtime/domain docs only when ownership/source locations materially change; do not churn docs for internal movement that preserves all documented truths.

--- a/docs/agent/verification/DEFINITION_OF_DONE.md
+++ b/docs/agent/verification/DEFINITION_OF_DONE.md
@@ -1,0 +1,74 @@
+---
+doc_id: agent.definition-of-done
+doc_type: verification-guide
+truth: normative
+status: active
+---
+
+# Definition of Done
+
+An agent may claim a BurnCloud task is complete only when every applicable item below is satisfied or explicitly reported as not applicable/unavailable.
+
+## Understanding
+
+- [ ] The user/operator goal is explicit.
+- [ ] Current behavior was established from appropriate evidence.
+- [ ] The real entry/ownership point was found.
+- [ ] The relevant execution path was traced far enough to bound the change.
+- [ ] Important claims are labeled STATIC CONFIRMED, DYNAMIC, INFERRED, UNKNOWN, or RUNTIME VERIFIED as appropriate.
+
+## Contract and scope
+
+- [ ] The relevant domain/ownership boundary is known.
+- [ ] Applicable invariants were identified.
+- [ ] Root cause or implementation path is evidence-backed.
+- [ ] The final change remains within the Task Contract or the contract was explicitly expanded based on evidence.
+- [ ] No unrelated refactor/cleanup is mixed into the task.
+
+## Implementation
+
+- [ ] Requested behavior is implemented.
+- [ ] Relevant failure/error/retry/streaming paths were considered.
+- [ ] Public/API/persistence/billing/auth/routing semantics were not changed unintentionally.
+- [ ] No debug code, secrets, disabled checks, or temporary hacks remain.
+
+## Verification
+
+- [ ] The requested behavior has concrete evidence.
+- [ ] Required targeted checks were run or explicitly reported unavailable.
+- [ ] Required regression checks were run or explicitly reported unavailable.
+- [ ] Relevant invariants were re-checked.
+- [ ] Verification claims describe what actually ran, not what should probably pass.
+
+## Documentation
+
+- [ ] Runtime/architecture/contracts were updated when their declared truth changed.
+- [ ] `TASK_ROUTER.md` was updated if stable ownership moved.
+- [ ] `INVARIANTS.md` was updated if an invariant intentionally changed.
+- [ ] `TEST_MATRIX.md` was updated if verification ownership changed.
+- [ ] No documentation was changed merely to make the implementation appear correct.
+
+## Final inspection
+
+- [ ] The complete diff was inspected.
+- [ ] No unrelated files changed.
+- [ ] No accidental deletion or generated noise is present.
+- [ ] Remaining unknown/dynamic boundaries and risks are disclosed.
+
+## Completion report
+
+The final report should contain, when applicable:
+
+```text
+Result
+Root Cause / Rationale
+Verified Runtime or Ownership Path
+Changes
+Verification
+Invariants
+Evidence
+Remaining Risk
+Unrelated Changes
+```
+
+If a required verification step cannot run, the task can still be presented for review, but it must not be described as fully verified.

--- a/docs/agent/verification/VERIFICATION_STANDARD.md
+++ b/docs/agent/verification/VERIFICATION_STANDARD.md
@@ -1,0 +1,93 @@
+---
+doc_id: agent.verification-standard
+doc_type: verification-guide
+truth: normative
+status: active
+---
+
+# Verification Standard
+
+Verification is risk-based. Passing compilation proves only compilation; it does not prove the requested runtime behavior, regression safety, or invariant preservation.
+
+Use `../TEST_MATRIX.md` for current repository-specific test ownership.
+
+## Three proof questions
+
+Every non-trivial change should answer:
+
+1. **Functional:** does the requested behavior work?
+2. **Regression:** did adjacent existing behavior remain intact?
+3. **Invariant:** do relevant system truths still hold?
+
+## Verification levels
+
+### V0 — Inspection
+
+Static inspection only.
+
+Typical use: pure prose/docs changes with no executable behavior change.
+
+### V1 — Build / static checks
+
+Examples:
+
+- formatting;
+- type checking / compilation;
+- linting;
+- deterministic static validation scripts.
+
+V1 does not by itself prove business behavior.
+
+### V2 — Targeted behavior test
+
+Run the closest unit/package/component test proving the changed branch or behavior.
+
+### V3 — Regression verification
+
+Run targeted tests plus adjacent suites protecting neighboring behavior and affected interfaces.
+
+### V4 — Runtime / integration verification
+
+Exercise the real multi-component execution path or integration boundary.
+
+### V5 — End-to-end verification
+
+Exercise the complete user/operator flow from its external entry through relevant side effects and response.
+
+## Risk guidance
+
+| Change area | Typical minimum |
+|---|---|
+| Documentation only | V0 |
+| UI presentation only | V1-V2 |
+| Local utility/internal logic | V2 |
+| Handler/service behavior | V2-V3 |
+| Provider/adaptor | V3 |
+| Routing/failover | V3 |
+| Billing/usage/quota | V3 |
+| Authentication/authorization | V3 |
+| Database migration/persistence semantics | V4 where feasible |
+| Critical E2E data-plane behavior | V4-V5 where feasible |
+| Provenance/security boundary | V4-V5 where feasible |
+
+The table is a floor, not a ceiling. Raise the level when blast radius or uncertainty is higher.
+
+## Unavailable checks
+
+Never report an unavailable check as passed.
+
+Report:
+
+- what was attempted;
+- why it could not run;
+- what lower-level evidence was obtained instead;
+- remaining risk.
+
+## Documentation-only PRs
+
+For Agent Docs changes, V0 is sufficient only when the diff is purely Markdown/prose and does not alter scripts/configuration/executable contracts. The required checks are then:
+
+- inspect all changed paths;
+- verify links/path references against the repository tree where practical;
+- confirm no executable files changed;
+- review the final diff for contradictions with current agent/runtime docs.


### PR DESCRIPTION
## What changed

- turn `AGENTS.md` into the repository-level Agent Constitution + documentation router
- codify 20 core agent rules covering evidence, tracing, invariants, scope, failure handling, verification, and completion
- introduce a standard execution loop: `DISCOVER -> UNDERSTAND -> TRACE -> CONTRACT -> PLAN -> CHANGE -> VERIFY -> INSPECT -> REPORT`
- add a reusable Task Contract for non-trivial changes
- add the Domain Contract authoring standard without inventing unaudited domain facts
- add an invariant authoring/risk standard while preserving `INVARIANTS.md` as the current source-derived inventory
- add playbooks for bug fixes, features, refactors, provider integrations, and database changes
- add verification levels V0-V5 and a repository-wide Definition of Done
- update `START_HERE.md` to route agents through the new operating model

## Why

BurnCloud already had a strong source-derived Agent foundation (`START_HERE`, `TASK_ROUTER`, `INVARIANTS`, `TEST_MATRIX`, and `CHANGE_PROTOCOL`). This change turns those pieces into a more explicit Agent operating system without replacing the existing runtime/architecture/contracts documentation.

The goal is to make agent behavior consistent across Codex, Claude Code, Cursor, and other coding agents: understand the real system first, constrain the task, preserve invariants, verify the result, and report evidence.

## Impact

Documentation/agent policy only. No Rust source, build configuration, scripts, schemas, runtime behavior, billing, routing, authentication, provider execution, or UI code is changed.

Domain-specific implementation facts are intentionally not fabricated in this PR. Future domain contracts should be added only after source audit.

## Verification

- compared the branch against the current `main` base commit
- confirmed the branch is exactly one commit ahead
- confirmed all 13 changed paths are Markdown Agent Docs
- reviewed the new document links against the existing repository documentation layout
- no executable checks were required because this is a documentation-only V0 change under the newly defined verification standard

## Follow-up

After this foundation lands, the next useful step is to source-audit the first high-value Domain Contracts and Runtime Flows (routing/provider/billing/auth) rather than generating broad architecture prose.