### PR TITLE
Fix P0 security and billing invariants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,10 @@ BASE_URL=http://127.0.0.1:3000
 # JWT signing secret. Must be changed in production.
 # Default (debug builds): burncloud-default-secret-change-in-production
 # JWT_SECRET=burncloud-default-secret-change-in-production
-# Shared secret for internal API endpoints (X-Internal-Secret header). Optional.
-# BURNCLOUD_INTERNAL_SECRET=
+# Shared secret for sensitive internal POST endpoints (X-Internal-Secret header).
+# Required to use price-sync and emergency circuit-break operations; those
+# mutations fail closed when this value is missing or empty.
+# BURNCLOUD_INTERNAL_SECRET=replace-with-a-long-random-secret
 
 # ── Database ──────────────────────────────────────────────────────────────────
 # Database connection string. Defaults to local SQLite if unset.

--- a/.github/workflows/security-billing-invariants.yml
+++ b/.github/workflows/security-billing-invariants.yml
@@ -1,0 +1,57 @@
+name: Security & Billing Invariants
+
+on:
+  pull_request:
+    paths:
+      - "crates/server/**"
+      - "crates/router/**"
+      - "crates/database/crates/router/**"
+      - "crates/service/crates/router-log/**"
+      - ".github/workflows/security-billing-invariants.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/server/**"
+      - "crates/router/**"
+      - "crates/database/crates/router/**"
+      - "crates/service/crates/router-log/**"
+      - ".github/workflows/security-billing-invariants.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  invariants:
+    name: Security + Billing invariant suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      JWT_SECRET: burncloud-ci-security-invariant-jwt-secret-2026
+      BURNCLOUD_INTERNAL_SECRET: burncloud-ci-security-invariant-internal-secret
+      MASTER_KEY: a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8
+      SKIP_INITIAL_PRICE_SYNC: "1"
+      RUST_BACKTRACE: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Formatting
+        run: cargo fmt --check
+
+      - name: Check affected packages
+        run: cargo check -p burncloud-router -p burncloud-server
+
+      - name: Billing invariants
+        run: cargo test -p burncloud-router --test billing_invariants --test quota_tests
+
+      - name: Security invariants
+        run: cargo test -p burncloud-server --test security_invariants

--- a/crates/database/crates/router/src/lib.rs
+++ b/crates/database/crates/router/src/lib.rs
@@ -8,7 +8,7 @@
 //! - [`log`] - Router logs, usage stats and balance deduction (RouterLog, RouterLogModel, BalanceModel)
 //! - [`router_video_task`] - Router video task persistence (RouterVideoTask, RouterVideoTaskModel)
 
-use burncloud_database::{adapt_sql, Database, Result};
+use burncloud_database::{adapt_sql, phs, Database, Result};
 
 pub mod log;
 pub mod router_video_task;
@@ -228,8 +228,66 @@ impl RouterDatabase {
 
     // ============== Log delegations ==============
 
+    /// Insert an immutable usage/billing log entry.
+    ///
+    /// Logging is intentionally side-effect free with respect to credential
+    /// spend quota. Spend settlement is owned by `deduct_quota` and is scoped
+    /// to the credential that actually authorized the request.
     pub async fn insert_log(db: &Database, log: &RouterLog) -> Result<()> {
-        RouterLogModel::insert(db, log).await
+        let conn = db.get_connection()?;
+        let is_postgres = db.kind() == "postgres";
+        let sql = format!(
+            r#"
+            INSERT INTO router_logs
+            (request_id, user_id, path, upstream_id, status_code, latency_ms,
+             prompt_tokens, completion_tokens, cost,
+             model, cache_read_tokens, reasoning_tokens, pricing_region, video_tokens,
+             cache_write_tokens, audio_input_tokens, audio_output_tokens, image_tokens, embedding_tokens,
+             input_cost, output_cost, cache_read_cost, cache_write_cost,
+             audio_cost, image_cost, video_cost, reasoning_cost, embedding_cost,
+             layer_decision, traffic_color, cost_status, error_type)
+            VALUES ({})
+            "#,
+            phs(is_postgres, 32)
+        );
+
+        sqlx::query(&sql)
+            .bind(&log.request_id)
+            .bind(&log.user_id)
+            .bind(&log.path)
+            .bind(&log.upstream_id)
+            .bind(log.status_code)
+            .bind(log.latency_ms)
+            .bind(log.prompt_tokens)
+            .bind(log.completion_tokens)
+            .bind(log.cost)
+            .bind(&log.model)
+            .bind(log.cache_read_tokens)
+            .bind(log.reasoning_tokens)
+            .bind(&log.pricing_region)
+            .bind(log.video_tokens)
+            .bind(log.cache_write_tokens)
+            .bind(log.audio_input_tokens)
+            .bind(log.audio_output_tokens)
+            .bind(log.image_tokens)
+            .bind(log.embedding_tokens)
+            .bind(log.input_cost)
+            .bind(log.output_cost)
+            .bind(log.cache_read_cost)
+            .bind(log.cache_write_cost)
+            .bind(log.audio_cost)
+            .bind(log.image_cost)
+            .bind(log.video_cost)
+            .bind(log.reasoning_cost)
+            .bind(log.embedding_cost)
+            .bind(&log.layer_decision)
+            .bind(&log.traffic_color)
+            .bind(&log.cost_status)
+            .bind(&log.error_type)
+            .execute(conn.pool())
+            .await?;
+
+        Ok(())
     }
 
     pub async fn get_logs(db: &Database, limit: i32, offset: i32) -> Result<Vec<RouterLog>> {

--- a/crates/database/crates/router/src/token.rs
+++ b/crates/database/crates/router/src/token.rs
@@ -1,7 +1,7 @@
 //! Database operations for token management
 //!
 //! This crate handles all database operations related to API tokens,
-//! including validation, quota tracking, CRUD operations, and key rotation.
+//! including validation, spend-quota tracking, CRUD operations, and key rotation.
 
 use burncloud_common::CrudRepository;
 use burncloud_database::{adapt_sql, phs, Database, DatabaseError, Result};
@@ -40,8 +40,10 @@ pub struct RouterToken {
     pub user_id: String,
     pub status: String, // "active", "disabled"
     #[sqlx(default)]
-    pub quota_limit: i64, // -1 for unlimited
+    /// Spend limit in nanodollars. `-1` means unlimited.
+    pub quota_limit: i64,
     #[sqlx(default)]
+    /// Settled spend in nanodollars. Never store token counts in this field.
     pub used_quota: i64,
     #[sqlx(default)]
     pub expired_time: i64, // -1 for never expire, >0 = unix timestamp
@@ -79,6 +81,10 @@ impl RouterTokenModel {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs() as i64
+    }
+
+    fn quota_allows(limit: i64, used: i64, cost: i64) -> bool {
+        limit < 0 || used.saturating_add(cost) <= limit
     }
 
     /// List all tokens
@@ -270,7 +276,6 @@ impl RouterTokenModel {
             .fetch_optional(conn.pool())
             .await?
         {
-            // Check if token is expired
             if t.expired_time > 0 && now > t.expired_time {
                 return Ok(None);
             }
@@ -293,8 +298,6 @@ impl RouterTokenModel {
             .fetch_optional(conn.pool())
             .await?
         {
-            // Old key is valid during transition period
-            // Check if token itself is expired
             if t.expired_time > 0 && now > t.expired_time {
                 return Ok(None);
             }
@@ -312,7 +315,6 @@ impl RouterTokenModel {
         let conn = db.get_connection()?;
         let now = Self::current_timestamp();
 
-        // First, try to find the token directly
         let sql = adapt_sql(
             db.kind() == "postgres",
             "SELECT token, user_id, status, quota_limit, used_quota, expired_time, accessed_time, \
@@ -325,16 +327,13 @@ impl RouterTokenModel {
             .fetch_optional(conn.pool())
             .await?
         {
-            // Check if token is expired
             if t.expired_time > 0 && now > t.expired_time {
                 return Ok(RouterTokenValidationResult::Expired);
             }
             return Ok(RouterTokenValidationResult::Valid(t));
         }
 
-        // Check if it's an old key during transition period
         let token_hash = format!("{:x}", md5::compute(token.as_bytes()));
-
         let old_key_sql = adapt_sql(
             db.kind() == "postgres",
             "SELECT token, user_id, status, quota_limit, used_quota, expired_time, accessed_time, \
@@ -348,7 +347,6 @@ impl RouterTokenModel {
             .fetch_optional(conn.pool())
             .await?
         {
-            // Old key is valid during transition period
             if t.expired_time > 0 && now > t.expired_time {
                 return Ok(RouterTokenValidationResult::Expired);
             }
@@ -376,79 +374,153 @@ impl RouterTokenModel {
         Ok(())
     }
 
-    /// Check if quota is sufficient without deducting.
-    /// Cost parameter uses i64 nanodollars for precision.
-    /// quota_limit = -1 means unlimited.
+    /// Check whether a credential has enough spend quota for `cost`.
+    ///
+    /// `quota_limit` / `remain_quota` and `used_quota` are nanodollars.
+    /// Missing or inactive credentials fail closed. Router-token rotation aliases
+    /// are resolved to the canonical current token before checking quota.
     pub async fn check_quota(db: &Database, token: &str, cost: i64) -> Result<bool> {
-        let conn = db.get_connection()?;
-
         if cost <= 0 {
             return Ok(true);
         }
 
-        let quota_sql = adapt_sql(
-            db.kind() == "postgres",
-            "SELECT quota_limit, used_quota FROM router_tokens WHERE token = ?",
+        let conn = db.get_connection()?;
+        let is_postgres = db.kind() == "postgres";
+        let direct_sql = adapt_sql(
+            is_postgres,
+            "SELECT quota_limit, used_quota FROM router_tokens WHERE token = ? AND status = 'active'",
         );
-        let token_quota: Option<(i64, i64)> = sqlx::query_as(&quota_sql)
+        if let Some((limit, used)) = sqlx::query_as::<_, (i64, i64)>(&direct_sql)
+            .bind(token)
+            .fetch_optional(conn.pool())
+            .await?
+        {
+            return Ok(Self::quota_allows(limit, used, cost));
+        }
+
+        let now = Self::current_timestamp();
+        let token_hash = format!("{:x}", md5::compute(token.as_bytes()));
+        let old_key_sql = adapt_sql(
+            is_postgres,
+            "SELECT quota_limit, used_quota FROM router_tokens WHERE old_key_hash = ? AND old_key_expires_at > ? AND status = 'active'",
+        );
+        if let Some((limit, used)) = sqlx::query_as::<_, (i64, i64)>(&old_key_sql)
+            .bind(token_hash)
+            .bind(now)
+            .fetch_optional(conn.pool())
+            .await?
+        {
+            return Ok(Self::quota_allows(limit, used, cost));
+        }
+
+        let legacy_sql = adapt_sql(
+            is_postgres,
+            "SELECT remain_quota, used_quota FROM user_api_keys WHERE key = ? AND status = 1",
+        );
+        let legacy = sqlx::query_as::<_, (i64, i64)>(&legacy_sql)
             .bind(token)
             .fetch_optional(conn.pool())
             .await?;
 
-        if let Some((quota_limit, used_quota)) = token_quota {
-            // quota_limit = -1 means unlimited
-            if quota_limit >= 0 && used_quota + cost > quota_limit {
-                return Ok(false);
-            }
-        }
-
-        Ok(true)
+        Ok(legacy
+            .map(|(limit, used)| Self::quota_allows(limit, used, cost))
+            .unwrap_or(false))
     }
 
-    /// Deduct quota from token atomically.
-    /// Returns Ok(true) if deduction successful, Ok(false) if insufficient quota.
-    /// Cost parameter uses i64 nanodollars for precision.
-    /// quota_limit = -1 means unlimited.
+    /// Settle actual request cost against exactly the credential that was used.
+    ///
+    /// The write is durable even when the new total crosses a configured cap;
+    /// the return value then becomes `false` so the caller knows the credential
+    /// is exhausted. This prevents the final over-cap request from becoming free.
+    /// Missing/inactive credentials fail closed and never report a successful
+    /// settlement.
     pub async fn deduct_quota(db: &Database, token: &str, cost: i64) -> Result<bool> {
-        let conn = db.get_connection()?;
-        let is_postgres = db.kind() == "postgres";
-
         if cost <= 0 {
             return Ok(true);
         }
 
+        let conn = db.get_connection()?;
+        let is_postgres = db.kind() == "postgres";
         let mut tx = conn.pool().begin().await?;
 
-        // Read quota_limit and used_quota in one query. Any DB failure propagates as an error.
-        let quota_sql = adapt_sql(
+        let direct_sql = adapt_sql(
             is_postgres,
-            "SELECT quota_limit, used_quota FROM router_tokens WHERE token = ?",
+            "SELECT token, quota_limit, used_quota FROM router_tokens WHERE token = ? AND status = 'active'",
         );
-        let token_quota: Option<(i64, i64)> = sqlx::query_as(&quota_sql)
+        let mut router_quota = sqlx::query_as::<_, (String, i64, i64)>(&direct_sql)
             .bind(token)
             .fetch_optional(&mut *tx)
             .await?;
 
-        if let Some((quota_limit, used_quota)) = token_quota {
-            // quota_limit = -1 means unlimited
-            if quota_limit >= 0 && used_quota + cost > quota_limit {
+        if router_quota.is_none() {
+            let now = Self::current_timestamp();
+            let token_hash = format!("{:x}", md5::compute(token.as_bytes()));
+            let old_key_sql = adapt_sql(
+                is_postgres,
+                "SELECT token, quota_limit, used_quota FROM router_tokens WHERE old_key_hash = ? AND old_key_expires_at > ? AND status = 'active'",
+            );
+            router_quota = sqlx::query_as::<_, (String, i64, i64)>(&old_key_sql)
+                .bind(token_hash)
+                .bind(now)
+                .fetch_optional(&mut *tx)
+                .await?;
+        }
+
+        if let Some((canonical_token, limit, used)) = router_quota {
+            let within_limit = Self::quota_allows(limit, used, cost);
+            let update_sql = adapt_sql(
+                is_postgres,
+                "UPDATE router_tokens SET used_quota = used_quota + ? WHERE token = ? AND status = 'active'",
+            );
+            let rows = sqlx::query(&update_sql)
+                .bind(cost)
+                .bind(canonical_token)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+            if rows == 0 {
                 tx.rollback().await?;
                 return Ok(false);
             }
+            tx.commit().await?;
+            return Ok(within_limit);
         }
 
-        let deduct_sql = adapt_sql(
+        // `user_api_keys` is the primary credential table for normal API keys.
+        // `remain_quota = -1` represents unlimited quota, including keys created
+        // with `unlimited_quota=true`.
+        let legacy_sql = adapt_sql(
             is_postgres,
-            "UPDATE router_tokens SET used_quota = used_quota + ? WHERE token = ?",
+            "SELECT remain_quota, used_quota FROM user_api_keys WHERE key = ? AND status = 1",
         );
-        sqlx::query(&deduct_sql)
+        let legacy = sqlx::query_as::<_, (i64, i64)>(&legacy_sql)
+            .bind(token)
+            .fetch_optional(&mut *tx)
+            .await?;
+
+        let Some((limit, used)) = legacy else {
+            tx.rollback().await?;
+            return Ok(false);
+        };
+
+        let within_limit = Self::quota_allows(limit, used, cost);
+        let update_sql = adapt_sql(
+            is_postgres,
+            "UPDATE user_api_keys SET used_quota = used_quota + ? WHERE key = ? AND status = 1",
+        );
+        let rows = sqlx::query(&update_sql)
             .bind(cost)
             .bind(token)
             .execute(&mut *tx)
-            .await?;
+            .await?
+            .rows_affected();
+        if rows == 0 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
 
         tx.commit().await?;
-        Ok(true)
+        Ok(within_limit)
     }
 
     /// Revoke old key version immediately
@@ -491,10 +563,9 @@ impl RouterTokenModel {
             .await?;
 
         match ip_whitelist {
-            None => Ok(true),                              // No whitelist = all IPs allowed
-            Some(ref list) if list.is_empty() => Ok(true), // Empty whitelist = all IPs allowed
+            None => Ok(true),
+            Some(ref list) if list.is_empty() => Ok(true),
             Some(list) => {
-                // Parse whitelist (comma-separated CIDR ranges or IPs)
                 for entry in list.split(',') {
                     let entry = entry.trim();
                     if entry.is_empty() {

--- a/crates/router/tests/billing_invariants.rs
+++ b/crates/router/tests/billing_invariants.rs
@@ -1,0 +1,165 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::disallowed_types
+)]
+
+mod common;
+
+use burncloud_database::sqlx;
+use burncloud_database_router::{RouterDatabase, RouterLog, RouterTokenModel};
+use common::{insert_router_token, setup_db};
+
+fn test_log(user_id: &str) -> RouterLog {
+    RouterLog {
+        id: 0,
+        request_id: uuid::Uuid::new_v4().to_string(),
+        user_id: Some(user_id.to_string()),
+        path: "/v1/chat/completions".to_string(),
+        upstream_id: Some("1".to_string()),
+        status_code: 200,
+        latency_ms: 10,
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        cost: 25_000_000,
+        model: Some("test-model".to_string()),
+        cache_read_tokens: 0,
+        reasoning_tokens: 0,
+        pricing_region: None,
+        video_tokens: 0,
+        cache_write_tokens: 0,
+        audio_input_tokens: 0,
+        audio_output_tokens: 0,
+        image_tokens: 0,
+        embedding_tokens: 0,
+        input_cost: 10_000_000,
+        output_cost: 15_000_000,
+        cache_read_cost: 0,
+        cache_write_cost: 0,
+        audio_cost: 0,
+        image_cost: 0,
+        video_cost: 0,
+        reasoning_cost: 0,
+        embedding_cost: 0,
+        layer_decision: None,
+        traffic_color: None,
+        cost_status: Some("ok".to_string()),
+        error_type: None,
+        created_at: None,
+    }
+}
+
+#[tokio::test]
+async fn router_log_insert_never_mutates_spend_quota() -> anyhow::Result<()> {
+    let (db, pool, _db_url) = setup_db().await?;
+
+    for (token, used) in [("bc_live_log_a", 100_i64), ("bc_live_log_b", 200_i64)] {
+        sqlx::query(
+            "INSERT INTO router_tokens (token, user_id, status, quota_limit, used_quota) VALUES (?, 'same-user', 'active', 1000000000, ?)",
+        )
+        .bind(token)
+        .bind(used)
+        .execute(&pool)
+        .await?;
+    }
+
+    RouterDatabase::insert_log(&db, &test_log("same-user")).await?;
+
+    let a: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
+        .bind("bc_live_log_a")
+        .fetch_one(&pool)
+        .await?;
+    let b: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
+        .bind("bc_live_log_b")
+        .fetch_one(&pool)
+        .await?;
+
+    assert_eq!(a, 100, "usage logging must not settle spend for token A");
+    assert_eq!(b, 200, "usage logging must not settle spend for token B");
+    Ok(())
+}
+
+#[tokio::test]
+async fn spend_settlement_is_scoped_to_the_presented_router_token() -> anyhow::Result<()> {
+    let (db, pool, _db_url) = setup_db().await?;
+
+    for token in ["bc_live_scope_a", "bc_live_scope_b"] {
+        sqlx::query(
+            "INSERT INTO router_tokens (token, user_id, status, quota_limit, used_quota) VALUES (?, 'same-user', 'active', 100, 0)",
+        )
+        .bind(token)
+        .execute(&pool)
+        .await?;
+    }
+
+    assert!(RouterDatabase::deduct_quota(&db, "same-user", "bc_live_scope_a", 40).await?);
+
+    let a: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
+        .bind("bc_live_scope_a")
+        .fetch_one(&pool)
+        .await?;
+    let b: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
+        .bind("bc_live_scope_b")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!((a, b), (40, 0), "one key must never consume another key's quota");
+
+    assert!(!RouterDatabase::deduct_quota(&db, "same-user", "bc_live_scope_a", 70).await?);
+    let a: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
+        .bind("bc_live_scope_a")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(a, 110, "actual over-cap spend must still be durably settled");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn user_api_key_settlement_is_key_scoped() -> anyhow::Result<()> {
+    let (db, pool, _db_url) = setup_db().await?;
+
+    insert_router_token(&db, "sk-legacy-a", "legacy-user", "default", None, None).await?;
+    insert_router_token(&db, "sk-legacy-b", "legacy-user", "default", None, None).await?;
+
+    sqlx::query("UPDATE user_api_keys SET remain_quota = 100, used_quota = 0 WHERE user_id = ?")
+        .bind("legacy-user")
+        .execute(&pool)
+        .await?;
+
+    assert!(RouterDatabase::deduct_quota(&db, "legacy-user", "sk-legacy-a", 25).await?);
+
+    let a: i64 = sqlx::query_scalar("SELECT used_quota FROM user_api_keys WHERE key = ?")
+        .bind("sk-legacy-a")
+        .fetch_one(&pool)
+        .await?;
+    let b: i64 = sqlx::query_scalar("SELECT used_quota FROM user_api_keys WHERE key = ?")
+        .bind("sk-legacy-b")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!((a, b), (25, 0));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn rotated_old_key_settles_against_the_current_key() -> anyhow::Result<()> {
+    let (db, pool, _db_url) = setup_db().await?;
+
+    sqlx::query(
+        "INSERT INTO router_tokens (token, user_id, status, quota_limit, used_quota, key_version, key_prefix) VALUES (?, 'rotate-user', 'active', 100, 0, 1, 'bc_live_')",
+    )
+    .bind("bc_live_old")
+    .execute(&pool)
+    .await?;
+
+    let rotation = RouterTokenModel::rotate(&db, "bc_live_old", 1, false).await?;
+    assert!(RouterDatabase::deduct_quota(&db, "rotate-user", "bc_live_old", 30).await?);
+
+    let used: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
+        .bind(&rotation.new_token)
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(used, 30, "transition keys must not create an unmetered billing path");
+
+    Ok(())
+}

--- a/crates/router/tests/quota_tests.rs
+++ b/crates/router/tests/quota_tests.rs
@@ -14,12 +14,11 @@ use burncloud_database_router::RouterDatabase;
 use common::setup_db;
 use std::time::Duration;
 
-/// Test quota deduction
+/// Spend quota is measured in nanodollars and actual cost is always settled.
 #[tokio::test]
 async fn test_quota_deduction() -> anyhow::Result<()> {
-    let (_db, pool, _db_url) = setup_db().await?;
+    let (db, pool, _db_url) = setup_db().await?;
 
-    // Create a test token with limited quota
     sqlx::query(
         r#"
         INSERT INTO router_tokens (token, user_id, status, quota_limit, used_quota)
@@ -31,65 +30,52 @@ async fn test_quota_deduction() -> anyhow::Result<()> {
     .execute(&pool)
     .await?;
 
-    // Small delay to ensure SQLite transaction completes
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    // Deduct 50 quota
     let result =
-        RouterDatabase::deduct_quota(&_db, "test-quota-user", "sk-test-quota-token", 50).await?;
-    assert!(result, "Deduction should succeed");
-
-    // Small delay
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    // Check used_quota
-    let used: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
-        .bind("sk-test-quota-token")
-        .fetch_one(&pool)
-        .await?;
-
-    assert_eq!(used, 50, "used_quota should be 50");
-
-    // Deduct another 50 (should succeed, total 100)
-    let result =
-        RouterDatabase::deduct_quota(&_db, "test-quota-user", "sk-test-quota-token", 50).await?;
-    assert!(result, "Second deduction should succeed");
-
-    tokio::time::sleep(Duration::from_millis(50)).await;
+        RouterDatabase::deduct_quota(&db, "test-quota-user", "sk-test-quota-token", 50).await?;
+    assert!(result, "Settlement within the spend cap should report available");
 
     let used: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
         .bind("sk-test-quota-token")
         .fetch_one(&pool)
         .await?;
+    assert_eq!(used, 50, "used_quota is settled nanodollar spend");
 
-    assert_eq!(used, 100, "used_quota should be 100");
-
-    // Try to deduct 1 more (should fail - quota exceeded)
     let result =
-        RouterDatabase::deduct_quota(&_db, "test-quota-user", "sk-test-quota-token", 1).await?;
-    assert!(!result, "Deduction should fail - quota exceeded");
+        RouterDatabase::deduct_quota(&db, "test-quota-user", "sk-test-quota-token", 50).await?;
+    assert!(result, "Settlement reaching the cap should still report available");
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    // Verify used_quota didn't change
     let used: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
         .bind("sk-test-quota-token")
         .fetch_one(&pool)
         .await?;
+    assert_eq!(used, 100);
 
-    assert_eq!(used, 100, "used_quota should still be 100");
+    // The final request may cross the cap because the exact cost is only known
+    // after the upstream response. Its real cost must still be recorded, while
+    // the return value tells the caller the credential is now exhausted.
+    let result =
+        RouterDatabase::deduct_quota(&db, "test-quota-user", "sk-test-quota-token", 1).await?;
+    assert!(!result, "Over-cap settlement should report quota exhausted");
 
-    println!("✓ Quota deduction test passed");
+    let used: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
+        .bind("sk-test-quota-token")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(used, 101, "actual spend must never be silently dropped");
+
+    let result = RouterDatabase::check_quota(&db, "sk-test-quota-token", 1).await?;
+    assert!(!result, "An exhausted credential must fail the next pre-check");
 
     Ok(())
 }
 
-/// Test unlimited quota token
+/// Unlimited spend quota remains unlimited but settlement is still recorded.
 #[tokio::test]
 async fn test_unlimited_quota() -> anyhow::Result<()> {
-    let (_db, pool, _db_url) = setup_db().await?;
+    let (db, pool, _db_url) = setup_db().await?;
 
-    // Create a token with unlimited quota
     sqlx::query(
         r#"
         INSERT INTO router_tokens (token, user_id, status, quota_limit, used_quota)
@@ -101,29 +87,29 @@ async fn test_unlimited_quota() -> anyhow::Result<()> {
     .execute(&pool)
     .await?;
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    // Deduct a large amount
     let result = RouterDatabase::deduct_quota(
-        &_db,
+        &db,
         "test-unlimited-user",
         "sk-test-unlimited-token",
         1_000_000,
     )
     .await?;
-    assert!(result, "Unlimited token should always succeed");
+    assert!(result, "Unlimited token should always report quota available");
 
-    println!("✓ Unlimited quota test passed");
+    let used: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
+        .bind("sk-test-unlimited-token")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(used, 1_000_000, "unlimited does not mean unmetered");
 
     Ok(())
 }
 
-/// Test quota check without deduction
+/// Quota checks are read-only and missing credentials fail closed.
 #[tokio::test]
 async fn test_quota_check() -> anyhow::Result<()> {
-    let (_db, pool, _db_url) = setup_db().await?;
+    let (db, pool, _db_url) = setup_db().await?;
 
-    // Create a token with quota 100
     sqlx::query(
         r#"
         INSERT INTO router_tokens (token, user_id, status, quota_limit, used_quota)
@@ -135,25 +121,26 @@ async fn test_quota_check() -> anyhow::Result<()> {
     .execute(&pool)
     .await?;
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    let result = RouterDatabase::check_quota(&db, "sk-test-check-token", 40).await?;
+    assert!(result, "Should have enough spend quota");
 
-    // Check if 40 quota is available (should pass: 50 used + 40 = 90 < 100)
-    let result = RouterDatabase::check_quota(&_db, "sk-test-check-token", 40).await?;
-    assert!(result, "Should have enough quota");
+    let result = RouterDatabase::check_quota(&db, "sk-test-check-token", 60).await?;
+    assert!(!result, "Should not have enough spend quota");
 
-    // Check if 60 quota is available (should fail: 50 used + 60 = 110 > 100)
-    let result = RouterDatabase::check_quota(&_db, "sk-test-check-token", 60).await?;
-    assert!(!result, "Should not have enough quota");
-
-    // Verify used_quota didn't change
     let used: i64 = sqlx::query_scalar("SELECT used_quota FROM router_tokens WHERE token = ?")
         .bind("sk-test-check-token")
         .fetch_one(&pool)
         .await?;
+    assert_eq!(used, 50, "quota check must not mutate settlement state");
 
-    assert_eq!(used, 50, "used_quota should still be 50");
-
-    println!("✓ Quota check test passed");
+    assert!(
+        !RouterDatabase::check_quota(&db, "missing-token", 1).await?,
+        "unknown credentials must fail closed"
+    );
+    assert!(
+        !RouterDatabase::deduct_quota(&db, "test-check-user", "missing-token", 1).await?,
+        "unknown credentials must not report a successful settlement"
+    );
 
     Ok(())
 }

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -3,7 +3,7 @@ use crate::AppState;
 use axum::{
     body::Body,
     extract::{Json, State},
-    http::{Request, StatusCode},
+    http::{Method, Request, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -66,6 +66,118 @@ pub fn verify_jwt(token: &str) -> Result<Claims, jsonwebtoken::errors::Error> {
         &Validation::default(),
     )?;
     Ok(token_data.claims)
+}
+
+/// Resolve whether the authenticated principal currently has the admin role.
+/// Roles are read from the database instead of trusting client-provided claims.
+pub async fn is_admin(state: &AppState, claims: &Claims) -> Result<bool, StatusCode> {
+    state
+        .user_service
+        .get_user_roles(&state.db, &claims.sub)
+        .await
+        .map(|roles| roles.iter().any(|role| role == "admin"))
+        .map_err(|e| {
+            tracing::error!(user_id = %claims.sub, error = %e, "Failed to resolve admin role");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+}
+
+/// Authorization middleware for administrator-only Console routes.
+/// Authentication must run outside this layer so `Claims` are already present.
+#[tracing::instrument(skip_all)]
+pub async fn admin_middleware(
+    State(state): State<AppState>,
+    req: Request<Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let claims = req
+        .extensions()
+        .get::<Claims>()
+        .cloned()
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    if is_admin(&state, &claims).await? {
+        Ok(next.run(req).await)
+    } else {
+        Err(StatusCode::FORBIDDEN)
+    }
+}
+
+fn is_data_plane_path(path: &str) -> bool {
+    path == "/v1"
+        || path.starts_with("/v1/")
+        || path == "/api/v1"
+        || path.starts_with("/api/v1/")
+}
+
+fn is_sensitive_internal_mutation(method: &Method, path: &str) -> bool {
+    method == Method::POST
+        && matches!(
+            path,
+            "/console/internal/prices/sync" | "/console/internal/circuit-breaker/trip-all"
+        )
+}
+
+/// Enforce the trust boundary between the management plane, data plane, and
+/// sensitive internal control-plane mutations.
+///
+/// Invariants:
+/// - a Console JWT is never accepted as an inference credential;
+/// - sensitive internal POST endpoints fail closed unless
+///   `BURNCLOUD_INTERNAL_SECRET` is configured and presented.
+#[tracing::instrument(skip_all)]
+pub async fn security_boundary_middleware(
+    req: Request<Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let path = req.uri().path();
+
+    if is_sensitive_internal_mutation(req.method(), path) {
+        let expected = std::env::var("BURNCLOUD_INTERNAL_SECRET")
+            .ok()
+            .filter(|secret| !secret.is_empty())
+            .ok_or_else(|| {
+                tracing::error!(
+                    path,
+                    "Sensitive internal endpoint disabled: BURNCLOUD_INTERNAL_SECRET is not configured"
+                );
+                StatusCode::SERVICE_UNAVAILABLE
+            })?;
+        let provided = req
+            .headers()
+            .get("x-internal-secret")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("");
+        if provided != expected {
+            tracing::warn!(path, "Rejected unauthorized internal mutation");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    }
+
+    if is_data_plane_path(path) {
+        let credential = req
+            .headers()
+            .get("authorization")
+            .and_then(|header| header.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .or_else(|| {
+                req.headers()
+                    .get("x-api-key")
+                    .and_then(|header| header.to_str().ok())
+            })
+            .or_else(|| {
+                req.headers()
+                    .get("x-goog-api-key")
+                    .and_then(|header| header.to_str().ok())
+            });
+
+        if credential.is_some_and(|token| verify_jwt(token).is_ok()) {
+            tracing::warn!(path, "Rejected Console JWT on data-plane route");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    }
+
+    Ok(next.run(req).await)
 }
 
 /// Public routes - no authentication required

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -27,31 +27,39 @@ async fn api_not_found() -> impl IntoResponse {
 }
 
 pub fn routes(state: AppState) -> Router {
-    // Public routes - no authentication required
-    // These are auth endpoints that must be accessible without a token
+    // Public routes - no authentication required.
     let public_routes = Router::new()
         .merge(auth::public_routes())
         .with_state(state.clone());
 
-    // Protected routes - authentication required
-    // All /console/api/* endpoints (except public auth routes) require a valid JWT
+    // Administrator-only management surfaces. Authentication runs on the
+    // outer protected router; this inner layer performs authorization.
+    let admin_routes = Router::new()
+        .merge(channel::routes())
+        .merge(log::routes())
+        .merge(monitor::routes())
+        .merge(security::security_routes())
+        .merge(cache::routes())
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::admin_middleware,
+        ));
+
+    // Authenticated self-service routes. Token handlers perform resource-level
+    // owner/admin authorization because users are allowed to manage their own
+    // API credentials while administrators may manage all credentials.
     let protected_routes = Router::new()
         .merge(auth::protected_routes())
         .merge(billing::routes())
-        .merge(channel::routes())
         .merge(token::routes())
-        .merge(log::routes())
-        .merge(monitor::routes())
         .merge(user::routes())
-        .merge(security::security_routes())
         .merge(openapi::routes())
-        .merge(cache::routes())
-        // Catch-all for any unmatched /console/api/* paths
-        // This prevents LiveView from returning HTML for non-existent API endpoints
+        .merge(admin_routes)
+        // Catch-all for any unmatched /console/api/* paths. This prevents
+        // LiveView from returning HTML for non-existent API endpoints.
         .route("/console/api/{*path}", get(api_not_found))
         .layer(middleware::from_fn(crate::auth_middleware))
         .with_state(state);
 
-    // Merge public and protected routes
     public_routes.merge(protected_routes)
 }

--- a/crates/server/src/api/response.rs
+++ b/crates/server/src/api/response.rs
@@ -1,4 +1,5 @@
 /// Typed API response helpers — eliminates `serde_json::Value` from handler return types.
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json};
 use serde::Serialize;
 
@@ -26,4 +27,19 @@ pub fn err(msg: impl ToString) -> impl IntoResponse {
         success: false,
         message: msg.to_string(),
     })
+}
+
+/// Return the standard failure envelope with an explicit HTTP status.
+///
+/// Prefer this helper for authorization, validation, and not-found branches so
+/// callers, proxies, and SDKs can rely on the HTTP contract instead of parsing
+/// `success: false` from a 200 response.
+pub fn err_status(status: StatusCode, msg: impl ToString) -> impl IntoResponse {
+    (
+        status,
+        Json(ApiFailure {
+            success: false,
+            message: msg.to_string(),
+        }),
+    )
 }

--- a/crates/server/src/api/token.rs
+++ b/crates/server/src/api/token.rs
@@ -1,7 +1,9 @@
+use crate::api::auth::{is_admin, Claims};
 use crate::AppState;
 use axum::{
-    extract::{Json, Path, State},
-    response::IntoResponse,
+    extract::{Extension, Json, Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
     routing::{get, post},
     Router,
 };
@@ -9,11 +11,12 @@ use burncloud_service_token::{RouterToken, TokenService};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::response::{err, ok};
+use super::response::{err, err_status, ok};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CreateTokenRequest {
     pub user_id: String,
+    /// Spend limit in nanodollars. `-1` means unlimited.
     pub quota_limit: Option<i64>,
 }
 
@@ -37,6 +40,51 @@ pub struct SetIpWhitelistRequest {
     pub ip_whitelist: String,
 }
 
+/// A management-plane representation that never returns the bearer secret.
+/// The full token is only returned once by create/rotate operations.
+#[derive(Debug, Serialize)]
+struct TokenSummary {
+    token_hint: String,
+    user_id: String,
+    status: String,
+    quota_limit: i64,
+    used_quota: i64,
+    expired_time: i64,
+    accessed_time: i64,
+    key_version: i32,
+    old_key_expires_at: i64,
+    ip_whitelist: Option<String>,
+    key_prefix: String,
+    created_at: i64,
+    last_rotated_at: i64,
+}
+
+fn token_hint(token: &RouterToken) -> String {
+    let suffix: String = token.token.chars().rev().take(4).collect::<Vec<_>>().into_iter().rev().collect();
+    format!("{}…{}", token.key_prefix, suffix)
+}
+
+impl From<RouterToken> for TokenSummary {
+    fn from(token: RouterToken) -> Self {
+        let hint = token_hint(&token);
+        Self {
+            token_hint: hint,
+            user_id: token.user_id,
+            status: token.status,
+            quota_limit: token.quota_limit,
+            used_quota: token.used_quota,
+            expired_time: token.expired_time,
+            accessed_time: token.accessed_time,
+            key_version: token.key_version,
+            old_key_expires_at: token.old_key_expires_at,
+            ip_whitelist: token.ip_whitelist,
+            key_prefix: token.key_prefix,
+            created_at: token.created_at,
+            last_rotated_at: token.last_rotated_at,
+        }
+    }
+}
+
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/console/api/tokens", post(create_token).get(list_tokens))
@@ -55,13 +103,52 @@ pub fn routes() -> Router<AppState> {
         )
 }
 
+async fn principal_is_admin(state: &AppState, claims: &Claims) -> Result<bool, Response> {
+    is_admin(state, claims)
+        .await
+        .map_err(|status| err_status(status, "Failed to authorize request").into_response())
+}
+
+async fn authorized_token(
+    state: &AppState,
+    claims: &Claims,
+    token: &str,
+) -> Result<RouterToken, Response> {
+    let admin = principal_is_admin(state, claims).await?;
+    let tokens = TokenService::list(&state.db).await.map_err(|e| {
+        tracing::error!(error = %e, "Failed to load API token for authorization");
+        err_status(StatusCode::INTERNAL_SERVER_ERROR, "Failed to load API token").into_response()
+    })?;
+
+    let Some(record) = tokens.into_iter().find(|record| record.token == token) else {
+        return Err(err_status(StatusCode::NOT_FOUND, "Token not found").into_response());
+    };
+
+    if admin || record.user_id == claims.sub {
+        Ok(record)
+    } else {
+        Err(err_status(StatusCode::FORBIDDEN, "Token access denied").into_response())
+    }
+}
+
 #[tracing::instrument(skip_all)]
-async fn list_tokens(State(state): State<AppState>) -> impl IntoResponse {
-    tracing::info!("[API] list_tokens request received");
+async fn list_tokens(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+) -> impl IntoResponse {
+    let admin = match principal_is_admin(&state, &claims).await {
+        Ok(value) => value,
+        Err(response) => return response,
+    };
+
     match TokenService::list(&state.db).await {
         Ok(tokens) => {
-            tracing::info!("[API] list_tokens success: found {} tokens", tokens.len());
-            ok(tokens).into_response()
+            let summaries: Vec<TokenSummary> = tokens
+                .into_iter()
+                .filter(|token| admin || token.user_id == claims.sub)
+                .map(TokenSummary::from)
+                .collect();
+            ok(summaries).into_response()
         }
         Err(e) => {
             tracing::error!("[API] list_tokens error: {}", e);
@@ -70,16 +157,23 @@ async fn list_tokens(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
-#[tracing::instrument(skip(state), fields(user_id = %payload.user_id))]
+#[tracing::instrument(skip_all, fields(user_id = %payload.user_id))]
 async fn create_token(
     State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
     Json(payload): Json<CreateTokenRequest>,
 ) -> impl IntoResponse {
-    tracing::info!(
-        "[API] create_token request: user_id={}, quota={:?}",
-        payload.user_id,
-        payload.quota_limit
-    );
+    let admin = match principal_is_admin(&state, &claims).await {
+        Ok(value) => value,
+        Err(response) => return response,
+    };
+    if !admin && payload.user_id != claims.sub {
+        return err_status(
+            StatusCode::FORBIDDEN,
+            "Users may only create API tokens for themselves",
+        )
+        .into_response();
+    }
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -87,10 +181,11 @@ async fn create_token(
         .as_secs() as i64;
 
     let token_str = format!("bc_live_{}", Uuid::new_v4());
+    let user_id = payload.user_id;
 
     let db_token = RouterToken {
         token: token_str.clone(),
-        user_id: payload.user_id,
+        user_id: user_id.clone(),
         status: "active".to_string(),
         quota_limit: payload.quota_limit.unwrap_or(-1),
         used_quota: 0,
@@ -107,7 +202,8 @@ async fn create_token(
 
     match TokenService::create(&state.db, &db_token).await {
         Ok(_) => {
-            tracing::info!("[API] create_token success: {}", token_str);
+            tracing::info!(user_id, "API token created");
+            // Creation is the single disclosure point for the bearer secret.
             ok(serde_json::json!({
                 "status": "created",
                 "token": token_str
@@ -121,45 +217,31 @@ async fn create_token(
     }
 }
 
-#[tracing::instrument(skip(state))]
-async fn get_token(State(state): State<AppState>, Path(token): Path<String>) -> impl IntoResponse {
-    tracing::info!("[API] get_token request: {}", token);
-    match TokenService::validate(&state.db, &token).await {
-        Ok(Some(t)) => {
-            tracing::info!("[API] get_token success");
-            ok(t).into_response()
-        }
-        Ok(None) => {
-            tracing::info!("[API] get_token: token not found");
-            err("Token not found").into_response()
-        }
-        Err(e) => {
-            tracing::error!("[API] get_token error: {}", e);
-            err(e).into_response()
-        }
+#[tracing::instrument(skip_all)]
+async fn get_token(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(token): Path<String>,
+) -> impl IntoResponse {
+    match authorized_token(&state, &claims, &token).await {
+        Ok(record) => ok(TokenSummary::from(record)).into_response(),
+        Err(response) => response,
     }
 }
 
-#[tracing::instrument(skip(state, payload), fields(status = %payload.status))]
+#[tracing::instrument(skip_all, fields(status = %payload.status))]
 async fn update_token(
     State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
     Path(token): Path<String>,
     Json(payload): Json<UpdateTokenRequest>,
 ) -> impl IntoResponse {
-    tracing::info!(
-        "[API] update_token request: {} -> {}",
-        token,
-        payload.status
-    );
+    if let Err(response) = authorized_token(&state, &claims, &token).await {
+        return response;
+    }
+
     match TokenService::update_status(&state.db, &token, &payload.status).await {
-        Ok(_) => {
-            tracing::info!("[API] update_token success");
-            ok(serde_json::json!({
-                "status": "updated",
-                "token": token
-            }))
-            .into_response()
-        }
+        Ok(_) => ok(serde_json::json!({ "status": "updated" })).into_response(),
         Err(e) => {
             tracing::error!("[API] update_token error: {}", e);
             err(e).into_response()
@@ -167,21 +249,18 @@ async fn update_token(
     }
 }
 
-#[tracing::instrument(skip(state))]
+#[tracing::instrument(skip_all)]
 async fn delete_token(
     State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
     Path(token): Path<String>,
 ) -> impl IntoResponse {
-    tracing::info!("[API] delete_token request: {}", token);
+    if let Err(response) = authorized_token(&state, &claims, &token).await {
+        return response;
+    }
+
     match TokenService::delete(&state.db, &token).await {
-        Ok(_) => {
-            tracing::info!("[API] delete_token success");
-            ok(serde_json::json!({
-                "status": "deleted",
-                "token": token
-            }))
-            .into_response()
-        }
+        Ok(_) => ok(serde_json::json!({ "status": "deleted" })).into_response(),
         Err(e) => {
             tracing::error!("[API] delete_token error: {}", e);
             err(e).into_response()
@@ -189,18 +268,16 @@ async fn delete_token(
     }
 }
 
-#[tracing::instrument(skip(state))]
+#[tracing::instrument(skip_all)]
 async fn rotate_token(
     State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
     Path(token): Path<String>,
     Json(payload): Json<RotateTokenRequest>,
 ) -> impl IntoResponse {
-    tracing::info!(
-        "[API] rotate_token request: token={}, transition_hours={}, revoke_old={}",
-        token,
-        payload.transition_period_hours,
-        payload.revoke_old
-    );
+    if let Err(response) = authorized_token(&state, &claims, &token).await {
+        return response;
+    }
 
     match TokenService::rotate(
         &state.db,
@@ -211,10 +288,8 @@ async fn rotate_token(
     .await
     {
         Ok(result) => {
-            tracing::info!(
-                "[API] rotate_token success: new_version={}",
-                result.key_version
-            );
+            tracing::info!(new_version = result.key_version, "API token rotated");
+            // Rotation is the single disclosure point for the new bearer secret.
             ok(result).into_response()
         }
         Err(e) => {
@@ -224,26 +299,19 @@ async fn rotate_token(
     }
 }
 
-#[tracing::instrument(skip(state))]
+#[tracing::instrument(skip_all)]
 async fn revoke_old_key(
     State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
     Path(token): Path<String>,
 ) -> impl IntoResponse {
-    tracing::info!("[API] revoke_old_key request: {}", token);
+    if let Err(response) = authorized_token(&state, &claims, &token).await {
+        return response;
+    }
 
     match TokenService::revoke_old_key(&state.db, &token).await {
-        Ok(true) => {
-            tracing::info!("[API] revoke_old_key success");
-            ok(serde_json::json!({
-                "status": "revoked",
-                "token": token
-            }))
-            .into_response()
-        }
-        Ok(false) => {
-            tracing::info!("[API] revoke_old_key: token not found");
-            err("Token not found").into_response()
-        }
+        Ok(true) => ok(serde_json::json!({ "status": "revoked" })).into_response(),
+        Ok(false) => err_status(StatusCode::NOT_FOUND, "Token not found").into_response(),
         Err(e) => {
             tracing::error!("[API] revoke_old_key error: {}", e);
             err(e).into_response()
@@ -251,31 +319,20 @@ async fn revoke_old_key(
     }
 }
 
-#[tracing::instrument(skip(state))]
+#[tracing::instrument(skip_all)]
 async fn set_ip_whitelist(
     State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
     Path(token): Path<String>,
     Json(payload): Json<SetIpWhitelistRequest>,
 ) -> impl IntoResponse {
-    tracing::info!(
-        "[API] set_ip_whitelist request: token={}, whitelist={}",
-        token,
-        payload.ip_whitelist
-    );
+    if let Err(response) = authorized_token(&state, &claims, &token).await {
+        return response;
+    }
 
     match TokenService::set_ip_whitelist(&state.db, &token, &payload.ip_whitelist).await {
-        Ok(true) => {
-            tracing::info!("[API] set_ip_whitelist success");
-            ok(serde_json::json!({
-                "status": "updated",
-                "token": token
-            }))
-            .into_response()
-        }
-        Ok(false) => {
-            tracing::info!("[API] set_ip_whitelist: token not found");
-            err("Token not found").into_response()
-        }
+        Ok(true) => ok(serde_json::json!({ "status": "updated" })).into_response(),
+        Ok(false) => err_status(StatusCode::NOT_FOUND, "Token not found").into_response(),
         Err(e) => {
             tracing::error!("[API] set_ip_whitelist error: {}", e);
             err(e).into_response()

--- a/crates/server/src/api/user.rs
+++ b/crates/server/src/api/user.rs
@@ -1,8 +1,9 @@
-use crate::api::auth::Claims;
-use crate::api::response::{err, ok};
+use crate::api::auth::{is_admin, Claims};
+use crate::api::response::{err, err_status, ok};
 use crate::AppState;
 use axum::{
     extract::{Extension, Json, Query, State},
+    http::StatusCode,
     response::IntoResponse,
     routing::{get, post},
     Router,
@@ -77,8 +78,24 @@ pub fn routes() -> Router<AppState> {
         .merge(authenticated)
 }
 
-#[tracing::instrument(skip(state, payload), fields(user_id = %payload.user_id))]
-async fn topup(State(state): State<AppState>, Json(payload): Json<TopupDto>) -> impl IntoResponse {
+async fn require_admin_or_response(state: &AppState, claims: &Claims) -> Option<axum::response::Response> {
+    match is_admin(state, claims).await {
+        Ok(true) => None,
+        Ok(false) => Some(err_status(StatusCode::FORBIDDEN, "Admin access required").into_response()),
+        Err(status) => Some(err_status(status, "Failed to authorize request").into_response()),
+    }
+}
+
+#[tracing::instrument(skip(state, claims, payload), fields(user_id = %payload.user_id))]
+async fn topup(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Json(payload): Json<TopupDto>,
+) -> impl IntoResponse {
+    if let Some(response) = require_admin_or_response(&state, &claims).await {
+        return response;
+    }
+
     let currency = payload.currency.unwrap_or_else(|| "USD".to_string());
     match state
         .user_service
@@ -90,11 +107,16 @@ async fn topup(State(state): State<AppState>, Json(payload): Json<TopupDto>) -> 
     }
 }
 
-#[tracing::instrument(skip(state, payload), fields(username = %payload.username))]
+#[tracing::instrument(skip(state, claims, payload), fields(username = %payload.username))]
 async fn register(
     State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
     Json(payload): Json<RegisterDto>,
 ) -> impl IntoResponse {
+    if let Some(response) = require_admin_or_response(&state, &claims).await {
+        return response;
+    }
+
     match state
         .user_service
         .register_user(
@@ -214,7 +236,14 @@ fn persist_client_state(username: &str, token: &str) {
 }
 
 #[tracing::instrument(skip_all)]
-async fn list_users(State(state): State<AppState>) -> impl IntoResponse {
+async fn list_users(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+) -> impl IntoResponse {
+    if let Some(response) = require_admin_or_response(&state, &claims).await {
+        return response;
+    }
+
     match state.user_service.list_users(&state.db).await {
         Ok(users) => {
             let mut summaries = Vec::new();

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -3,7 +3,7 @@ pub mod logging;
 pub use api::auth::{auth_middleware, Claims};
 
 use axum::http::HeaderName;
-use axum::{routing::get, Router};
+use axum::{middleware, routing::get, Router};
 use burncloud_database::{create_default_database, Database};
 use burncloud_database_router::RouterDatabase;
 use burncloud_database_user::UserDatabase;
@@ -86,7 +86,12 @@ pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Res
         ))
         .layer(PropagateRequestIdLayer::new(x_request_id.clone()))
         .layer(TraceLayer::new_for_http())
-        .layer(CorsLayer::permissive());
+        .layer(CorsLayer::permissive())
+        // Security boundary is intentionally global so it protects both the
+        // explicitly merged internal routes and the data-plane fallback.
+        .layer(middleware::from_fn(
+            api::auth::security_boundary_middleware,
+        ));
 
     Ok(app)
 }

--- a/crates/server/tests/security_invariants.rs
+++ b/crates/server/tests/security_invariants.rs
@@ -1,0 +1,252 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::disallowed_types
+)]
+
+mod test_utils;
+
+use burncloud_database::Database;
+use burncloud_database_router::RouterToken;
+use burncloud_service_token::TokenService;
+use burncloud_service_user::UserService;
+use reqwest::{Client, StatusCode};
+use serde_json::Value;
+use std::sync::Arc;
+
+const JWT_SECRET: &str = "burncloud-security-invariant-jwt-secret-2026";
+const INTERNAL_SECRET: &str = "burncloud-security-invariant-internal-secret";
+
+fn configure_security_env() {
+    std::env::set_var("JWT_SECRET", JWT_SECRET);
+    std::env::set_var("BURNCLOUD_INTERNAL_SECRET", INTERNAL_SECRET);
+    std::env::set_var("SKIP_INITIAL_PRICE_SYNC", "1");
+}
+
+async fn spawn_server(db: Arc<Database>) -> anyhow::Result<String> {
+    let app = burncloud_server::create_app(db, false).await?;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .unwrap_or_else(|e| panic!("security invariant server failed: {e}"));
+    });
+    Ok(format!("http://{addr}"))
+}
+
+async fn create_principals(
+    db: &Database,
+) -> anyhow::Result<(String, String, String, String)> {
+    let service = UserService::new();
+    let admin_id = service
+        .register_user(db, "invariant-admin", "test-password", None)
+        .await?;
+    let user_id = service
+        .register_user(db, "invariant-user", "test-password", None)
+        .await?;
+
+    let admin_jwt = service
+        .generate_token(&admin_id, "invariant-admin")?
+        .token;
+    let user_jwt = service
+        .generate_token(&user_id, "invariant-user")?
+        .token;
+
+    Ok((admin_id, admin_jwt, user_id, user_jwt))
+}
+
+fn router_token(token: &str, user_id: &str) -> RouterToken {
+    RouterToken {
+        token: token.to_string(),
+        user_id: user_id.to_string(),
+        status: "active".to_string(),
+        quota_limit: -1,
+        used_quota: 0,
+        expired_time: -1,
+        accessed_time: 0,
+        key_version: 1,
+        old_key_hash: None,
+        old_key_expires_at: 0,
+        ip_whitelist: None,
+        key_prefix: "bc_live_".to_string(),
+        created_at: 0,
+        last_rotated_at: 0,
+    }
+}
+
+#[tokio::test]
+async fn console_jwt_cannot_authenticate_data_plane() -> anyhow::Result<()> {
+    configure_security_env();
+    let db = test_utils::make_isolated_db().await;
+    let (_admin_id, _admin_jwt, user_id, user_jwt) = create_principals(&db).await?;
+    let api_key = "bc_live_security_data_plane_key";
+    TokenService::create(&db, &router_token(api_key, &user_id)).await?;
+    let base = spawn_server(db).await?;
+    let client = Client::new();
+    let body = serde_json::json!({
+        "model": "security-invariant-model",
+        "messages": [{"role": "user", "content": "hello"}]
+    });
+
+    let jwt_response = client
+        .post(format!("{base}/v1/chat/completions"))
+        .bearer_auth(&user_jwt)
+        .json(&body)
+        .send()
+        .await?;
+    assert_eq!(
+        jwt_response.status(),
+        StatusCode::UNAUTHORIZED,
+        "management JWTs must never be accepted as inference credentials"
+    );
+
+    let api_key_response = client
+        .post(format!("{base}/v1/chat/completions"))
+        .bearer_auth(api_key)
+        .json(&body)
+        .send()
+        .await?;
+    assert_ne!(
+        api_key_response.status(),
+        StatusCode::UNAUTHORIZED,
+        "the management/data-plane boundary must not reject a real API credential"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn regular_users_cannot_execute_admin_management_actions() -> anyhow::Result<()> {
+    configure_security_env();
+    let db = test_utils::make_isolated_db().await;
+    let (_admin_id, admin_jwt, user_id, user_jwt) = create_principals(&db).await?;
+    let base = spawn_server(db).await?;
+    let client = Client::new();
+
+    let logs = client
+        .get(format!("{base}/console/api/logs"))
+        .bearer_auth(&user_jwt)
+        .send()
+        .await?;
+    assert_eq!(logs.status(), StatusCode::FORBIDDEN);
+
+    let topup = client
+        .post(format!("{base}/console/api/user/topup"))
+        .bearer_auth(&user_jwt)
+        .json(&serde_json::json!({
+            "user_id": user_id,
+            "amount": 1_000_000_000_i64,
+            "currency": "USD"
+        }))
+        .send()
+        .await?;
+    assert_eq!(
+        topup.status(),
+        StatusCode::FORBIDDEN,
+        "a normal account must not be able to mint balance"
+    );
+
+    let admin_logs = client
+        .get(format!("{base}/console/api/logs"))
+        .bearer_auth(&admin_jwt)
+        .send()
+        .await?;
+    assert_eq!(
+        admin_logs.status(),
+        StatusCode::OK,
+        "admin access must remain functional"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn token_management_is_owner_scoped_and_redacted() -> anyhow::Result<()> {
+    configure_security_env();
+    let db = test_utils::make_isolated_db().await;
+    let (admin_id, admin_jwt, user_id, user_jwt) = create_principals(&db).await?;
+    let admin_key = "bc_live_admin_secret_1234";
+    let user_key = "bc_live_user_secret_5678";
+    TokenService::create(&db, &router_token(admin_key, &admin_id)).await?;
+    TokenService::create(&db, &router_token(user_key, &user_id)).await?;
+    let base = spawn_server(db.clone()).await?;
+    let client = Client::new();
+
+    let user_list = client
+        .get(format!("{base}/console/api/tokens"))
+        .bearer_auth(&user_jwt)
+        .send()
+        .await?;
+    assert_eq!(user_list.status(), StatusCode::OK);
+    let user_body = user_list.text().await?;
+    assert!(!user_body.contains(user_key), "token lists must redact bearer secrets");
+    assert!(!user_body.contains(admin_key), "users must not see another owner's secret");
+    assert!(user_body.contains("5678"), "owner should receive a non-secret token hint");
+    assert!(!user_body.contains("1234"), "owner list must exclude other users' tokens");
+
+    let forbidden_delete = client
+        .delete(format!("{base}/console/api/tokens/{admin_key}"))
+        .bearer_auth(&user_jwt)
+        .send()
+        .await?;
+    assert_eq!(forbidden_delete.status(), StatusCode::FORBIDDEN);
+    assert!(TokenService::validate(&db, admin_key).await?.is_some());
+
+    let owner_get = client
+        .get(format!("{base}/console/api/tokens/{user_key}"))
+        .bearer_auth(&user_jwt)
+        .send()
+        .await?;
+    assert_eq!(owner_get.status(), StatusCode::OK);
+    let owner_body = owner_get.text().await?;
+    assert!(!owner_body.contains(user_key));
+    assert!(owner_body.contains("5678"));
+
+    let admin_list = client
+        .get(format!("{base}/console/api/tokens"))
+        .bearer_auth(&admin_jwt)
+        .send()
+        .await?;
+    assert_eq!(admin_list.status(), StatusCode::OK);
+    let admin_json: Value = admin_list.json().await?;
+    let rendered = admin_json.to_string();
+    assert!(!rendered.contains(admin_key));
+    assert!(!rendered.contains(user_key));
+    assert!(rendered.contains("1234"));
+    assert!(rendered.contains("5678"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sensitive_internal_mutations_require_internal_secret() -> anyhow::Result<()> {
+    configure_security_env();
+    let db = test_utils::make_isolated_db().await;
+    let base = spawn_server(db).await?;
+    let client = Client::new();
+    let url = format!("{base}/console/internal/circuit-breaker/trip-all");
+
+    let missing = client.post(&url).send().await?;
+    assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+
+    let wrong = client
+        .post(&url)
+        .header("X-Internal-Secret", "wrong-secret")
+        .send()
+        .await?;
+    assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+
+    let allowed = client
+        .post(&url)
+        .header("X-Internal-Secret", INTERNAL_SECRET)
+        .send()
+        .await?;
+    assert_eq!(
+        allowed.status(),
+        StatusCode::OK,
+        "authorized internal operations must remain available"
+    );
+
+    Ok(())
+}

--- a/crates/service/crates/router-log/src/lib.rs
+++ b/crates/service/crates/router-log/src/lib.rs
@@ -4,7 +4,7 @@
 //! usage statistics, and balance deductions.
 
 use burncloud_database::Database;
-use burncloud_database_router::{BalanceModel, RouterLogModel};
+use burncloud_database_router::{BalanceModel, RouterDatabase, RouterLogModel};
 
 pub use burncloud_database_router::{
     BillingModelSummary, BillingSummary, ModelUsageStats, RouterLog, UsageStats,
@@ -16,9 +16,9 @@ type Result<T> = std::result::Result<T, burncloud_database::DatabaseError>;
 pub struct RouterLogService;
 
 impl RouterLogService {
-    /// Insert a new router log entry
+    /// Insert a new router log entry without mutating credential spend quota.
     pub async fn insert(db: &Database, log: &RouterLog) -> Result<()> {
-        RouterLogModel::insert(db, log).await
+        RouterDatabase::insert_log(db, log).await
     }
 
     /// Get logs with pagination

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - HOST=0.0.0.0
       - PORT=8080
       - JWT_SECRET=${JWT_SECRET:?Set JWT_SECRET in .env}
+      - BURNCLOUD_INTERNAL_SECRET=${BURNCLOUD_INTERNAL_SECRET:?Set BURNCLOUD_INTERNAL_SECRET in .env}
       - BURNCLOUD_DATABASE_URL=postgres://burncloud:burncloud@postgres:5432/burncloud
       - RUST_LOG=info
     depends_on:

--- a/docs/agent/INVARIANTS.md
+++ b/docs/agent/INVARIANTS.md
@@ -3,7 +3,6 @@ doc_id: agent.invariants
 doc_type: engineering-invariants
 truth: source-derived
 status: active
-audited_against: c7107382b8479deb44f992e9e5ae8dcac5efb417
 ---
 
 # Verified Engineering Invariants
@@ -28,6 +27,8 @@ These are high-value facts visible in current code. If a change intentionally al
 - optional Dioxus LiveView,
 - the data-plane router as `fallback_service`.
 
+The unified server also applies `security_boundary_middleware` across explicit routes and the data-plane fallback.
+
 **Evidence:** `crates/server/src/lib.rs :: create_app`.
 
 ### INV-ROUTER-001 — Data plane uses explicit utility routes plus a fallback
@@ -48,13 +49,53 @@ Router internal health/price-sync/circuit-breaker/metrics routes are constructed
 
 **Evidence:** `crates/router/src/lib.rs :: create_router_app`; `crates/server/src/lib.rs :: create_app`.
 
-## Authentication
+## Authentication and authorization
 
 ### INV-AUTH-001 — Public and protected management routes are separate routers
 
 `crates/server/src/api/mod.rs` merges public auth routes without auth middleware and wraps the protected route group with `auth_middleware`.
 
 **Evidence:** `crates/server/src/api/mod.rs :: routes`.
+
+### INV-AUTH-002 — Console JWTs are management-plane credentials, not inference credentials
+
+The unified server rejects a valid Console JWT when it is presented as the bearer/API credential for `/v1/*` or `/api/v1/*`. Data-plane inference must use an API credential rather than a management session token.
+
+**Evidence:** `crates/server/src/api/auth.rs :: security_boundary_middleware`; `crates/server/tests/security_invariants.rs :: console_jwt_cannot_authenticate_data_plane`.
+
+### INV-AUTH-003 — Administrative Console operations require current admin authorization
+
+Channel, logs/usage administration, monitor/security, and cache management routes require both a valid JWT and the current `admin` role from the database. User registration from the Console, user listing, and balance top-up also perform admin authorization in their handlers.
+
+**Evidence:** `crates/server/src/api/mod.rs :: routes`; `crates/server/src/api/auth.rs :: admin_middleware`; `crates/server/src/api/user.rs`; `crates/server/tests/security_invariants.rs :: regular_users_cannot_execute_admin_management_actions`.
+
+### INV-AUTH-004 — API-token management is owner-scoped with admin override
+
+A non-admin authenticated user may list/create/manage only their own router tokens. Administrators may manage tokens across users. List/detail responses expose a token hint, not the bearer secret; create and rotate are the explicit one-time secret disclosure points.
+
+**Evidence:** `crates/server/src/api/token.rs`; `crates/server/tests/security_invariants.rs :: token_management_is_owner_scoped_and_redacted`.
+
+## Internal control plane
+
+### INV-INTERNAL-001 — Sensitive internal mutations fail closed without the internal secret
+
+`POST /console/internal/prices/sync` and `POST /console/internal/circuit-breaker/trip-all` require `BURNCLOUD_INTERNAL_SECRET` to be configured and the matching value in `X-Internal-Secret`. If the server has no configured secret, these mutations are unavailable rather than unauthenticated.
+
+**Evidence:** `crates/server/src/api/auth.rs :: security_boundary_middleware`; `crates/server/tests/security_invariants.rs :: sensitive_internal_mutations_require_internal_secret`.
+
+## Billing and quota
+
+### INV-BILLING-001 — Credential quota fields represent spend, not token counts
+
+`router_tokens.quota_limit` / `router_tokens.used_quota` and the corresponding `user_api_keys` quota values used by settlement are nanodollar spend values. Usage-log insertion does not mutate spend quota.
+
+**Evidence:** `crates/database/crates/router/src/token.rs :: RouterTokenModel::{check_quota,deduct_quota}`; `crates/database/crates/router/src/lib.rs :: RouterDatabase::insert_log`; `crates/router/tests/billing_invariants.rs :: router_log_insert_never_mutates_spend_quota`.
+
+### INV-BILLING-002 — Spend settlement is credential-scoped and actual cost is durable
+
+Settlement updates only the credential that authorized the request. A missing/inactive credential fails closed. If exact post-response cost crosses a configured cap, the actual cost is still recorded and settlement returns `false`; subsequent quota checks reject further spend. A valid old key during a rotation transition settles against its canonical current token.
+
+**Evidence:** `crates/database/crates/router/src/token.rs :: RouterTokenModel::{check_quota,deduct_quota}`; `crates/router/tests/quota_tests.rs`; `crates/router/tests/billing_invariants.rs`.
 
 ## Database
 

--- a/docs/agent/TEST_MATRIX.md
+++ b/docs/agent/TEST_MATRIX.md
@@ -3,20 +3,26 @@ doc_id: agent.test-matrix
 doc_type: verification-guide
 truth: source-derived
 status: active
-audited_against: c7107382b8479deb44f992e9e5ae8dcac5efb417
 ---
 
 # Test Matrix
 
 The repository's integration/E2E crate is `crates/tests`. Its current tests live under `crates/tests/tests/`, including `api/`, `e2e/`, provider-specific suites, and deployment/provider flows.
 
+Security and billing also have dedicated invariant suites close to the owning runtime crates:
+
+- `crates/server/tests/security_invariants.rs` — management/data-plane credential separation, admin authorization, token ownership/redaction, internal control-plane authentication.
+- `crates/router/tests/billing_invariants.rs` — log/settlement separation, key-scoped spend, legacy API-key settlement, rotation-transition settlement.
+- `.github/workflows/security-billing-invariants.yml` — mandatory PR gate when the protected runtime areas change.
+
 ## Default verification ladder
 
 1. Format changed Rust: `cargo fmt --check` (or format before checking).
 2. Check affected package(s): `cargo check -p <package>`.
 3. Run affected package tests: `cargo test -p <package>`.
-4. Run relevant `burncloud-tests` target(s) for the user flow.
-5. Run broader workspace checks when shared APIs/dependencies changed.
+4. Run relevant invariant suite when a protected cross-cutting truth is involved.
+5. Run relevant `burncloud-tests` target(s) for the user flow.
+6. Run broader workspace checks when shared APIs/dependencies changed.
 
 Do not claim tests passed unless they actually ran in the current environment.
 
@@ -27,16 +33,32 @@ Do not claim tests passed unless they actually ran in the current environment.
 | Router core / failover / provider execution | `burncloud-router` tests + relevant files under `crates/tests/tests/api/` |
 | Channel routing | router tests + `api/ability_routing.rs` + channel/provider regression tests |
 | Auth / login / password | server/user service tests + `api/auth.rs`, `api/auth_handlers.rs`, `e2e/auth_flow.rs`, `e2e/login_flow.rs` |
+| Management authorization / security boundary | `cargo test -p burncloud-server --test security_invariants` + adjacent auth/API tests |
 | Channel Console CRUD | server/channel/service/database tests + `api/channel.rs`, `e2e/channel_flow.rs` |
-| API key/token flows | token/service/database tests + `e2e/api_key_flow.rs` and related API tests |
-| Billing / usage | router + service-billing/database-billing tests + billing/provider integration tests such as `api/gemini_billing.rs` when relevant |
+| API key/token flows | `security_invariants` + token/service/database tests + `e2e/api_key_flow.rs` and related API tests |
+| Billing / usage / quota settlement | `cargo test -p burncloud-router --test billing_invariants --test quota_tests` + service-billing/database-billing tests + provider billing integrations such as `api/gemini_billing.rs` when relevant |
+| Internal control-plane mutations | `security_invariants::sensitive_internal_mutations_require_internal_secret` + affected internal handler tests |
 | UI / Console styling | affected client crate + `e2e/console_pages.rs`, `css_visual_acceptance.rs`, `aesthetic_acceptance.rs` as applicable |
 | Shared database utilities | affected database crates; test both dialect-sensitive code paths where tests support them |
 | Workspace dependency/API changes | targeted tests first, then `cargo check --workspace` and the relevant integration suites |
 
+## Security + Billing invariant gate
+
+Changes under the server/router/router-database/router-log ownership paths are checked by `.github/workflows/security-billing-invariants.yml`. Treat a failure here as a violated business/security contract, not as an optional regression signal.
+
+The invariant gate answers these minimum questions:
+
+1. Can a management JWT cross into the inference data plane?
+2. Can a non-admin execute an admin management action?
+3. Can one user enumerate or mutate another user's API token?
+4. Can a sensitive internal mutation run without the configured internal secret?
+5. Can usage-log insertion mutate spend quota?
+6. Can settling one credential mutate another credential's spend?
+7. Can missing or rotation-transition credentials create an unmetered path?
+
 ## Test discovery rule
 
-This matrix is a navigation aid, not a complete generated index. Before editing a flow, inspect `crates/tests/tests/` for tests that reference the exact route, symbol, provider, or state being changed.
+This matrix is a navigation aid, not a complete generated index. Before editing a flow, inspect `crates/tests/tests/` and the owning crate's invariant tests for tests that reference the exact route, symbol, provider, or state being changed.
 
 ## Failure handling
 


### PR DESCRIPTION
## Behavior change

- Separate management JWTs from inference credentials: Console JWTs are rejected on `/v1/*` and `/api/v1/*` in the unified server.
- Require current admin authorization for administrative Console surfaces and balance top-ups/user administration.
- Scope router-token management to owner/admin and redact bearer secrets from list/detail responses.
- Require `X-Internal-Secret` for sensitive internal mutations (`prices/sync`, emergency `circuit-breaker/trip-all`) and fail closed when no internal secret is configured.
- Define token quota fields used by settlement as nanodollar spend, not token counts.
- Make spend settlement credential-scoped, including `user_api_keys` and rotation-transition old keys.
- Keep actual over-cap request cost durable while reporting the credential exhausted for subsequent checks.

## Implementation

- Added global `security_boundary_middleware` in the unified server.
- Added DB-backed admin authorization middleware plus handler-level checks for user administration.
- Added owner/admin resource authorization and token summaries for token management.
- Added a side-effect-free `RouterDatabase::insert_log`; runtime/service log writes no longer mutate spend quota.
- Hardened `RouterTokenModel::{check_quota,deduct_quota}` to fail closed and settle only the presented credential/canonical rotated key.
- Updated Docker/env defaults for the required internal mutation secret.

## Security + Billing Invariant Test Suite

Added:

- `crates/server/tests/security_invariants.rs`
  - Console JWT cannot authenticate the data plane
  - normal users cannot execute admin management actions
  - token management is owner-scoped and list/detail responses are redacted
  - sensitive internal mutations require the internal secret
- `crates/router/tests/billing_invariants.rs`
  - usage-log insertion never mutates spend quota
  - one credential cannot mutate another credential's spend
  - legacy `user_api_keys` settlement remains key-scoped
  - rotation-transition old keys settle against the canonical current key
- updated `quota_tests.rs` for durable over-cap settlement and fail-closed missing credentials
- added `.github/workflows/security-billing-invariants.yml` as a dedicated invariant CI gate

## Agent Harness docs

Updated `docs/agent/INVARIANTS.md` and `docs/agent/TEST_MATRIX.md` so future agents route Auth/Billing changes through these invariant suites.

## Verification

Local clone/build execution is unavailable in the current execution environment (`gh` is not installed and direct GitHub DNS access is unavailable), so no local Cargo pass is claimed. This Draft PR intentionally triggers GitHub Actions for `cargo fmt --check`, affected-package `cargo check`, Billing invariants, and Security invariants. CI results will be treated as the executable verification source.

## Known boundaries / follow-ups

- This PR fixes the production unified-server JWT/data-plane boundary. The lower-level `burncloud_router::create_router_app` library by itself still contains the legacy JWT fallback; callers bypassing `burncloud_server::create_app` are outside this PR's enforced boundary and should be hardened in a follow-up.
- Router token secrets are still stored as the current database primary key and appear in token-management URL paths. This PR removes list/detail disclosure and explicit tracing of the token value, but a separate credential-storage migration is still needed for hashed/opaque token IDs.
- The legacy public `RouterLogModel::insert` implementation still has the old quota side effect for compatibility; production Router/Service paths now use the side-effect-free `RouterDatabase::insert_log`. A follow-up can deprecate/remove the legacy method once remaining direct consumers are proven absent.
