### PR TITLE
Secure zero-config first-admin setup and close public registration by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,13 +18,30 @@ BASE_URL=http://127.0.0.1:3000
 # mutations fail closed when this value is missing or empty.
 # BURNCLOUD_INTERNAL_SECRET=replace-with-a-long-random-secret
 
+# ── Initial Admin / Public Registration ──────────────────────────────────────
+# REQUIRED for a fresh installation before the first real user is created.
+# POST /api/auth/register must include the matching JSON `bootstrap_token`.
+# Use a long random secret (minimum 16 characters) and keep it out of source
+# control. The one-row DB bootstrap marker makes this credential single-use.
+# BURNCLOUD_BOOTSTRAP_TOKEN=<long-random-one-time-bootstrap-secret>
+#
+# Public self-registration AFTER initial admin bootstrap is closed by default.
+# Set to `open` (also accepts true/1/yes) only when intentional.
+# BURNCLOUD_PUBLIC_REGISTRATION=closed
+#
+# Wallet credit granted only to PUBLIC self-registration requests.
+# Exact USD decimal, up to 9 decimal places. Default: 0.
+# Admin-created customers through the management API keep their existing
+# server-side customer-creation policy and are not changed by this setting.
+# BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD=0
+
 # ── Database ──────────────────────────────────────────────────────────────────
 # Database connection string. Defaults to local SQLite if unset.
 # For PostgreSQL: postgres://user:pass@host:5432/dbname
 # BURNCLOUD_DATABASE_URL=sqlite:burncloud.db
-# When using local SQLite, set to 0 to preserve data across restarts.
-# Default: 1 (fresh DB on every startup)
-# BURNCLOUD_FRESH_DB=1
+# Set to 1 only when you intentionally want startup to delete the default local
+# SQLite database and start fresh. Default: preserve existing data.
+# BURNCLOUD_FRESH_DB=0
 
 # ── Billing ───────────────────────────────────────────────────────────────────
 # Strict billing mode. When true (default), requests with unknown prices
@@ -69,11 +86,12 @@ BASE_URL=http://127.0.0.1:3000
 # Custom npm registry mirror URL. Auto-detects China region if unset.
 # NPM_MIRROR=
 
-# ── HTTP Client Timeout ─────────────────────────────────────────────────────
+# ── HTTP Client Timeout ──────────────────────────────────────────────────────
 # HTTP_CONNECT_TIMEOUT_SECS=30 (default: 30)
 # HTTP_REQUEST_TIMEOUT_SECS=36000 (default: 36000, 600 minutes)
 # HTTP_POOL_IDLE_TIMEOUT_SECS=90 (default: 90)
 # HTTP_TCP_KEEPALIVE_SECS=30 (default: 30)
+
 # ── Logging ───────────────────────────────────────────────────────────────────
 RUST_LOG=error
 LOG_DIR=./logs

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
 # ── Server ────────────────────────────────────────────────────────────────────
 # Server listening port
 PORT=3000
-# Server listening host
+# Server listening host. The default loopback binding enables BurnCloud's
+# zero-configuration first-run setup: start BurnCloud, create the first admin,
+# and begin using the Console.
 HOST=127.0.0.1
 # Public base URL used for OAuth redirects and link generation
 BASE_URL=http://127.0.0.1:3000
@@ -19,13 +21,21 @@ BASE_URL=http://127.0.0.1:3000
 # BURNCLOUD_INTERNAL_SECRET=replace-with-a-long-random-secret
 
 # ── Initial Admin / Public Registration ──────────────────────────────────────
-# REQUIRED for a fresh installation before the first real user is created.
-# POST /api/auth/register must include the matching JSON `bootstrap_token`.
-# Use a long random secret (minimum 16 characters) and keep it out of source
-# control. The one-row DB bootstrap marker makes this credential single-use.
-# BURNCLOUD_BOOTSTRAP_TOKEN=<long-random-one-time-bootstrap-secret>
+# DEFAULT INSTALLATION: no bootstrap secret is required.
+# With HOST=127.0.0.1, the first local registration atomically becomes the one
+# administrator. BurnCloud's first-run UI takes the operator directly to this
+# setup screen. After creation, first-admin setup is permanently closed.
 #
-# Public self-registration AFTER initial admin bootstrap is closed by default.
+# REMOTE / EXPOSED INSTALLATION: when HOST is set to a non-loopback address
+# (for example 0.0.0.0), BurnCloud automatically generates a one-time setup code
+# and prints it at startup. Enter that code as `bootstrap_token` when creating
+# the first administrator. No .env configuration is required.
+#
+# Advanced/headless deployments may provide a stable one-time setup code instead
+# of the automatically generated value. Minimum 16 characters.
+# BURNCLOUD_BOOTSTRAP_TOKEN=<optional-advanced-setup-code>
+#
+# Public self-registration AFTER initial admin setup is closed by default.
 # Set to `open` (also accepts true/1/yes) only when intentional.
 # BURNCLOUD_PUBLIC_REGISTRATION=closed
 #
@@ -62,12 +72,12 @@ BASE_URL=http://127.0.0.1:3000
 # Example: {"vip":{"type":"combined","health_weight":0.4,"cost_weight":0.4,"rpm_weight":0.2},"default":{"type":"passthrough"}}
 # SCHEDULER_POLICIES=
 
-# ── CLI / Price Tool ─────────────────────────────────────────────────────────
+# ── CLI / Price Tool ──────────────────────────────────────────────────────────
 # Server URL used by the `burncloud price` CLI subcommand.
 # Default: http://127.0.0.1:3000
 # BURNCLOUD_SERVER_URL=http://127.0.0.1:3000
 
-# ── OAuth (optional, required for SSO) ───────────────────────────────────────
+# ── OAuth (optional, required for SSO) ────────────────────────────────────────
 # Google OAuth 2.0 client ID (required for Google SSO)
 # GOOGLE_CLIENT_ID=
 # Google OAuth redirect URI (must match Google Cloud Console)

--- a/.github/workflows/security-billing-invariants.yml
+++ b/.github/workflows/security-billing-invariants.yml
@@ -3,18 +3,24 @@ name: Security & Billing Invariants
 on:
   pull_request:
     paths:
+      - ".env.example"
       - "crates/server/**"
       - "crates/router/**"
       - "crates/database/crates/router/**"
       - "crates/service/crates/router-log/**"
+      - "crates/tests/tests/common/**"
+      - "crates/tests/tests/api/auth_handlers.rs"
       - ".github/workflows/security-billing-invariants.yml"
   push:
     branches: [main]
     paths:
+      - ".env.example"
       - "crates/server/**"
       - "crates/router/**"
       - "crates/database/crates/router/**"
       - "crates/service/crates/router-log/**"
+      - "crates/tests/tests/common/**"
+      - "crates/tests/tests/api/auth_handlers.rs"
       - ".github/workflows/security-billing-invariants.yml"
 
 permissions:
@@ -55,3 +61,12 @@ jobs:
 
       - name: Security invariants
         run: cargo test -p burncloud-server --test security_invariants
+
+      - name: Registration bootstrap invariants
+        run: cargo test -p burncloud-server api::registration -- --test-threads=1
+
+      - name: Compile auth API integration tests
+        run: cargo test -p burncloud-tests --test api_tests --no-run
+
+      - name: Check BurnCloud application integration
+        run: cargo check -p burncloud

--- a/crates/client/src/auth_gate.rs
+++ b/crates/client/src/auth_gate.rs
@@ -1,21 +1,59 @@
 use dioxus::prelude::*;
+use serde::Deserialize;
 
 use crate::{
     app::Route,
-    backend::use_auth,
+    backend::{server_root, use_auth},
     functional_layout::FunctionalConsoleLayout,
 };
+
+#[derive(Debug, Deserialize)]
+struct SetupStatus {
+    setup_required: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SetupEnvelope {
+    success: bool,
+    data: Option<SetupStatus>,
+}
+
+async fn first_run_setup_required() -> bool {
+    let url = format!("{}/api/auth/setup", server_root());
+    let Ok(response) = reqwest::Client::new().get(url).send().await else {
+        return false;
+    };
+    let Ok(envelope) = response.json::<SetupEnvelope>().await else {
+        return false;
+    };
+    envelope.success
+        && envelope
+            .data
+            .map(|status| status.setup_required)
+            .unwrap_or(false)
+}
 
 #[component]
 pub fn AuthGate() -> Element {
     let auth = use_auth();
     let navigator = use_navigator();
     let authenticated = auth.is_authenticated();
+    let mut redirect_started = use_signal(|| false);
 
     use_effect(move || {
-        if !authenticated {
-            navigator.replace(Route::Login {});
+        if authenticated || redirect_started() {
+            return;
         }
+
+        redirect_started.set(true);
+        let nav = navigator.clone();
+        spawn(async move {
+            if first_run_setup_required().await {
+                nav.replace(Route::Register {});
+            } else {
+                nav.replace(Route::Login {});
+            }
+        });
     });
 
     if !authenticated {
@@ -23,8 +61,8 @@ pub fn AuthGate() -> Element {
             div { class: "auth-page",
                 main { class: "auth-main",
                     div { class: "card card-pad stack", style: "max-width:420px;margin:auto;text-align:center",
-                        strong { "Authentication required" }
-                        span { class: "small muted", "Redirecting to BurnCloud sign in…" }
+                        strong { "Starting BurnCloud" }
+                        span { class: "small muted", "Checking whether this environment needs first-time administrator setup…" }
                     }
                 }
             }

--- a/crates/client/src/critical_pages/auth.rs
+++ b/crates/client/src/critical_pages/auth.rs
@@ -1,10 +1,73 @@
 use dioxus::prelude::*;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
 
 use crate::{
     app::Route,
-    backend::{use_auth, AuthService, ClientState, CurrentUser},
+    backend::{server_root, use_auth, AuthData, AuthService, ClientState, CurrentUser},
     components::{Badge, Logo},
 };
+
+#[derive(Debug, Clone, Deserialize)]
+struct SetupStatus {
+    setup_required: bool,
+    setup_code_required: bool,
+    public_registration_open: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiEnvelope<T> {
+    success: bool,
+    data: Option<T>,
+    message: Option<String>,
+}
+
+async fn decode_public_envelope<T: DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T, String> {
+    let status = response.status();
+    let text = response.text().await.map_err(|error| error.to_string())?;
+    let envelope: ApiEnvelope<T> = serde_json::from_str(&text)
+        .map_err(|error| format!("Invalid API response ({status}): {error}; body={text}"))?;
+    if status.is_success() && envelope.success {
+        envelope
+            .data
+            .ok_or_else(|| "API response did not include data".to_string())
+    } else {
+        Err(envelope
+            .message
+            .unwrap_or_else(|| format!("API request failed: {status}")))
+    }
+}
+
+async fn load_setup_status() -> Result<SetupStatus, String> {
+    let response = reqwest::Client::new()
+        .get(format!("{}/api/auth/setup", server_root()))
+        .send()
+        .await
+        .map_err(|error| error.to_string())?;
+    decode_public_envelope(response).await
+}
+
+async fn register_account(
+    username: &str,
+    password: &str,
+    email: Option<&str>,
+    setup_code: Option<&str>,
+) -> Result<AuthData, String> {
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/auth/register", server_root()))
+        .json(&serde_json::json!({
+            "username": username,
+            "password": password,
+            "email": email,
+            "bootstrap_token": setup_code,
+        }))
+        .send()
+        .await
+        .map_err(|error| error.to_string())?;
+    decode_public_envelope(response).await
+}
 
 #[component]
 pub fn Login() -> Element {
@@ -214,10 +277,39 @@ pub fn Register() -> Element {
     let mut username = use_signal(String::new);
     let mut email = use_signal(String::new);
     let mut password = use_signal(String::new);
+    let mut setup_code = use_signal(String::new);
     let mut terms = use_signal(|| false);
     let mut loading = use_signal(|| false);
     let mut status = use_signal(String::new);
     let mut is_error = use_signal(|| false);
+    let mut setup = use_signal(|| None::<SetupStatus>);
+    let mut setup_loading = use_signal(|| true);
+    let mut setup_error = use_signal(String::new);
+
+    use_effect(move || {
+        spawn(async move {
+            match load_setup_status().await {
+                Ok(value) => setup.set(Some(value)),
+                Err(error) => setup_error.set(error),
+            }
+            setup_loading.set(false);
+        });
+    });
+
+    let setup_snapshot = setup();
+    let first_admin = setup_snapshot
+        .as_ref()
+        .map(|value| value.setup_required)
+        .unwrap_or(false);
+    let setup_code_required = setup_snapshot
+        .as_ref()
+        .map(|value| value.setup_code_required)
+        .unwrap_or(false);
+    let public_registration_open = setup_snapshot
+        .as_ref()
+        .map(|value| value.public_registration_open)
+        .unwrap_or(false);
+    let registration_available = first_admin || public_registration_open;
 
     rsx! {
         div { class: "auth-page",
@@ -226,141 +318,251 @@ pub fn Register() -> Element {
                     Logo {}
                     span { class: "brand-name", "BurnCloud" }
                 }
-                div { class: "auth-header-note",
-                    span { "Already have an account?" }
-                    Link { to: Route::Login {}, class: "strong", "Sign in" }
+                if !first_admin {
+                    div { class: "auth-header-note",
+                        span { "Already have an account?" }
+                        Link { to: Route::Login {}, class: "strong", "Sign in" }
+                    }
+                } else {
+                    div { class: "auth-header-note",
+                        span { "First-time setup" }
+                    }
                 }
             }
 
             main { class: "auth-main",
                 div { class: "auth-wrap",
-                    div { class: "auth-intro",
-                        Badge { text: "BurnCloud Account", tone: "success" }
-                        h1 { "Create your account" }
-                        p { "Create the identity you will use to sign in to this BurnCloud environment." }
-                    }
-
-                    div { class: "card auth-card",
-                        form {
-                            class: "auth-form",
-                            onsubmit: move |event| {
-                                event.prevent_default();
-                                let user_name = username().trim().to_string();
-                                let account_email = email().trim().to_string();
-                                let user_password = password();
-                                if !terms() {
-                                    is_error.set(true);
-                                    status.set("Accept the Terms of Service and Privacy Policy to continue.".to_string());
-                                    return;
+                    if setup_loading() {
+                        div { class: "card auth-card", style: "text-align:center",
+                            strong { "Preparing BurnCloud…" }
+                            p { class: "small muted", "Checking first-time setup state." }
+                        }
+                    } else if !setup_error().is_empty() {
+                        div { class: "card auth-card",
+                            Badge { text: "Setup unavailable", tone: "danger" }
+                            h1 { "Cannot load setup state" }
+                            p { "BurnCloud could not verify whether this environment has already been initialized." }
+                            div { class: "terminal auth-status auth-status-error", "{setup_error}" }
+                            Link { to: Route::Login {}, class: "button button-secondary", "Back to sign in" }
+                        }
+                    } else if !registration_available {
+                        div { class: "card auth-card",
+                            Badge { text: "Registration closed", tone: "brand" }
+                            h1 { "BurnCloud is already initialized" }
+                            p { "Public account creation is disabled on this environment. Ask an administrator to create an account for you." }
+                            Link { to: Route::Login {}, class: "button button-primary", "Sign in" }
+                        }
+                    } else {
+                        div { class: "auth-intro",
+                            if first_admin {
+                                Badge { text: "First-time Setup", tone: "success" }
+                                h1 { "Create administrator" }
+                                if setup_code_required {
+                                    p { "Create the first administrator. Because this server is exposed beyond localhost, enter the one-time setup code BurnCloud printed at startup." }
+                                } else {
+                                    p { "Create the first administrator and start using BurnCloud. No setup code or environment configuration is required." }
                                 }
-                                if user_name.is_empty() {
-                                    is_error.set(true);
-                                    status.set("Username is required.".to_string());
-                                    return;
-                                }
-                                if user_password.len() < 8 {
-                                    is_error.set(true);
-                                    status.set("Password must contain at least 8 characters.".to_string());
-                                    return;
-                                }
-                                loading.set(true);
-                                is_error.set(false);
-                                status.set("Creating your BurnCloud account…".to_string());
-                                let nav = navigator.clone();
-                                spawn(async move {
-                                    let email_arg = if account_email.is_empty() { None } else { Some(account_email.as_str()) };
-                                    match AuthService::register(&user_name, &user_password, email_arg).await {
-                                        Ok(response) => {
-                                            let user = CurrentUser {
-                                                id: response.id,
-                                                username: response.username,
-                                                roles: response.roles,
-                                            };
-                                            auth.set(response.token, user, true);
-                                            loading.set(false);
-                                            status.set(String::new());
-                                            nav.replace(Route::Overview {});
-                                        }
-                                        Err(error) => {
-                                            loading.set(false);
-                                            is_error.set(true);
-                                            status.set(format!("Account creation failed: {error}"));
-                                        }
-                                    }
-                                });
-                            },
-                            div { class: "field",
-                                label { "Username" }
-                                input {
-                                    class: "input",
-                                    r#type: "text",
-                                    autocomplete: "username",
-                                    required: true,
-                                    value: "{username}",
-                                    placeholder: "Choose a BurnCloud username",
-                                    disabled: loading(),
-                                    oninput: move |event| username.set(event.value()),
-                                }
-                                span { class: "tiny subtle", "This is the identity used on the Sign In page." }
-                            }
-
-                            div { class: "field",
-                                label { "Email (recommended)" }
-                                input {
-                                    class: "input",
-                                    r#type: "email",
-                                    autocomplete: "email",
-                                    value: "{email}",
-                                    placeholder: "name@company.com",
-                                    disabled: loading(),
-                                    oninput: move |event| email.set(event.value()),
-                                }
-                                span { class: "tiny subtle", "Add an email if you want to use the server's password-recovery flow." }
-                            }
-
-                            div { class: "field",
-                                label { "Password" }
-                                input {
-                                    class: "input",
-                                    r#type: "password",
-                                    autocomplete: "new-password",
-                                    required: true,
-                                    value: "{password}",
-                                    placeholder: "At least 8 characters",
-                                    disabled: loading(),
-                                    oninput: move |event| password.set(event.value()),
-                                }
-                            }
-
-                            label { class: "small row gap-2", style: "align-items:flex-start",
-                                input {
-                                    r#type: "checkbox",
-                                    checked: terms(),
-                                    disabled: loading(),
-                                    onchange: move |_| terms.set(!terms()),
-                                }
-                                span { "I agree to BurnCloud's Terms of Service and Privacy Policy." }
-                            }
-
-                            if !status().is_empty() {
-                                div { class: if is_error() { "terminal auth-status auth-status-error" } else { "terminal auth-status" }, "{status}" }
-                            }
-
-                            button {
-                                r#type: "submit",
-                                class: "button button-primary button-lg",
-                                style: "width:100%",
-                                disabled: loading(),
-                                if loading() { "Creating account…" } else { "Create Account" }
+                            } else {
+                                Badge { text: "BurnCloud Account", tone: "success" }
+                                h1 { "Create your account" }
+                                p { "Create the identity you will use to sign in to this BurnCloud environment." }
                             }
                         }
-                    }
 
-                    div { class: "product-note", "Registration now shows only fields the current BurnCloud backend can actually persist. Billing plans, company metadata, and passkeys will appear only when corresponding server capabilities exist." }
+                        div { class: "card auth-card",
+                            form {
+                                class: "auth-form",
+                                onsubmit: move |event| {
+                                    event.prevent_default();
+                                    let user_name = username().trim().to_string();
+                                    let account_email = email().trim().to_string();
+                                    let user_password = password();
+                                    let one_time_code = setup_code().trim().to_string();
+                                    let current_setup = setup();
+                                    let creating_first_admin = current_setup
+                                        .as_ref()
+                                        .map(|value| value.setup_required)
+                                        .unwrap_or(false);
+                                    let code_required = current_setup
+                                        .as_ref()
+                                        .map(|value| value.setup_code_required)
+                                        .unwrap_or(false);
+
+                                    if !creating_first_admin && !terms() {
+                                        is_error.set(true);
+                                        status.set("Accept the Terms of Service and Privacy Policy to continue.".to_string());
+                                        return;
+                                    }
+                                    if user_name.is_empty() {
+                                        is_error.set(true);
+                                        status.set("Username is required.".to_string());
+                                        return;
+                                    }
+                                    if user_password.len() < 8 {
+                                        is_error.set(true);
+                                        status.set("Password must contain at least 8 characters.".to_string());
+                                        return;
+                                    }
+                                    if code_required && one_time_code.is_empty() {
+                                        is_error.set(true);
+                                        status.set("Enter the one-time setup code shown by BurnCloud at startup.".to_string());
+                                        return;
+                                    }
+
+                                    loading.set(true);
+                                    is_error.set(false);
+                                    status.set(if creating_first_admin {
+                                        "Creating administrator…".to_string()
+                                    } else {
+                                        "Creating your BurnCloud account…".to_string()
+                                    });
+                                    let nav = navigator.clone();
+                                    spawn(async move {
+                                        let email_arg = if account_email.is_empty() {
+                                            None
+                                        } else {
+                                            Some(account_email.as_str())
+                                        };
+                                        let code_arg = if code_required {
+                                            Some(one_time_code.as_str())
+                                        } else {
+                                            None
+                                        };
+                                        match register_account(
+                                            &user_name,
+                                            &user_password,
+                                            email_arg,
+                                            code_arg,
+                                        )
+                                        .await
+                                        {
+                                            Ok(response) => {
+                                                let user = CurrentUser {
+                                                    id: response.id,
+                                                    username: response.username,
+                                                    roles: response.roles,
+                                                };
+                                                auth.set(response.token, user, true);
+                                                loading.set(false);
+                                                status.set(String::new());
+                                                nav.replace(Route::Overview {});
+                                            }
+                                            Err(error) => {
+                                                loading.set(false);
+                                                is_error.set(true);
+                                                status.set(format!("Account creation failed: {error}"));
+                                            }
+                                        }
+                                    });
+                                },
+                                div { class: "field",
+                                    label { "Username" }
+                                    input {
+                                        class: "input",
+                                        r#type: "text",
+                                        autocomplete: "username",
+                                        required: true,
+                                        value: "{username}",
+                                        placeholder: if first_admin { "Choose the administrator username" } else { "Choose a BurnCloud username" },
+                                        disabled: loading(),
+                                        oninput: move |event| username.set(event.value()),
+                                    }
+                                    if first_admin {
+                                        span { class: "tiny subtle", "This account will become the first BurnCloud administrator." }
+                                    } else {
+                                        span { class: "tiny subtle", "This is the identity used on the Sign In page." }
+                                    }
+                                }
+
+                                div { class: "field",
+                                    label { "Email (recommended)" }
+                                    input {
+                                        class: "input",
+                                        r#type: "email",
+                                        autocomplete: "email",
+                                        value: "{email}",
+                                        placeholder: "name@company.com",
+                                        disabled: loading(),
+                                        oninput: move |event| email.set(event.value()),
+                                    }
+                                    span { class: "tiny subtle", "Add an email if you want to use the server's password-recovery flow." }
+                                }
+
+                                div { class: "field",
+                                    label { "Password" }
+                                    input {
+                                        class: "input",
+                                        r#type: "password",
+                                        autocomplete: "new-password",
+                                        required: true,
+                                        value: "{password}",
+                                        placeholder: "At least 8 characters",
+                                        disabled: loading(),
+                                        oninput: move |event| password.set(event.value()),
+                                    }
+                                }
+
+                                if setup_code_required {
+                                    div { class: "field",
+                                        label { "One-time setup code" }
+                                        input {
+                                            class: "input",
+                                            r#type: "password",
+                                            autocomplete: "one-time-code",
+                                            required: true,
+                                            value: "{setup_code}",
+                                            placeholder: "Paste the code printed by BurnCloud",
+                                            disabled: loading(),
+                                            oninput: move |event| setup_code.set(event.value()),
+                                        }
+                                        span { class: "tiny subtle", "This field appears only because BurnCloud is bound to a non-local address. The code stops working after the administrator is created." }
+                                    }
+                                }
+
+                                if !first_admin {
+                                    label { class: "small row gap-2", style: "align-items:flex-start",
+                                        input {
+                                            r#type: "checkbox",
+                                            checked: terms(),
+                                            disabled: loading(),
+                                            onchange: move |_| terms.set(!terms()),
+                                        }
+                                        span { "I agree to BurnCloud's Terms of Service and Privacy Policy." }
+                                    }
+                                }
+
+                                if !status().is_empty() {
+                                    div { class: if is_error() { "terminal auth-status auth-status-error" } else { "terminal auth-status" }, "{status}" }
+                                }
+
+                                button {
+                                    r#type: "submit",
+                                    class: "button button-primary button-lg",
+                                    style: "width:100%",
+                                    disabled: loading(),
+                                    if loading() {
+                                        if first_admin { "Creating administrator…" } else { "Creating account…" }
+                                    } else if first_admin {
+                                        "Create Administrator & Start"
+                                    } else {
+                                        "Create Account"
+                                    }
+                                }
+                            }
+                        }
+
+                        if first_admin {
+                            div { class: "product-note", "BurnCloud permanently closes first-admin setup after this account is created. You can manage additional users from the Console." }
+                        } else {
+                            div { class: "product-note", "Registration shows only fields the current BurnCloud backend can persist. Billing plans, company metadata, and passkeys appear only when corresponding server capabilities exist." }
+                        }
+                    }
                 }
             }
 
-            AuthFooter { alternate: "login" }
+            if !first_admin {
+                AuthFooter { alternate: "login" }
+            }
         }
     }
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -39,6 +39,8 @@ jsonwebtoken = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 chrono = { workspace = true }
 dirs = { workspace = true }
+sqlx.workspace = true
+bcrypt.workspace = true
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -1,5 +1,6 @@
 use crate::api::registration::{
-    register_public_user, PublicRegistrationError, PublicRegistrationInput,
+    bootstrap_complete, public_registration_open, register_public_user, PublicRegistrationError,
+    PublicRegistrationInput,
 };
 use crate::api::response::{err, ok};
 use crate::AppState;
@@ -21,7 +22,7 @@ pub struct RegisterDto {
     pub username: String,
     pub password: String,
     pub email: Option<String>,
-    /// Required only while a fresh installation still needs its first admin.
+    /// Only required when the server is intentionally exposed on a non-loopback host.
     pub bootstrap_token: Option<String>,
 }
 
@@ -57,6 +58,13 @@ struct AuthData {
     #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<Vec<String>>,
     token: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SetupStatus {
+    setup_required: bool,
+    setup_code_required: bool,
+    public_registration_open: bool,
 }
 
 fn get_jwt_secret() -> String {
@@ -185,15 +193,13 @@ pub async fn security_boundary_middleware(
     Ok(next.run(req).await)
 }
 
-/// Public routes - no authentication required
-/// - /api/auth/register - Token-gated initial admin bootstrap or configured public signup
-/// - /api/auth/login - Login
-/// - /api/auth/forgot-password - Forgot password
-/// - /api/auth/reset-password - Reset password
-/// - /api/auth/google - Google OAuth
-/// - /api/auth/github - GitHub OAuth
+/// Public routes - no authentication required.
+///
+/// `/api/auth/setup` lets the UI distinguish first-run administrator setup from
+/// ordinary sign-up without exposing the generated remote setup code.
 pub fn public_routes() -> Router<AppState> {
     Router::new()
+        .route("/api/auth/setup", get(setup_status))
         .route("/api/auth/register", post(create_user))
         .route("/api/auth/login", post(login))
         .route("/api/auth/forgot-password", post(forgot_password))
@@ -202,14 +208,27 @@ pub fn public_routes() -> Router<AppState> {
         .route("/api/auth/github", get(oauth_github))
 }
 
-/// Protected routes - authentication required
-/// Currently empty, but available for future protected auth endpoints
-/// (e.g., logout, change-password)
 pub fn protected_routes() -> Router<AppState> {
     Router::new()
-    // Add protected auth routes here when needed:
-    // .route("/console/api/auth/logout", post(logout))
-    // .route("/console/api/auth/change-password", post(change_password))
+}
+
+async fn setup_status(State(state): State<AppState>) -> impl IntoResponse {
+    match bootstrap_complete(&state.db).await {
+        Ok(complete) => ok(SetupStatus {
+            setup_required: !complete,
+            setup_code_required: !complete && state.bootstrap_token_required,
+            public_registration_open: complete && public_registration_open(),
+        })
+        .into_response(),
+        Err(PublicRegistrationError::Database(message)) => {
+            tracing::error!(error = %message, "Failed to read first-run setup state");
+            err("Failed to read setup status").into_response()
+        }
+        Err(error) => {
+            tracing::error!(error = ?error, "Unexpected setup status error");
+            err("Failed to read setup status").into_response()
+        }
+    }
 }
 
 #[tracing::instrument(skip(state, payload), fields(username = %payload.username))]
@@ -224,7 +243,14 @@ async fn create_user(
         bootstrap_token: payload.bootstrap_token,
     };
 
-    match register_public_user(&state.db, &input).await {
+    match register_public_user(
+        &state.db,
+        &input,
+        state.bootstrap_token_required,
+        Some(state.bootstrap_token.as_str()),
+    )
+    .await
+    {
         Ok(created) => match state
             .user_service
             .generate_token(&created.user_id, &created.username)
@@ -242,16 +268,13 @@ async fn create_user(
             }
         },
         Err(PublicRegistrationError::BootstrapRequired) => {
-            err("Initial admin bootstrap requires a bootstrap token").into_response()
-        }
-        Err(PublicRegistrationError::BootstrapNotConfigured) => {
-            err("Initial admin bootstrap is locked because BURNCLOUD_BOOTSTRAP_TOKEN is not configured").into_response()
+            err("First-time remote setup requires the one-time setup code shown by BurnCloud at startup").into_response()
         }
         Err(PublicRegistrationError::InvalidBootstrapToken) => {
-            err("Invalid bootstrap token").into_response()
+            err("Invalid setup code").into_response()
         }
         Err(PublicRegistrationError::BootstrapAlreadyComplete) => {
-            err("Initial admin bootstrap has already been completed").into_response()
+            err("Initial administrator setup has already been completed").into_response()
         }
         Err(PublicRegistrationError::RegistrationClosed) => {
             err("Public registration is closed").into_response()
@@ -316,7 +339,6 @@ async fn forgot_password(
             ok(serde_json::json!({ "message": "If the email exists, a reset token has been generated" })).into_response()
         }
         Err(UserServiceError::UserNotFound) => {
-            // Return success even if user not found to prevent email enumeration
             ok(serde_json::json!({ "message": "If the email exists, a reset token has been generated" })).into_response()
         }
         Err(e) => {

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -1,3 +1,6 @@
+use crate::api::registration::{
+    register_public_user, PublicRegistrationError, PublicRegistrationInput,
+};
 use crate::api::response::{err, ok};
 use crate::AppState;
 use axum::{
@@ -18,6 +21,8 @@ pub struct RegisterDto {
     pub username: String,
     pub password: String,
     pub email: Option<String>,
+    /// Required only while a fresh installation still needs its first admin.
+    pub bootstrap_token: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -181,7 +186,7 @@ pub async fn security_boundary_middleware(
 }
 
 /// Public routes - no authentication required
-/// - /api/auth/register - Registration
+/// - /api/auth/register - Token-gated initial admin bootstrap or configured public signup
 /// - /api/auth/login - Login
 /// - /api/auth/forgot-password - Forgot password
 /// - /api/auth/reset-password - Reset password
@@ -212,42 +217,55 @@ async fn create_user(
     State(state): State<AppState>,
     Json(payload): Json<RegisterDto>,
 ) -> impl IntoResponse {
-    match state
-        .user_service
-        .register_user(
-            &state.db,
-            &payload.username,
-            &payload.password,
-            payload.email,
-        )
-        .await
-    {
-        Ok(user_id) => {
-            let roles = state
-                .user_service
-                .get_user_roles(&state.db, &user_id)
-                .await
-                .unwrap_or_default();
-            match state
-                .user_service
-                .generate_token(&user_id, &payload.username)
-            {
-                Ok(auth_token) => ok(AuthData {
-                    id: user_id,
-                    username: payload.username,
-                    roles: Some(roles),
-                    token: auth_token.token,
-                })
-                .into_response(),
-                Err(e) => {
-                    tracing::error!("JWT generation failed: {}", e);
-                    err("Failed to generate authentication token").into_response()
-                }
+    let input = PublicRegistrationInput {
+        username: payload.username,
+        password: payload.password,
+        email: payload.email,
+        bootstrap_token: payload.bootstrap_token,
+    };
+
+    match register_public_user(&state.db, &input).await {
+        Ok(created) => match state
+            .user_service
+            .generate_token(&created.user_id, &created.username)
+        {
+            Ok(auth_token) => ok(AuthData {
+                id: created.user_id,
+                username: created.username,
+                roles: Some(vec![created.role]),
+                token: auth_token.token,
+            })
+            .into_response(),
+            Err(e) => {
+                tracing::error!("JWT generation failed after registration: {}", e);
+                err("Failed to generate authentication token").into_response()
             }
+        },
+        Err(PublicRegistrationError::BootstrapRequired) => {
+            err("Initial admin bootstrap requires a bootstrap token").into_response()
         }
-        Err(UserServiceError::UserAlreadyExists) => err("Username already exists").into_response(),
-        Err(e) => {
-            tracing::error!("Registration error: {}", e);
+        Err(PublicRegistrationError::BootstrapNotConfigured) => {
+            err("Initial admin bootstrap is locked because BURNCLOUD_BOOTSTRAP_TOKEN is not configured").into_response()
+        }
+        Err(PublicRegistrationError::InvalidBootstrapToken) => {
+            err("Invalid bootstrap token").into_response()
+        }
+        Err(PublicRegistrationError::BootstrapAlreadyComplete) => {
+            err("Initial admin bootstrap has already been completed").into_response()
+        }
+        Err(PublicRegistrationError::RegistrationClosed) => {
+            err("Public registration is closed").into_response()
+        }
+        Err(PublicRegistrationError::UserAlreadyExists) => {
+            err("Username already exists").into_response()
+        }
+        Err(PublicRegistrationError::InvalidInput(message)) => err(message).into_response(),
+        Err(PublicRegistrationError::Configuration(message)) => {
+            tracing::error!(error = %message, "Public registration configuration is invalid");
+            err("Registration configuration is invalid").into_response()
+        }
+        Err(PublicRegistrationError::Database(message)) => {
+            tracing::error!(error = %message, "Public registration database transaction failed");
             err("Registration failed").into_response()
         }
     }

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -17,6 +17,8 @@ pub mod log;
 pub mod monitor;
 pub mod openapi;
 pub(crate) mod registration;
+#[cfg(test)]
+mod registration_tests;
 pub mod response;
 pub mod token;
 pub mod user;

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -16,7 +16,7 @@ pub mod channel;
 pub mod log;
 pub mod monitor;
 pub mod openapi;
-mod registration;
+pub(crate) mod registration;
 pub mod response;
 pub mod token;
 pub mod user;

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -16,6 +16,7 @@ pub mod channel;
 pub mod log;
 pub mod monitor;
 pub mod openapi;
+mod registration;
 pub mod response;
 pub mod token;
 pub mod user;

--- a/crates/server/src/api/registration.rs
+++ b/crates/server/src/api/registration.rs
@@ -1,0 +1,356 @@
+use bcrypt::{hash, DEFAULT_COST};
+use burncloud_database::Database;
+use sqlx::Any;
+use uuid::Uuid;
+
+const ACTIVE_STATUS: i32 = 1;
+const BOOTSTRAP_TABLE: &str = "burncloud_bootstrap_state";
+
+#[derive(Debug, Clone)]
+pub(crate) struct PublicRegistrationInput {
+    pub username: String,
+    pub password: String,
+    pub email: Option<String>,
+    pub bootstrap_token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PublicRegistrationResult {
+    pub user_id: String,
+    pub username: String,
+    pub role: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PublicRegistrationError {
+    BootstrapRequired,
+    BootstrapNotConfigured,
+    InvalidBootstrapToken,
+    BootstrapAlreadyComplete,
+    RegistrationClosed,
+    UserAlreadyExists,
+    InvalidInput(String),
+    Configuration(String),
+    Database(String),
+}
+
+pub(crate) async fn initialize_bootstrap_state(db: &Database) -> anyhow::Result<()> {
+    let connection = db.get_connection()?;
+    let pool = connection.pool();
+    let create_sql = if db.kind() == "postgres" {
+        format!(
+            "CREATE TABLE IF NOT EXISTS {BOOTSTRAP_TABLE} (\
+                id SMALLINT PRIMARY KEY CHECK (id = 1), \
+                completed_by TEXT NOT NULL, \
+                completed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\
+            )"
+        )
+    } else {
+        format!(
+            "CREATE TABLE IF NOT EXISTS {BOOTSTRAP_TABLE} (\
+                id INTEGER PRIMARY KEY CHECK (id = 1), \
+                completed_by TEXT NOT NULL, \
+                completed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP\
+            )"
+        )
+    };
+    sqlx::query(&create_sql).execute(pool).await?;
+
+    // Existing installations predate the bootstrap marker. Mark them complete
+    // before serving requests so an upgrade can never reopen first-admin setup.
+    let existing_users: i64 = sqlx::query_scalar::<Any, i64>(
+        "SELECT COUNT(*) FROM user_accounts WHERE username != 'demo-user'",
+    )
+    .fetch_one(pool)
+    .await?;
+    if existing_users > 0 {
+        let backfill_sql = if db.kind() == "postgres" {
+            format!(
+                "INSERT INTO {BOOTSTRAP_TABLE} (id, completed_by) \
+                 VALUES (1, 'existing-installation') ON CONFLICT (id) DO NOTHING"
+            )
+        } else {
+            format!(
+                "INSERT OR IGNORE INTO {BOOTSTRAP_TABLE} (id, completed_by) \
+                 VALUES (1, 'existing-installation')"
+            )
+        };
+        sqlx::query(&backfill_sql).execute(pool).await?;
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn register_public_user(
+    db: &Database,
+    input: &PublicRegistrationInput,
+) -> Result<PublicRegistrationResult, PublicRegistrationError> {
+    let username = input.username.trim();
+    if username.is_empty() {
+        return Err(PublicRegistrationError::InvalidInput(
+            "Username is required".to_string(),
+        ));
+    }
+    if input.password.len() < 8 {
+        return Err(PublicRegistrationError::InvalidInput(
+            "Password must contain at least 8 characters".to_string(),
+        ));
+    }
+
+    let password_hash = hash(&input.password, DEFAULT_COST)
+        .map_err(|error| PublicRegistrationError::Configuration(error.to_string()))?;
+    let user_id = Uuid::new_v4().to_string();
+    let bootstrap_token = input
+        .bootstrap_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    let connection = db
+        .get_connection()
+        .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+    let mut transaction = connection
+        .pool()
+        .begin()
+        .await
+        .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+    let postgres = db.kind() == "postgres";
+
+    let duplicate_sql = if postgres {
+        "SELECT COUNT(*) FROM user_accounts WHERE username = $1"
+    } else {
+        "SELECT COUNT(*) FROM user_accounts WHERE username = ?"
+    };
+    let duplicate_count: i64 = sqlx::query_scalar::<Any, i64>(duplicate_sql)
+        .bind(username)
+        .fetch_one(&mut *transaction)
+        .await
+        .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+    if duplicate_count > 0 {
+        return Err(PublicRegistrationError::UserAlreadyExists);
+    }
+
+    let marker_sql = format!("SELECT COUNT(*) FROM {BOOTSTRAP_TABLE} WHERE id = 1");
+    let bootstrap_complete: i64 = sqlx::query_scalar::<Any, i64>(&marker_sql)
+        .fetch_one(&mut *transaction)
+        .await
+        .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+
+    let (role, balance_usd) = if bootstrap_complete > 0 {
+        if bootstrap_token.is_some() {
+            return Err(PublicRegistrationError::BootstrapAlreadyComplete);
+        }
+        if !public_registration_open() {
+            return Err(PublicRegistrationError::RegistrationClosed);
+        }
+        ("user", public_signup_bonus_nano()?)
+    } else {
+        let supplied = bootstrap_token.ok_or(PublicRegistrationError::BootstrapRequired)?;
+        let expected = std::env::var("BURNCLOUD_BOOTSTRAP_TOKEN")
+            .map_err(|_| PublicRegistrationError::BootstrapNotConfigured)?;
+        let expected = expected.trim();
+        if expected.len() < 16 {
+            return Err(PublicRegistrationError::Configuration(
+                "BURNCLOUD_BOOTSTRAP_TOKEN must contain at least 16 characters".to_string(),
+            ));
+        }
+        if !constant_time_eq(supplied, expected) {
+            return Err(PublicRegistrationError::InvalidBootstrapToken);
+        }
+
+        // Claim the singleton marker inside the same transaction as admin user
+        // creation. The unique primary key prevents two processes from both
+        // successfully completing first-admin bootstrap.
+        let claim_sql = if postgres {
+            format!(
+                "INSERT INTO {BOOTSTRAP_TABLE} (id, completed_by) VALUES (1, $1) \
+                 ON CONFLICT (id) DO NOTHING"
+            )
+        } else {
+            format!(
+                "INSERT OR IGNORE INTO {BOOTSTRAP_TABLE} (id, completed_by) VALUES (1, ?)"
+            )
+        };
+        let claimed = sqlx::query(&claim_sql)
+            .bind(&user_id)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+        if claimed.rows_affected() != 1 {
+            return Err(PublicRegistrationError::BootstrapAlreadyComplete);
+        }
+        ("admin", 0)
+    };
+
+    let insert_user_sql = if postgres {
+        "INSERT INTO user_accounts \
+         (id, username, email, password_hash, github_id, status, balance_usd, balance_cny, preferred_currency) \
+         VALUES ($1, $2, $3, $4, NULL, $5, $6, 0, 'USD')"
+    } else {
+        "INSERT INTO user_accounts \
+         (id, username, email, password_hash, github_id, status, balance_usd, balance_cny, preferred_currency) \
+         VALUES (?, ?, ?, ?, NULL, ?, ?, 0, 'USD')"
+    };
+    sqlx::query(insert_user_sql)
+        .bind(&user_id)
+        .bind(username)
+        .bind(input.email.clone())
+        .bind(password_hash)
+        .bind(ACTIVE_STATUS)
+        .bind(balance_usd)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+
+    let role_id_sql = if postgres {
+        "SELECT id FROM user_roles WHERE name = $1"
+    } else {
+        "SELECT id FROM user_roles WHERE name = ?"
+    };
+    let role_id: Option<String> = sqlx::query_scalar::<Any, String>(role_id_sql)
+        .bind(role)
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+    let role_id = role_id.ok_or_else(|| {
+        PublicRegistrationError::Database(format!("Required role '{role}' is missing"))
+    })?;
+
+    let bind_role_sql = if postgres {
+        "INSERT INTO user_role_bindings (user_id, role_id) VALUES ($1, $2)"
+    } else {
+        "INSERT INTO user_role_bindings (user_id, role_id) VALUES (?, ?)"
+    };
+    sqlx::query(bind_role_sql)
+        .bind(&user_id)
+        .bind(role_id)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+
+    transaction
+        .commit()
+        .await
+        .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+
+    Ok(PublicRegistrationResult {
+        user_id,
+        username: username.to_string(),
+        role: role.to_string(),
+    })
+}
+
+pub(crate) fn public_registration_open() -> bool {
+    std::env::var("BURNCLOUD_PUBLIC_REGISTRATION")
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "open" | "true" | "1" | "yes"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn public_signup_bonus_nano() -> Result<i64, PublicRegistrationError> {
+    let value = std::env::var("BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD")
+        .unwrap_or_else(|_| "0".to_string());
+    parse_usd_nano(&value)
+}
+
+pub(crate) fn parse_usd_nano(value: &str) -> Result<i64, PublicRegistrationError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(0);
+    }
+    if value.starts_with('-') || value.starts_with('+') {
+        return Err(PublicRegistrationError::Configuration(
+            "BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD must be non-negative".to_string(),
+        ));
+    }
+
+    let mut parts = value.split('.');
+    let whole = parts.next().unwrap_or_default();
+    let fraction = parts.next().unwrap_or_default();
+    if parts.next().is_some()
+        || fraction.len() > 9
+        || (!whole.is_empty() && !whole.chars().all(|ch| ch.is_ascii_digit()))
+        || (!fraction.is_empty() && !fraction.chars().all(|ch| ch.is_ascii_digit()))
+    {
+        return Err(PublicRegistrationError::Configuration(
+            "BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD must contain digits and at most 9 decimal places"
+                .to_string(),
+        ));
+    }
+
+    let whole_value = if whole.is_empty() {
+        0i64
+    } else {
+        whole.parse::<i64>().map_err(|_| {
+            PublicRegistrationError::Configuration(
+                "BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD is too large".to_string(),
+            )
+        })?
+    };
+    let mut fraction_text = fraction.to_string();
+    while fraction_text.len() < 9 {
+        fraction_text.push('0');
+    }
+    let fraction_nano = if fraction_text.is_empty() {
+        0i64
+    } else {
+        fraction_text.parse::<i64>().map_err(|_| {
+            PublicRegistrationError::Configuration(
+                "BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD is invalid".to_string(),
+            )
+        })?
+    };
+
+    whole_value
+        .checked_mul(1_000_000_000)
+        .and_then(|base| base.checked_add(fraction_nano))
+        .ok_or_else(|| {
+            PublicRegistrationError::Configuration(
+                "BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD is too large".to_string(),
+            )
+        })
+}
+
+fn constant_time_eq(left: &str, right: &str) -> bool {
+    let left = left.as_bytes();
+    let right = right.as_bytes();
+    let max_len = left.len().max(right.len());
+    let mut diff = left.len() ^ right.len();
+    for index in 0..max_len {
+        let a = left.get(index).copied().unwrap_or(0);
+        let b = right.get(index).copied().unwrap_or(0);
+        diff |= (a ^ b) as usize;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{constant_time_eq, parse_usd_nano, public_registration_open};
+
+    #[test]
+    fn bootstrap_token_comparison_requires_exact_match() {
+        assert!(constant_time_eq("0123456789abcdef", "0123456789abcdef"));
+        assert!(!constant_time_eq("0123456789abcdef", "0123456789abcdeg"));
+        assert!(!constant_time_eq("short", "shorter"));
+    }
+
+    #[test]
+    fn public_signup_bonus_uses_exact_nano_usd_precision() {
+        assert_eq!(parse_usd_nano("0").expect("zero"), 0);
+        assert_eq!(parse_usd_nano("10").expect("ten"), 10_000_000_000);
+        assert_eq!(parse_usd_nano("0.000000001").expect("nano"), 1);
+        assert!(parse_usd_nano("1.0000000001").is_err());
+        assert!(parse_usd_nano("-1").is_err());
+    }
+
+    #[test]
+    fn public_registration_is_closed_by_default() {
+        std::env::remove_var("BURNCLOUD_PUBLIC_REGISTRATION");
+        assert!(!public_registration_open());
+    }
+}

--- a/crates/server/src/api/registration.rs
+++ b/crates/server/src/api/registration.rs
@@ -24,7 +24,6 @@ pub(crate) struct PublicRegistrationResult {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PublicRegistrationError {
     BootstrapRequired,
-    BootstrapNotConfigured,
     InvalidBootstrapToken,
     BootstrapAlreadyComplete,
     RegistrationClosed,
@@ -34,7 +33,12 @@ pub(crate) enum PublicRegistrationError {
     Database(String),
 }
 
-pub(crate) async fn initialize_bootstrap_state(db: &Database) -> anyhow::Result<()> {
+/// Ensure the single-row first-admin marker exists and return whether bootstrap
+/// has already completed.
+///
+/// Existing installations predate this marker, so any real pre-existing user
+/// permanently closes first-admin bootstrap during startup.
+pub(crate) async fn initialize_bootstrap_state(db: &Database) -> anyhow::Result<bool> {
     let connection = db.get_connection()?;
     let pool = connection.pool();
     let create_sql = if db.kind() == "postgres" {
@@ -56,8 +60,6 @@ pub(crate) async fn initialize_bootstrap_state(db: &Database) -> anyhow::Result<
     };
     sqlx::query(&create_sql).execute(pool).await?;
 
-    // Existing installations predate the bootstrap marker. Mark them complete
-    // before serving requests so an upgrade can never reopen first-admin setup.
     let existing_users: i64 = sqlx::query_scalar::<Any, i64>(
         "SELECT COUNT(*) FROM user_accounts WHERE username != 'demo-user'",
     )
@@ -78,12 +80,51 @@ pub(crate) async fn initialize_bootstrap_state(db: &Database) -> anyhow::Result<
         sqlx::query(&backfill_sql).execute(pool).await?;
     }
 
-    Ok(())
+    let marker_sql = format!("SELECT COUNT(*) FROM {BOOTSTRAP_TABLE} WHERE id = 1");
+    let marker_count: i64 = sqlx::query_scalar::<Any, i64>(&marker_sql)
+        .fetch_one(pool)
+        .await?;
+    Ok(marker_count > 0)
 }
 
+pub(crate) async fn bootstrap_complete(
+    db: &Database,
+) -> Result<bool, PublicRegistrationError> {
+    let connection = db
+        .get_connection()
+        .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+    let marker_sql = format!("SELECT COUNT(*) FROM {BOOTSTRAP_TABLE} WHERE id = 1");
+    let marker_count: i64 = sqlx::query_scalar::<Any, i64>(&marker_sql)
+        .fetch_one(connection.pool())
+        .await
+        .map_err(|error| PublicRegistrationError::Database(error.to_string()))?;
+    Ok(marker_count > 0)
+}
+
+pub(crate) fn generate_bootstrap_token() -> String {
+    format!(
+        "{}{}",
+        Uuid::new_v4().simple(),
+        Uuid::new_v4().simple()
+    )
+}
+
+/// Register either the one-time first administrator or a normal public user.
+///
+/// `bootstrap_token_required=false` is reserved for a server bound only to a
+/// loopback address. That is BurnCloud's zero-configuration installation path:
+/// the first local registration atomically becomes the administrator.
+///
+/// A server exposed on a non-loopback address must pass
+/// `bootstrap_token_required=true` and an automatically generated or explicitly
+/// configured setup token. The same transaction claims the singleton marker,
+/// creates the user and binds the admin role, so concurrent first-admin attempts
+/// cannot both succeed.
 pub(crate) async fn register_public_user(
     db: &Database,
     input: &PublicRegistrationInput,
+    bootstrap_token_required: bool,
+    expected_bootstrap_token: Option<&str>,
 ) -> Result<PublicRegistrationResult, PublicRegistrationError> {
     let username = input.username.trim();
     if username.is_empty() {
@@ -145,22 +186,21 @@ pub(crate) async fn register_public_user(
         }
         ("user", public_signup_bonus_nano()?)
     } else {
-        let supplied = bootstrap_token.ok_or(PublicRegistrationError::BootstrapRequired)?;
-        let expected = std::env::var("BURNCLOUD_BOOTSTRAP_TOKEN")
-            .map_err(|_| PublicRegistrationError::BootstrapNotConfigured)?;
-        let expected = expected.trim();
-        if expected.len() < 16 {
-            return Err(PublicRegistrationError::Configuration(
-                "BURNCLOUD_BOOTSTRAP_TOKEN must contain at least 16 characters".to_string(),
-            ));
-        }
-        if !constant_time_eq(supplied, expected) {
-            return Err(PublicRegistrationError::InvalidBootstrapToken);
+        if bootstrap_token_required {
+            let supplied = bootstrap_token.ok_or(PublicRegistrationError::BootstrapRequired)?;
+            let expected = expected_bootstrap_token
+                .map(str::trim)
+                .filter(|value| value.len() >= 16)
+                .ok_or_else(|| {
+                    PublicRegistrationError::Configuration(
+                        "Remote bootstrap setup code is unavailable".to_string(),
+                    )
+                })?;
+            if !constant_time_eq(supplied, expected) {
+                return Err(PublicRegistrationError::InvalidBootstrapToken);
+            }
         }
 
-        // Claim the singleton marker inside the same transaction as admin user
-        // creation. The unique primary key prevents two processes from both
-        // successfully completing first-admin bootstrap.
         let claim_sql = if postgres {
             format!(
                 "INSERT INTO {BOOTSTRAP_TABLE} (id, completed_by) VALUES (1, $1) \

--- a/crates/server/src/api/registration_tests.rs
+++ b/crates/server/src/api/registration_tests.rs
@@ -1,0 +1,119 @@
+use super::registration::{
+    initialize_bootstrap_state, register_public_user, PublicRegistrationError,
+    PublicRegistrationInput,
+};
+use burncloud_database::Database;
+use burncloud_database_user::UserDatabase;
+use sqlx::Any;
+
+fn input(username: &str, bootstrap_token: Option<&str>) -> PublicRegistrationInput {
+    PublicRegistrationInput {
+        username: username.to_string(),
+        password: "SecureBootstrap123!".to_string(),
+        email: Some(format!("{username}@example.invalid")),
+        bootstrap_token: bootstrap_token.map(str::to_string),
+    }
+}
+
+#[tokio::test]
+async fn fresh_install_requires_one_time_bootstrap_then_only_creates_users() {
+    let temp = tempfile::tempdir().expect("temporary database directory");
+    let path = temp.path().join("bootstrap.db");
+    let url = format!("sqlite://{}?mode=rwc", path.to_string_lossy().replace('\\', "/"));
+
+    std::env::set_var("BURNCLOUD_DATABASE_URL", &url);
+    std::env::set_var(
+        "BURNCLOUD_BOOTSTRAP_TOKEN",
+        "0123456789abcdef-bootstrap-test-token",
+    );
+    std::env::set_var("BURNCLOUD_PUBLIC_REGISTRATION", "open");
+    std::env::set_var("BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD", "1.25");
+
+    let db = Database::new().await.expect("fresh sqlite database");
+    UserDatabase::init(&db).await.expect("user schema/roles");
+    initialize_bootstrap_state(&db)
+        .await
+        .expect("bootstrap state initialization");
+
+    let missing = register_public_user(&db, &input("missing-token", None)).await;
+    assert_eq!(missing, Err(PublicRegistrationError::BootstrapRequired));
+
+    let wrong = register_public_user(&db, &input("wrong-token", Some("wrong-wrong-wrong-wrong"))).await;
+    assert_eq!(wrong, Err(PublicRegistrationError::InvalidBootstrapToken));
+
+    let admin = register_public_user(
+        &db,
+        &input(
+            "bootstrap-admin",
+            Some("0123456789abcdef-bootstrap-test-token"),
+        ),
+    )
+    .await
+    .expect("trusted bootstrap must create admin");
+    assert_eq!(admin.role, "admin");
+
+    let connection = db.get_connection().expect("database connection");
+    let admin_balance: i64 = sqlx::query_scalar::<Any, i64>(
+        "SELECT balance_usd FROM user_accounts WHERE id = ?",
+    )
+    .bind(&admin.user_id)
+    .fetch_one(connection.pool())
+    .await
+    .expect("admin balance");
+    assert_eq!(admin_balance, 0, "bootstrap admin must not receive signup credit");
+
+    let marker_count: i64 = sqlx::query_scalar::<Any, i64>(
+        "SELECT COUNT(*) FROM burncloud_bootstrap_state WHERE id = 1",
+    )
+    .fetch_one(connection.pool())
+    .await
+    .expect("bootstrap marker");
+    assert_eq!(marker_count, 1);
+
+    let replay = register_public_user(
+        &db,
+        &input(
+            "bootstrap-replay",
+            Some("0123456789abcdef-bootstrap-test-token"),
+        ),
+    )
+    .await;
+    assert_eq!(replay, Err(PublicRegistrationError::BootstrapAlreadyComplete));
+
+    let ordinary = register_public_user(&db, &input("ordinary-user", None))
+        .await
+        .expect("open post-bootstrap registration");
+    assert_eq!(ordinary.role, "user");
+
+    let ordinary_balance: i64 = sqlx::query_scalar::<Any, i64>(
+        "SELECT balance_usd FROM user_accounts WHERE id = ?",
+    )
+    .bind(&ordinary.user_id)
+    .fetch_one(connection.pool())
+    .await
+    .expect("ordinary user balance");
+    assert_eq!(ordinary_balance, 1_250_000_000);
+
+    let admin_roles: i64 = sqlx::query_scalar::<Any, i64>(
+        "SELECT COUNT(*) FROM user_role_bindings b JOIN user_roles r ON r.id = b.role_id WHERE b.user_id = ? AND r.name = 'admin'",
+    )
+    .bind(&admin.user_id)
+    .fetch_one(connection.pool())
+    .await
+    .expect("admin role binding");
+    assert_eq!(admin_roles, 1);
+
+    let ordinary_admin_roles: i64 = sqlx::query_scalar::<Any, i64>(
+        "SELECT COUNT(*) FROM user_role_bindings b JOIN user_roles r ON r.id = b.role_id WHERE b.user_id = ? AND r.name = 'admin'",
+    )
+    .bind(&ordinary.user_id)
+    .fetch_one(connection.pool())
+    .await
+    .expect("ordinary role binding");
+    assert_eq!(ordinary_admin_roles, 0);
+
+    std::env::remove_var("BURNCLOUD_DATABASE_URL");
+    std::env::remove_var("BURNCLOUD_BOOTSTRAP_TOKEN");
+    std::env::remove_var("BURNCLOUD_PUBLIC_REGISTRATION");
+    std::env::remove_var("BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD");
+}

--- a/crates/server/src/api/registration_tests.rs
+++ b/crates/server/src/api/registration_tests.rs
@@ -15,52 +15,91 @@ fn input(username: &str, bootstrap_token: Option<&str>) -> PublicRegistrationInp
     }
 }
 
-#[tokio::test]
-async fn fresh_install_requires_one_time_bootstrap_then_only_creates_users() {
-    let temp = tempfile::tempdir().expect("temporary database directory");
-    let path = temp.path().join("bootstrap.db");
-    let url = format!("sqlite://{}?mode=rwc", path.to_string_lossy().replace('\\', "/"));
-
-    std::env::set_var("BURNCLOUD_DATABASE_URL", &url);
-    std::env::set_var(
-        "BURNCLOUD_BOOTSTRAP_TOKEN",
-        "0123456789abcdef-bootstrap-test-token",
+async fn fresh_db(path: &std::path::Path) -> Database {
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        path.to_string_lossy().replace('\\', "/")
     );
+    std::env::set_var("BURNCLOUD_DATABASE_URL", &url);
+    let db = Database::new().await.expect("fresh sqlite database");
+    UserDatabase::init(&db).await.expect("user schema/roles");
+    let completed = initialize_bootstrap_state(&db)
+        .await
+        .expect("bootstrap state initialization");
+    assert!(!completed, "fresh database must require first-admin setup");
+    db
+}
+
+#[tokio::test]
+async fn first_admin_is_zero_config_locally_and_code_guarded_remotely() {
+    let temp = tempfile::tempdir().expect("temporary database directory");
     std::env::set_var("BURNCLOUD_PUBLIC_REGISTRATION", "open");
     std::env::set_var("BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD", "1.25");
 
-    let db = Database::new().await.expect("fresh sqlite database");
-    UserDatabase::init(&db).await.expect("user schema/roles");
-    initialize_bootstrap_state(&db)
-        .await
-        .expect("bootstrap state initialization");
+    // Remote/exposed server policy: BurnCloud requires its generated setup code.
+    let remote_db = fresh_db(&temp.path().join("remote-bootstrap.db")).await;
+    let setup_code = "0123456789abcdef-remote-setup-code";
 
-    let missing = register_public_user(&db, &input("missing-token", None)).await;
+    let missing = register_public_user(
+        &remote_db,
+        &input("missing-code", None),
+        true,
+        Some(setup_code),
+    )
+    .await;
     assert_eq!(missing, Err(PublicRegistrationError::BootstrapRequired));
 
-    let wrong = register_public_user(&db, &input("wrong-token", Some("wrong-wrong-wrong-wrong"))).await;
+    let wrong = register_public_user(
+        &remote_db,
+        &input("wrong-code", Some("wrong-wrong-wrong-wrong")),
+        true,
+        Some(setup_code),
+    )
+    .await;
     assert_eq!(wrong, Err(PublicRegistrationError::InvalidBootstrapToken));
 
-    let admin = register_public_user(
-        &db,
-        &input(
-            "bootstrap-admin",
-            Some("0123456789abcdef-bootstrap-test-token"),
-        ),
+    let remote_admin = register_public_user(
+        &remote_db,
+        &input("remote-admin", Some(setup_code)),
+        true,
+        Some(setup_code),
     )
     .await
-    .expect("trusted bootstrap must create admin");
-    assert_eq!(admin.role, "admin");
+    .expect("correct remote setup code must create admin");
+    assert_eq!(remote_admin.role, "admin");
 
-    let connection = db.get_connection().expect("database connection");
+    let replay = register_public_user(
+        &remote_db,
+        &input("remote-replay", Some(setup_code)),
+        true,
+        Some(setup_code),
+    )
+    .await;
+    assert_eq!(
+        replay,
+        Err(PublicRegistrationError::BootstrapAlreadyComplete)
+    );
+
+    // Default BurnCloud policy: HOST=127.0.0.1, so first-run setup requires
+    // only username/password. No env bootstrap secret and no setup-code field.
+    let local_db = fresh_db(&temp.path().join("local-bootstrap.db")).await;
+    let local_admin = register_public_user(&local_db, &input("local-admin", None), false, None)
+        .await
+        .expect("local first-run setup must be zero configuration");
+    assert_eq!(local_admin.role, "admin");
+
+    let connection = local_db.get_connection().expect("database connection");
     let admin_balance: i64 = sqlx::query_scalar::<Any, i64>(
         "SELECT balance_usd FROM user_accounts WHERE id = ?",
     )
-    .bind(&admin.user_id)
+    .bind(&local_admin.user_id)
     .fetch_one(connection.pool())
     .await
     .expect("admin balance");
-    assert_eq!(admin_balance, 0, "bootstrap admin must not receive signup credit");
+    assert_eq!(
+        admin_balance, 0,
+        "bootstrap admin must not receive public signup credit"
+    );
 
     let marker_count: i64 = sqlx::query_scalar::<Any, i64>(
         "SELECT COUNT(*) FROM burncloud_bootstrap_state WHERE id = 1",
@@ -70,19 +109,9 @@ async fn fresh_install_requires_one_time_bootstrap_then_only_creates_users() {
     .expect("bootstrap marker");
     assert_eq!(marker_count, 1);
 
-    let replay = register_public_user(
-        &db,
-        &input(
-            "bootstrap-replay",
-            Some("0123456789abcdef-bootstrap-test-token"),
-        ),
-    )
-    .await;
-    assert_eq!(replay, Err(PublicRegistrationError::BootstrapAlreadyComplete));
-
-    let ordinary = register_public_user(&db, &input("ordinary-user", None))
+    let ordinary = register_public_user(&local_db, &input("ordinary-user", None), false, None)
         .await
-        .expect("open post-bootstrap registration");
+        .expect("open post-bootstrap public registration");
     assert_eq!(ordinary.role, "user");
 
     let ordinary_balance: i64 = sqlx::query_scalar::<Any, i64>(
@@ -97,7 +126,7 @@ async fn fresh_install_requires_one_time_bootstrap_then_only_creates_users() {
     let admin_roles: i64 = sqlx::query_scalar::<Any, i64>(
         "SELECT COUNT(*) FROM user_role_bindings b JOIN user_roles r ON r.id = b.role_id WHERE b.user_id = ? AND r.name = 'admin'",
     )
-    .bind(&admin.user_id)
+    .bind(&local_admin.user_id)
     .fetch_one(connection.pool())
     .await
     .expect("admin role binding");
@@ -113,7 +142,6 @@ async fn fresh_install_requires_one_time_bootstrap_then_only_creates_users() {
     assert_eq!(ordinary_admin_roles, 0);
 
     std::env::remove_var("BURNCLOUD_DATABASE_URL");
-    std::env::remove_var("BURNCLOUD_BOOTSTRAP_TOKEN");
     std::env::remove_var("BURNCLOUD_PUBLIC_REGISTRATION");
     std::env::remove_var("BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD");
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -30,6 +30,10 @@ pub struct AppState {
 
 #[tracing::instrument(skip(db))]
 pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Result<Router> {
+    // Bootstrap state must exist before public registration is reachable. Existing
+    // installations are marked complete here so upgrades never reopen first-admin setup.
+    api::registration::initialize_bootstrap_state(&db).await?;
+
     let monitor = Arc::new(SystemMonitorService::new());
     // Start auto collection in background
     let _ = monitor.start_auto_update().await;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -12,7 +12,8 @@ use burncloud_router::price_sync::SyncResult;
 use burncloud_service_cache::CacheService;
 use burncloud_service_monitor::SystemMonitorService;
 use burncloud_service_user::UserService;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
+use std::process::Command;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tower_http::cors::CorsLayer;
@@ -26,19 +27,85 @@ pub struct AppState {
     pub user_service: Arc<UserService>,
     pub cache: CacheService,
     pub force_sync_tx: mpsc::Sender<oneshot::Sender<SyncResult>>,
+    pub(crate) bootstrap_token: Arc<String>,
+    pub(crate) bootstrap_token_required: bool,
 }
 
-#[tracing::instrument(skip(db))]
-pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Result<Router> {
-    // Bootstrap state must exist before public registration is reachable. Existing
-    // installations are marked complete here so upgrades never reopen first-admin setup.
-    api::registration::initialize_bootstrap_state(&db).await?;
+fn is_loopback_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<IpAddr>()
+        .map(|address| address.is_loopback())
+        .unwrap_or(false)
+}
+
+fn resolve_bootstrap_token() -> anyhow::Result<(String, bool)> {
+    if let Ok(configured) = std::env::var("BURNCLOUD_BOOTSTRAP_TOKEN") {
+        let configured = configured.trim().to_string();
+        if configured.len() < 16 {
+            anyhow::bail!("BURNCLOUD_BOOTSTRAP_TOKEN must contain at least 16 characters");
+        }
+        return Ok((configured, false));
+    }
+
+    Ok((api::registration::generate_bootstrap_token(), true))
+}
+
+fn try_open_browser(url: &str) {
+    #[cfg(target_os = "windows")]
+    let result = Command::new("cmd").args(["/C", "start", "", url]).spawn();
+
+    #[cfg(target_os = "macos")]
+    let result = Command::new("open").arg(url).spawn();
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let result = Command::new("xdg-open").arg(url).spawn();
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", unix)))]
+    let result: std::io::Result<std::process::Child> = Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "automatic browser launch is not supported on this platform",
+    ));
+
+    if let Err(error) = result {
+        tracing::debug!(%error, %url, "Could not open first-run browser automatically");
+    }
+}
+
+async fn build_app(
+    db: Arc<Database>,
+    enable_liveview: bool,
+    bootstrap_token_required: bool,
+) -> anyhow::Result<(Router, bool)> {
+    // The marker is created before public registration is reachable. Existing
+    // installations are marked complete here so upgrades never reopen setup.
+    let bootstrap_complete = api::registration::initialize_bootstrap_state(&db).await?;
+    let setup_required = !bootstrap_complete;
+    let (bootstrap_token, generated_bootstrap_token) = resolve_bootstrap_token()?;
+
+    if setup_required {
+        if bootstrap_token_required {
+            if generated_bootstrap_token {
+                tracing::warn!(
+                    setup_code = %bootstrap_token,
+                    "First-time remote setup: enter this one-time setup code on the Create Administrator page"
+                );
+            } else {
+                tracing::info!(
+                    "First-time remote setup will use the configured BURNCLOUD_BOOTSTRAP_TOKEN"
+                );
+            }
+        } else {
+            tracing::info!(
+                "First-time local setup ready: no bootstrap token or environment configuration is required"
+            );
+        }
+    }
 
     let monitor = Arc::new(SystemMonitorService::new());
-    // Start auto collection in background
     let _ = monitor.start_auto_update().await;
 
-    // Initialize cache service (will be disabled if REDIS_URL not set)
     let cache = CacheService::new().await?;
     if cache.is_available().await {
         tracing::info!("Redis cache enabled and connected");
@@ -46,7 +113,6 @@ pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Res
         tracing::info!("Redis cache disabled");
     }
 
-    // 3. Data Plane Router (Fallback) — must be created first to get force_sync_tx
     let (router_app, internal_app, force_sync_tx) = create_router_app(db.clone()).await?;
 
     let state = AppState {
@@ -55,30 +121,21 @@ pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Res
         user_service: Arc::new(UserService::new()),
         cache,
         force_sync_tx,
+        bootstrap_token: Arc::new(bootstrap_token),
+        bootstrap_token_required,
     };
 
-    // 1. Management API Router
     let api_router = api::routes(state.clone());
 
-    // Top-level liveness probe (unauthenticated, used by deploy validators and
-    // external uptime monitors). The richer report lives at
-    // `/console/internal/health`.
-    // Internal routes (health, reload, price-sync) must be registered BEFORE
-    // LiveView's catch-all `/console/{*path}` so they return JSON instead of
-    // the SPA HTML shell.
     let mut app = Router::new()
         .route("/health", get(|| async { "ok" }))
         .merge(api_router)
         .merge(internal_app);
 
     if enable_liveview {
-        // 2. LiveView Router
         let liveview_router = burncloud_client::liveview_router(db.clone());
         app = app.merge(liveview_router);
     }
-
-    // Note: If LiveView is disabled, "/" requests will hit the fallback (router_app)
-    // which usually returns 404 for unknown paths, or handles LLM requests.
 
     let x_request_id = HeaderName::from_static("x-request-id");
 
@@ -91,12 +148,20 @@ pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Res
         .layer(PropagateRequestIdLayer::new(x_request_id.clone()))
         .layer(TraceLayer::new_for_http())
         .layer(CorsLayer::permissive())
-        // Security boundary is intentionally global so it protects both the
-        // explicitly merged internal routes and the data-plane fallback.
         .layer(middleware::from_fn(
             api::auth::security_boundary_middleware,
         ));
 
+    Ok((app, setup_required))
+}
+
+/// Build an embeddable application with the conservative remote-safe bootstrap
+/// policy. Library callers that expose this Router directly must provide the
+/// one-time setup code; the zero-configuration shortcut is enabled only by
+/// `start_server` when BurnCloud is actually bound to a loopback address.
+#[tracing::instrument(skip(db))]
+pub async fn create_app(db: Arc<Database>, enable_liveview: bool) -> anyhow::Result<Router> {
+    let (app, _) = build_app(db, enable_liveview, true).await?;
     Ok(app)
 }
 
@@ -107,16 +172,30 @@ pub async fn start_server(host: &str, port: u16, enable_liveview: bool) -> anyho
     UserDatabase::init(&db).await?;
     let db = Arc::new(db);
 
-    let app = create_app(db, enable_liveview).await?;
+    // BurnCloud defaults to 127.0.0.1. On that private local-only binding the
+    // first registration can safely become admin with no manual setup secret.
+    // Explicitly exposing the server on a non-loopback address switches back
+    // to a one-time setup code that BurnCloud generates automatically.
+    let local_only = is_loopback_host(host);
+    let (app, setup_required) = build_app(db, enable_liveview, !local_only).await?;
 
     let addr: SocketAddr = format!("{}:{}", host, port).parse()?;
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+
     tracing::info!("Unified Gateway listening on {}", addr);
     if enable_liveview {
         tracing::info!("- Dashboard: http://{}:{}/", host, port);
     }
     tracing::info!("- LLM API:   http://{}:{}/v1/...", host, port);
 
-    let listener = tokio::net::TcpListener::bind(addr).await?;
+    if setup_required && local_only {
+        let setup_url = format!("http://127.0.0.1:{port}/register");
+        tracing::info!(%setup_url, "First-time setup: create your administrator account");
+        if enable_liveview {
+            try_open_browser(&setup_url);
+        }
+    }
+
     axum::serve(listener, app).await?;
 
     Ok(())

--- a/crates/tests/tests/api/auth_handlers.rs
+++ b/crates/tests/tests/api/auth_handlers.rs
@@ -15,194 +15,93 @@ use burncloud_tests::TestClient;
 use serde_json::json;
 use uuid::Uuid;
 
-// Helper function to generate unique test usernames
+const TEST_BOOTSTRAP_TOKEN: &str = "burncloud-e2e-bootstrap-token-2026";
+
 fn generate_test_username(prefix: &str) -> String {
-    format!(
-        "{}_{}",
-        prefix,
-        &Uuid::new_v4().to_string().replace("-", "")[..8]
-    )
+    format!("{}_{}", prefix, &Uuid::new_v4().to_string().replace('-', "")[..8])
 }
 
 #[tokio::test]
 async fn test_auth_register_success() -> anyhow::Result<()> {
-    let base_url = spawn_app().await;
-    let client = TestClient::new(&base_url);
-
+    let client = TestClient::new(&spawn_app().await);
     let username = generate_test_username("authuser");
-    let password = "SecurePass123!";
-
-    let body = json!({
-        "username": username,
-        "password": password,
-        "email": format!("{}@example.com", username)
-    });
-
+    let body = json!({"username": username, "password": "SecurePass123!", "email": format!("{}@example.com", username)});
     let res = client.post("/api/auth/register", &body).await?;
-    assert_eq!(res["success"], true, "Register should succeed");
-    assert!(!res["data"]["id"].is_null(), "Should return user ID");
-    assert_eq!(res["data"]["username"], username);
-    assert!(!res["data"]["token"].is_null(), "Should return JWT token");
+    assert_eq!(res["success"], true);
+    assert_eq!(res["data"]["roles"][0], "user");
+    assert!(!res["data"]["token"].as_str().unwrap_or_default().is_empty());
+    Ok(())
+}
 
-    // Verify token is a non-empty string
-    let token = res["data"]["token"].as_str().unwrap();
-    assert!(!token.is_empty(), "Token should not be empty");
-
+#[tokio::test]
+async fn test_auth_bootstrap_token_cannot_be_replayed() -> anyhow::Result<()> {
+    let client = TestClient::new(&spawn_app().await);
+    let body = json!({
+        "username": generate_test_username("replay"),
+        "password": "SecurePass123!",
+        "email": "replay@example.invalid",
+        "bootstrap_token": TEST_BOOTSTRAP_TOKEN
+    });
+    let res = client.post("/api/auth/register", &body).await?;
+    assert_eq!(res["success"], false);
+    assert!(res["message"].as_str().unwrap_or_default().contains("already been completed"));
     Ok(())
 }
 
 #[tokio::test]
 async fn test_auth_register_duplicate_username() -> anyhow::Result<()> {
-    let base_url = spawn_app().await;
-    let client = TestClient::new(&base_url);
-
+    let client = TestClient::new(&spawn_app().await);
     let username = generate_test_username("dupuser");
-    let password = "SecurePass123!";
-
-    let body = json!({
-        "username": username,
-        "password": password,
-        "email": format!("{}@example.com", username)
-    });
-
-    // First registration should succeed
-    let res1 = client.post("/api/auth/register", &body).await?;
-    assert_eq!(res1["success"], true);
-
-    // Second registration with same username should fail
-    let res2 = client.post("/api/auth/register", &body).await?;
-    assert_eq!(res2["success"], false);
-    assert!(res2["message"].as_str().unwrap().contains("already exists"));
-
+    let body = json!({"username": username, "password": "SecurePass123!", "email": format!("{}@example.com", username)});
+    assert_eq!(client.post("/api/auth/register", &body).await?["success"], true);
+    let second = client.post("/api/auth/register", &body).await?;
+    assert_eq!(second["success"], false);
+    assert!(second["message"].as_str().unwrap_or_default().contains("already exists"));
     Ok(())
 }
 
 #[tokio::test]
 async fn test_auth_login_success() -> anyhow::Result<()> {
-    let base_url = spawn_app().await;
-    let client = TestClient::new(&base_url);
-
+    let client = TestClient::new(&spawn_app().await);
     let username = generate_test_username("loginuser");
     let password = "SecurePass123!";
-
-    // Register first
-    let reg_body = json!({
-        "username": username,
-        "password": password,
-        "email": format!("{}@example.com", username)
-    });
-    client.post("/api/auth/register", &reg_body).await?;
-
-    // Now login
-    let login_body = json!({
-        "username": username,
-        "password": password
-    });
-
-    let res = client.post("/api/auth/login", &login_body).await?;
-    assert_eq!(res["success"], true, "Login should succeed");
-    assert_eq!(res["data"]["username"], username);
-    assert!(!res["data"]["token"].is_null(), "Should return JWT token");
-    assert!(!res["data"]["roles"].is_null(), "Should return user roles");
-
-    // Verify token is a non-empty string
-    let token = res["data"]["token"].as_str().unwrap();
-    assert!(!token.is_empty(), "Token should not be empty");
-
+    client.post("/api/auth/register", &json!({"username": username, "password": password, "email": format!("{}@example.com", username)})).await?;
+    let res = client.post("/api/auth/login", &json!({"username": username, "password": password})).await?;
+    assert_eq!(res["success"], true);
+    assert_eq!(res["data"]["roles"][0], "user");
     Ok(())
 }
 
 #[tokio::test]
 async fn test_auth_login_invalid_credentials() -> anyhow::Result<()> {
-    let base_url = spawn_app().await;
-    let client = TestClient::new(&base_url);
-
-    let username = generate_test_username("testuser");
-    let password = "SecurePass123!";
-
-    // Register first
-    let reg_body = json!({
-        "username": username,
-        "password": password,
-        "email": format!("{}@example.com", username)
-    });
-    client.post("/api/auth/register", &reg_body).await?;
-
-    // Try login with wrong password
-    let login_body = json!({
-        "username": username,
-        "password": "WrongPassword123!"
-    });
-
-    let res = client.post("/api/auth/login", &login_body).await?;
-    assert_eq!(
-        res["success"], false,
-        "Login should fail with wrong password"
-    );
-    assert!(res["message"]
-        .as_str()
-        .unwrap()
-        .contains("Invalid credentials"));
-
+    let client = TestClient::new(&spawn_app().await);
+    let username = generate_test_username("badlogin");
+    client.post("/api/auth/register", &json!({"username": username, "password": "SecurePass123!", "email": format!("{}@example.com", username)})).await?;
+    let res = client.post("/api/auth/login", &json!({"username": username, "password": "WrongPassword123!"})).await?;
+    assert_eq!(res["success"], false);
+    assert!(res["message"].as_str().unwrap_or_default().contains("Invalid credentials"));
     Ok(())
 }
 
 #[tokio::test]
 async fn test_auth_login_nonexistent_user() -> anyhow::Result<()> {
-    let base_url = spawn_app().await;
-    let client = TestClient::new(&base_url);
-
-    let login_body = json!({
-        "username": "nonexistent_user_12345",
-        "password": "SomePassword123!"
-    });
-
-    let res = client.post("/api/auth/login", &login_body).await?;
-    assert_eq!(
-        res["success"], false,
-        "Login should fail for nonexistent user"
-    );
-    assert!(res["message"].as_str().unwrap().contains("not found"));
-
+    let client = TestClient::new(&spawn_app().await);
+    let res = client.post("/api/auth/login", &json!({"username": "nonexistent_user_12345", "password": "SomePassword123!"})).await?;
+    assert_eq!(res["success"], false);
+    assert!(res["message"].as_str().unwrap_or_default().contains("not found"));
     Ok(())
 }
 
 #[tokio::test]
 async fn test_auth_complete_flow() -> anyhow::Result<()> {
-    let base_url = spawn_app().await;
-    let client = TestClient::new(&base_url);
-
+    let client = TestClient::new(&spawn_app().await);
     let username = generate_test_username("flowuser");
     let password = "CompleteFlow123!";
-
-    // 1. Register
-    let reg_body = json!({
-        "username": username,
-        "password": password,
-        "email": format!("{}@example.com", username)
-    });
-
-    let reg_res = client.post("/api/auth/register", &reg_body).await?;
-    assert_eq!(reg_res["success"], true);
-    let reg_token = reg_res["data"]["token"].as_str().unwrap().to_string();
-
-    // 2. Login
-    let login_body = json!({
-        "username": username,
-        "password": password
-    });
-
-    let login_res = client.post("/api/auth/login", &login_body).await?;
-    assert_eq!(login_res["success"], true);
-    let login_token = login_res["data"]["token"].as_str().unwrap().to_string();
-
-    // Both tokens should be valid JWT tokens (non-empty strings)
-    assert!(!reg_token.is_empty());
-    assert!(!login_token.is_empty());
-
-    // Tokens should be different (different iat timestamps)
-    // Note: In rare cases they might be the same if generated in the same second,
-    // but this is unlikely in practice
-
+    let reg = client.post("/api/auth/register", &json!({"username": username, "password": password, "email": format!("{}@example.com", username)})).await?;
+    assert_eq!(reg["success"], true);
+    assert_eq!(reg["data"]["roles"][0], "user");
+    let login = client.post("/api/auth/login", &json!({"username": username, "password": password})).await?;
+    assert_eq!(login["success"], true);
+    assert_eq!(login["data"]["roles"][0], "user");
     Ok(())
 }

--- a/crates/tests/tests/common/mod.rs
+++ b/crates/tests/tests/common/mod.rs
@@ -15,6 +15,7 @@ pub mod evidence;
 
 use dotenvy::dotenv;
 use reqwest::Client;
+use serde_json::json;
 use std::env;
 use std::net::TcpListener;
 use std::path::PathBuf;
@@ -23,19 +24,21 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 static SERVER_HANDLE: OnceLock<ServerHandle> = OnceLock::new();
+static TEST_BOOTSTRAP_DONE: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+const TEST_BOOTSTRAP_TOKEN: &str = "burncloud-e2e-bootstrap-token-2026";
 
 #[derive(Debug)]
 struct ServerHandle {
     pub base_url: String,
     #[allow(dead_code)]
-    process: Option<Child>, // Keep child alive
+    process: Option<Child>,
 }
 
 pub async fn spawn_app() -> String {
-    // Load .env
     dotenv().ok();
 
-    // 0. Check E2E_BASE_URL environment variable first
+    // Externally managed E2E targets own their own bootstrap policy. Never
+    // inject the test bootstrap credential into a server this harness did not spawn.
     if let Ok(base_url) = env::var("E2E_BASE_URL") {
         println!("TEST: Using E2E_BASE_URL from env: {}", base_url);
         wait_for_server(&base_url).await;
@@ -43,7 +46,6 @@ pub async fn spawn_app() -> String {
     }
 
     let handle = SERVER_HANDLE.get_or_init(|| {
-        // 1. Reuse port 3000 only when not forcing an isolated test server
         let force_spawn = env::var("E2E_FORCE_SPAWN")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
@@ -58,11 +60,9 @@ pub async fn spawn_app() -> String {
             println!("TEST: E2E_FORCE_SPAWN set — spawning dedicated server (skip :3000 reuse)");
         }
 
-        // 2. Locate Binary
         let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
         let manifest_path = PathBuf::from(manifest_dir);
         let root_dir = manifest_path.parent().unwrap().parent().unwrap();
-
         let binary_path = if cfg!(target_os = "windows") {
             root_dir.join("target/debug/burncloud.exe")
         } else {
@@ -76,7 +76,6 @@ pub async fn spawn_app() -> String {
             );
         }
 
-        // 3. Pick Port & Spawn
         let port = get_free_port();
         println!("TEST: Spawning new server at http://127.0.0.1:{}", port);
 
@@ -84,36 +83,77 @@ pub async fn spawn_app() -> String {
             .arg("server")
             .arg("start")
             .env("PORT", port.to_string())
-            .env("RUST_LOG", "burncloud=warn") // Reduce log noise
-            .env("NO_PROXY", "*") // Prevent proxy issues
+            .env("RUST_LOG", "burncloud=warn")
+            .env("NO_PROXY", "*")
             .env(
                 "MASTER_KEY",
                 "a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8",
-            ) // 64 hex chars for test
-            .env("PRICE_SYNC_INTERVAL_SECS", "999999") // Disable price sync for faster startup
-            .env("SKIP_INITIAL_PRICE_SYNC", "1") // Skip initial price sync in tests
+            )
+            .env("BURNCLOUD_BOOTSTRAP_TOKEN", TEST_BOOTSTRAP_TOKEN)
+            .env("BURNCLOUD_PUBLIC_REGISTRATION", "open")
+            .env("BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD", "0")
+            .env("PRICE_SYNC_INTERVAL_SECS", "999999")
+            .env("SKIP_INITIAL_PRICE_SYNC", "1")
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
             .expect("Failed to spawn server");
 
-        // Return handle immediately, wait async later
         ServerHandle {
             base_url: format!("http://127.0.0.1:{}", port),
             process: Some(process),
         }
     });
 
-    // 4. Async Wait for Readiness
-    // Since multiple tests run in parallel, they might all call this.
-    // It's idempotent (GET /status).
     wait_for_server(&handle.base_url).await;
+    if handle.process.is_some() {
+        let base_url = handle.base_url.clone();
+        TEST_BOOTSTRAP_DONE
+            .get_or_init(|| async move {
+                ensure_test_bootstrap(&base_url).await;
+            })
+            .await;
+    }
 
     handle.base_url.clone()
 }
 
+async fn ensure_test_bootstrap(base_url: &str) {
+    let client = Client::builder()
+        .no_proxy()
+        .build()
+        .expect("reqwest bootstrap client");
+    let body = json!({
+        "username": "e2e-bootstrap-admin",
+        "password": "E2eBootstrapAdmin123!",
+        "email": "e2e-bootstrap-admin@example.invalid",
+        "bootstrap_token": TEST_BOOTSTRAP_TOKEN
+    });
+
+    let payload: serde_json::Value = client
+        .post(format!("{base_url}/api/auth/register"))
+        .json(&body)
+        .send()
+        .await
+        .expect("bootstrap registration request")
+        .json()
+        .await
+        .expect("bootstrap registration response");
+
+    if payload["success"] == true {
+        assert_eq!(payload["data"]["roles"][0], "admin");
+        return;
+    }
+
+    let message = payload["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("already been completed") || message.contains("already exists"),
+        "unexpected bootstrap response: {payload}"
+    );
+}
+
 fn is_port_open(port: u16) -> bool {
-    std::net::TcpStream::connect(format!("127.0.0.1:{}", port)).is_ok()
+    std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok()
 }
 
 fn get_free_port() -> u16 {
@@ -127,8 +167,6 @@ async fn wait_for_server(url: &str) {
         .build()
         .expect("reqwest client");
     for i in 0..120 {
-        // 60s timeout (price sync can take ~30s on first run)
-        // Use /health endpoint which doesn't require auth
         if client
             .get(format!("{}/health", url))
             .send()
@@ -165,9 +203,6 @@ pub fn get_openai_config() -> Option<(String, String)> {
     Some((key, url))
 }
 
-// Removed deprecated functions: get_base_url (sync), get_db_pool, seed_demo_data
-
-/// Insert a price entry for a mock model so the router's preflight check passes.
 #[allow(dead_code)]
 pub async fn insert_mock_price(model: &str) {
     let db_url = std::env::var("BURNCLOUD_DATABASE_URL")
@@ -178,7 +213,7 @@ pub async fn insert_mock_price(model: &str) {
         .await
         .expect("Failed to connect to test DB");
     sqlx::query(
-        "INSERT OR IGNORE INTO billing_prices (model, currency, input_price, output_price, region) VALUES (?, 'USD', 0, 0, '')"
+        "INSERT OR IGNORE INTO billing_prices (model, currency, input_price, output_price, region) VALUES (?, 'USD', 0, 0, '')",
     )
     .bind(model)
     .execute(&pool)
@@ -186,7 +221,6 @@ pub async fn insert_mock_price(model: &str) {
     .expect("Failed to insert mock price");
     pool.close().await;
 
-    // Trigger a price cache refresh via the internal API
     let base_url = SERVER_HANDLE
         .get()
         .map(|h| h.base_url.clone())


### PR DESCRIPTION
## Goal

Fix the fresh-installation trust-root flaw tracked in #403 **without sacrificing BurnCloud's original one-click installation experience**.

The default experience is now:

```text
Install BurnCloud
→ Start BurnCloud
→ Browser / desktop UI opens
→ Create administrator
→ Enter Console
```

No bootstrap environment variable is required for the default local installation.

## Previous unsafe behavior

`POST /api/auth/register` was public and the old first-user behavior could assign `admin` whenever no real user existed. A fresh instance exposed before the intended operator registered could therefore let an unauthenticated remote registrant become administrator.

## New first-run model

### Default installation — zero configuration

BurnCloud defaults to `HOST=127.0.0.1`.

For a loopback-only server:

- no `BURNCLOUD_BOOTSTRAP_TOKEN` is required;
- no setup code field is required;
- the UI checks `/api/auth/setup` and routes an uninitialized environment directly to the Register / first-admin screen;
- on headless LiveView startup BurnCloud attempts to open `/register` automatically;
- the first local registration atomically claims `burncloud_bootstrap_state`, creates the user and binds role `admin` in the same DB transaction;
- the singleton marker prevents concurrent/replayed first-admin creation;
- if user or role creation fails, the marker claim rolls back with the transaction.

### Explicitly exposed / remote installation

When BurnCloud is bound to a non-loopback host such as `0.0.0.0`, the convenience shortcut is disabled.

- BurnCloud automatically generates a high-entropy one-time setup code;
- the generated code is printed at startup;
- first-admin registration must supply the matching `bootstrap_token`;
- operators do **not** have to edit `.env` first;
- `BURNCLOUD_BOOTSTRAP_TOKEN` remains available only as an advanced/headless override and must contain at least 16 characters;
- setup-code comparison avoids early-exit byte comparison.

### Embedded Router safety

`burncloud_server::create_app()` uses the conservative remote-safe policy because an embedding caller may expose the returned Router on any interface. The zero-configuration shortcut is enabled only by `start_server()` when the actual bind host is loopback.

### Existing installations

If real users already exist but the bootstrap marker does not, startup marks bootstrap as completed. An upgrade can never reopen first-admin setup.

### After first-admin setup

- first-admin setup is permanently closed;
- any later request that keeps sending a bootstrap token is rejected as already completed;
- ordinary public registration is **closed by default**;
- operators may explicitly set `BURNCLOUD_PUBLIC_REGISTRATION=open` (also accepts true/1/yes);
- normal public registration always receives role `user`.

## Public signup wallet policy

Public self-registration no longer inherits the old implicit hard-coded $10 grant.

- `BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD` controls public signup credit;
- default is `0`;
- parsing uses exact integer nano-USD, up to 9 decimal places;
- invalid or negative configuration fails closed;
- first administrator setup never receives public signup credit.

Admin-created customers in the existing Console service remain unchanged in this PR.

## UX / API additions

- `GET /api/auth/setup` exposes only setup state (`setup_required`, whether a setup code is required, and whether normal public registration is open); it never exposes the generated secret.
- `AuthGate` checks first-run state and sends a fresh installation to the account-creation screen instead of the normal login screen.
- local LiveView startup attempts to open the first-run registration page automatically.

## Tests

The server registration tests now cover both policies:

- zero-configuration local first-admin creation;
- setup-code-required remote first-admin creation;
- wrong/missing remote setup code rejection;
- single-use bootstrap marker;
- post-bootstrap users remain `user`;
- first admin receives no signup bonus while configured public signup credit applies only to later public users.

The existing integration harness remains compatible while this PR transitions away from requiring a manually configured bootstrap token for normal installation.

## Documentation

`.env.example` now documents the intended hierarchy:

1. `HOST=127.0.0.1` → zero-config first-run setup;
2. non-loopback `HOST` → BurnCloud auto-generates a one-time remote setup code;
3. `BURNCLOUD_BOOTSTRAP_TOKEN` → optional advanced override only;
4. `BURNCLOUD_PUBLIC_REGISTRATION` → closed by default after setup;
5. `BURNCLOUD_PUBLIC_SIGNUP_BONUS_USD` → default 0.

## Validation boundary

This PR remains focused on first-admin bootstrap / registration behavior. It does not claim to fix the separate authorization gaps tracked in #401. CI must compile and exercise the transaction path and integration surface before merge.