### PR TITLE
Polish Overview visual hierarchy and readiness states

### DIFF
--- a/crates/client/src/critical_pages/dashboard.rs
+++ b/crates/client/src/critical_pages/dashboard.rs
@@ -22,15 +22,15 @@ fn compact(n: i64) -> String {
     }
 }
 
-fn kpi(label: &str, value: String, note: String, icon: &'static str, tone: &'static str) -> Element {
+fn kpi(label: &str, value: String, note: String, icon: &'static str) -> Element {
     rsx! {
-        div { class: "card metric card-hover",
+        div { class: "card metric",
             div { class: "metric-copy",
                 span { class: "metric-label", "{label}" }
                 span { class: "metric-value", "{value}" }
                 span { class: "metric-note mono", "{note}" }
             }
-            div { class: "metric-icon {tone}", Icon { name: icon } }
+            div { class: "metric-icon tone-gray", Icon { name: icon } }
         }
     }
 }
@@ -93,9 +93,7 @@ fn SetupStep(
                 strong { "{title}" }
                 small { "{detail}" }
             }
-            if complete {
-                span { class: "badge badge-success", "Done" }
-            } else {
+            if !complete {
                 Link { class: "button button-ghost button-sm", to: to, "{action}" }
             }
         }
@@ -176,31 +174,56 @@ pub fn Overview() -> Element {
     let has_model = model_count > 0;
     let has_key = active_keys > 0;
     let has_request = !logs.is_empty();
+    let has_verified_request = logs.iter().any(|log| {
+        (200..300).contains(&log.status_code)
+            && log
+                .upstream_id
+                .as_deref()
+                .map(|id| !id.trim().is_empty())
+                .unwrap_or(false)
+    });
     let setup_complete = has_provider && has_model && has_key;
+    let traffic_verified = setup_complete && has_verified_request;
 
-    let (status_class, status_title, status_copy) = if has_errors {
+    let (status_class, status_badge_class, status_badge, status_title, status_copy) = if has_errors {
         (
             "product-status-card status-blocked",
+            "badge badge-error",
+            "ATTENTION",
             "Some system data is unavailable",
             "BurnCloud is reachable, but one or more operational data sources could not be loaded. Review the errors below before relying on this environment.",
         )
     } else if !setup_complete {
         (
             "product-status-card status-attention",
+            "badge badge-warning",
+            "SETUP REQUIRED",
             "Finish setup before sending production traffic",
-            "BurnCloud still needs one or more routing prerequisites. Complete the checklist to make a verified end-to-end request.",
+            "BurnCloud still needs one or more routing prerequisites. Complete the checklist before verifying the full traffic path.",
         )
     } else if down_channels > 0 {
         (
             "product-status-card status-attention",
+            "badge badge-warning",
+            "DEGRADED",
             "Traffic is available, but a provider needs attention",
             "At least one provider is inactive or down. Healthy providers can still serve traffic, but routing resilience may be reduced.",
+        )
+    } else if !traffic_verified {
+        (
+            "product-status-card status-configured",
+            "badge badge-neutral",
+            "CONFIGURED",
+            "BurnCloud is configured. Verify the traffic path",
+            "Providers, models and API access are configured. Send a controlled Playground request to verify routing end to end before treating this environment as operational.",
         )
     } else {
         (
             "product-status-card status-ready",
+            "badge badge-success",
+            "OPERATIONAL",
             "BurnCloud is ready to serve traffic",
-            "Providers, models and API access are configured. Use Playground for a controlled test or inspect recent request activity below.",
+            "A successful routed request has verified the configured provider, model and API access path. Continue with normal traffic or inspect recent activity below.",
         )
     };
 
@@ -222,13 +245,13 @@ pub fn Overview() -> Element {
 
     rsx! {
         div { class: "page",
-            div { class: "page-header",
+            div { class: "page-header overview-page-header",
                 div {
                     h2 { class: "page-title", "System Overview" }
                     p { class: "page-subtitle", "Know whether BurnCloud can serve traffic, what needs attention, and where to act next." }
                 }
                 button {
-                    class: "button button-secondary",
+                    class: "button button-ghost button-sm overview-refresh",
                     onclick: move |_| {
                         metrics_resource.restart();
                         channels_resource.restart();
@@ -245,9 +268,7 @@ pub fn Overview() -> Element {
             div { class: "product-hero",
                 div { class: "card {status_class}",
                     div { class: "row gap-2",
-                        span { class: if setup_complete && !has_errors && down_channels == 0 { "badge badge-success" } else { "badge badge-warning" },
-                            if setup_complete && !has_errors && down_channels == 0 { "READY" } else { "ATTENTION" }
-                        }
+                        span { class: "{status_badge_class}", "{status_badge}" }
                     }
                     div {
                         div { class: "product-status-title", "{status_title}" }
@@ -269,17 +290,17 @@ pub fn Overview() -> Element {
                     div { class: "product-section-head",
                         div {
                             h3 { "Setup & readiness" }
-                            p { "The minimum path to a working routed request." }
+                            p { "Configuration first, then verify one successful routed request." }
                         }
-                        span { class: if setup_complete { "badge badge-success" } else { "badge badge-neutral" },
-                            if setup_complete { "Ready" } else { "In progress" }
+                        span { class: if traffic_verified { "badge badge-success" } else { "badge badge-neutral" },
+                            if traffic_verified { "Verified" } else if setup_complete { "Configured" } else { "In progress" }
                         }
                     }
                     div { class: "setup-list",
                         SetupStep { complete: has_provider, title: "Provider connected", detail: format!("{} active providers", active_channels), to: Route::Providers {}, action: "Configure" }
                         SetupStep { complete: has_model, title: "Model available", detail: format!("{} unique models exposed", model_count), to: Route::Models {}, action: "Review" }
                         SetupStep { complete: has_key, title: "API access created", detail: format!("{} active API keys", active_keys), to: Route::APIKeys {}, action: "Create" }
-                        SetupStep { complete: has_request, title: "First request observed", detail: if has_request { "Traffic is visible in Logs".to_string() } else { "Send a request from Playground".to_string() }, to: Route::Playground {}, action: "Test" }
+                        SetupStep { complete: has_verified_request, title: "Verified request", detail: if has_verified_request { "Successful routed traffic is visible in Logs".to_string() } else { "Send a successful request from Playground".to_string() }, to: Route::Playground {}, action: "Test" }
                     }
                 }
             }
@@ -293,11 +314,11 @@ pub fn Overview() -> Element {
                 }
             }
 
-            div { class: "metrics",
-                {kpi("Requests", request_text, request_note, "activity", "tone-blue")}
-                {kpi("Tokens", token_text, usage_note, "models", "tone-purple")}
-                {kpi("Spend", spend_text, spend_note, "dollar", "tone-amber")}
-                {kpi("Active Providers", active_channels.to_string(), provider_note, "server", "tone-green")}
+            div { class: "metrics overview-metrics",
+                {kpi("Requests", request_text, request_note, "activity")}
+                {kpi("Tokens", token_text, usage_note, "models")}
+                {kpi("Spend", spend_text, spend_note, "dollar")}
+                {kpi("Active Providers", active_channels.to_string(), provider_note, "server")}
             }
 
             div { class: "grid-2",
@@ -343,7 +364,7 @@ pub fn Overview() -> Element {
                     }
                 }
 
-                div { class: "card card-pad stack",
+                div { class: "card card-pad stack latest-request-card",
                     div { class: "product-section-head",
                         div {
                             h3 { "Latest request" }
@@ -380,7 +401,7 @@ pub fn Overview() -> Element {
             }
 
             div { class: "grid-2",
-                div { class: "card card-pad stack",
+                div { class: "card card-pad stack overview-secondary",
                     div { class: "product-section-head",
                         div { h3 { "Runtime" } p { "Host resource pressure is secondary to traffic health, but useful for capacity diagnosis." } }
                         Link { class: "button button-ghost button-sm", to: Route::Settings {}, "System details" }

--- a/crates/client/src/functional_layout.rs
+++ b/crates/client/src/functional_layout.rs
@@ -6,27 +6,6 @@ use crate::{
     components::{Icon, Logo},
 };
 
-fn page_title(route: &Route) -> &'static str {
-    match route {
-        Route::Overview {} | Route::Dashboard {} => "Overview",
-        Route::Playground {} => "Playground",
-        Route::Routes {} => "Routes",
-        Route::Models {} => "Models",
-        Route::Providers {} => "Providers",
-        Route::APIKeys {} => "API Keys",
-        Route::Customers {} | Route::Users {} => "Customers",
-        Route::Guardrails {} => "Guardrails",
-        Route::Logs {} => "Logs",
-        Route::Evaluation {} => "Evaluation",
-        Route::Billing {} => "Billing",
-        Route::Team {} => "Team",
-        Route::Settings {} => "Settings",
-        Route::Home {} | Route::Landing {} => "Home",
-        Route::Login {} => "Sign In",
-        Route::Register {} => "Register",
-    }
-}
-
 fn search_route(query: &str) -> Option<Route> {
     let q = query.trim().to_ascii_lowercase();
     if q.is_empty() {
@@ -71,8 +50,6 @@ fn initials(name: &str) -> String {
 
 #[component]
 pub fn FunctionalConsoleLayout() -> Element {
-    let current = use_route::<Route>();
-    let title = page_title(&current);
     let auth = use_auth();
     let navigator = use_navigator();
     let search_navigator = navigator.clone();
@@ -136,7 +113,6 @@ pub fn FunctionalConsoleLayout() -> Element {
             }
             div { class:"console-main",
                 header { class:"topbar",
-                    h1 { class:"topbar-title", "{title}" }
                     div { class:"topbar-right",
                         div { class:"global-search", title: if search_status().is_empty() { "Jump to a console page" } else { "{search_status}" },
                             Icon { name:"search" }
@@ -163,10 +139,9 @@ pub fn FunctionalConsoleLayout() -> Element {
                             }
                         }
                         div { class:"top-actions",
-                            Link { to:Route::Home {}, class:"tiny-link", Icon { name:"globe" } span { "Landing Page" } }
-                            div { class:"env-chip", title:"BurnCloud server is configured; live health is shown on Overview", span { class:"green-dot" } "Server Configured" }
-                            Link { to:Route::Logs {}, class:"icon-button", title:"Open request logs", Icon { name:"bell" } }
-                            Link { to:Route::Settings {}, class:"icon-button", title:"System settings", Icon { name:"help" } }
+                            div { class:"env-chip", title:"BurnCloud server is configured; live health is shown on Overview", span { class:"neutral-dot" } "Server Configured" }
+                            Link { to:Route::Logs {}, class:"icon-button", title:"Open request activity", Icon { name:"activity" } }
+                            Link { to:Route::Settings {}, class:"icon-button", title:"System settings", Icon { name:"settings" } }
                             div { class:"top-divider" }
                             div { class:"profile-link",
                                 div { class:"avatar", "{avatar}" }

--- a/crates/client/src/product_ui.css
+++ b/crates/client/src/product_ui.css
@@ -256,6 +256,141 @@
   justify-content: flex-end;
 }
 
+/* BurnCloud visual baseline: status first, data second, decoration last. */
+:root {
+  --bc-brand: #e95513;
+  --bc-brand-soft: color-mix(in srgb, var(--bc-brand) 9%, #fff);
+  --bc-surface: #fff;
+  --bc-surface-subtle: #f6f7f8;
+  --bc-border: rgba(229, 231, 235, .82);
+  --bc-border-strong: rgba(209, 213, 219, .92);
+  --bc-radius-card: 16px;
+  --bc-radius-control: 10px;
+  --bc-shadow-floating: 0 18px 48px -18px rgba(17, 24, 39, .22);
+}
+
+.console-shell .card {
+  border-radius: var(--bc-radius-card);
+  border-color: var(--bc-border);
+  box-shadow: none;
+}
+
+.topbar {
+  justify-content: flex-end;
+}
+
+.topbar-right {
+  margin-left: auto;
+  gap: 20px;
+}
+
+.env-chip {
+  background: var(--bc-surface-subtle);
+  color: #6b7280;
+}
+
+.neutral-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #9ca3af;
+  flex: 0 0 auto;
+}
+
+.nav-item.active::before,
+.nav-item[aria-current="page"]::before {
+  content: "";
+  position: absolute;
+  left: 3px;
+  top: 9px;
+  bottom: 9px;
+  width: 2px;
+  border-radius: 999px;
+  background: var(--bc-brand);
+}
+
+.global-search input:focus {
+  border-color: color-mix(in srgb, var(--bc-brand) 24%, #d1d5db);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--bc-brand) 7%, transparent);
+}
+
+.button:focus-visible,
+.icon-button:focus-visible,
+.nav-item:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--bc-brand) 35%, transparent);
+  outline-offset: 2px;
+}
+
+.page {
+  animation-duration: .18s;
+  animation-timing-function: ease-out;
+}
+
+@keyframes page-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.product-status-card.status-ready,
+.product-status-card.status-configured,
+.product-status-card.status-attention,
+.product-status-card.status-blocked {
+  background: var(--bc-surface);
+  border-color: var(--bc-border-strong);
+}
+
+.product-status-card.status-ready {
+  box-shadow: inset 3px 0 0 #22c55e;
+}
+
+.product-status-card.status-configured {
+  box-shadow: inset 3px 0 0 var(--bc-brand);
+}
+
+.product-status-card.status-attention {
+  box-shadow: inset 3px 0 0 #f59e0b;
+}
+
+.product-status-card.status-blocked {
+  box-shadow: inset 3px 0 0 #ef4444;
+}
+
+.overview-page-header {
+  align-items: center;
+}
+
+.overview-refresh {
+  color: var(--muted);
+}
+
+.overview-metrics {
+  gap: 16px;
+}
+
+.overview-metrics .metric {
+  min-height: 96px;
+}
+
+.overview-metrics .metric-icon {
+  background: var(--bc-surface-subtle);
+  border-color: var(--bc-border);
+  color: #6b7280;
+}
+
+.overview-secondary {
+  background: color-mix(in srgb, var(--bc-surface-subtle) 55%, #fff);
+}
+
+.latest-request-card {
+  border-color: var(--bc-border-strong);
+}
+
 @media (max-width: 1100px) {
   .product-hero {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Goal

Establish the first BurnCloud UI polish baseline on top of the new product-oriented console without changing backend behavior or page responsibilities.

This pass follows the principle: **status first, data second, decoration last**.

## What changed

### Console chrome

- remove the duplicate page title from the global top bar; page headers remain the source of page identity
- keep **Server Configured** truthful but render it as a neutral configured state rather than a green health claim
- remove the duplicate Landing Page shortcut from the top bar (it remains under External in the sidebar)
- make top-bar icons match their real destinations: request activity for Logs and settings gear for Settings

### Overview readiness

- separate **Configured** from **Operational**
- Provider + Model + API Key now means the environment is configured
- Operational now additionally requires an observed successful routed request with an upstream
- add a clear CONFIGURED state that directs the operator to Playground for end-to-end verification
- keep degraded/error states higher priority than verification state
- simplify completed setup steps so the checkmark is the completion signal instead of duplicating it with a Done badge

### KPI hierarchy

- remove rainbow KPI tones from Overview
- remove hover elevation from non-interactive KPI cards
- keep metrics visually neutral so color is reserved for operational state

### BurnCloud visual baseline

- introduce a small set of BurnCloud visual tokens for brand, surfaces, borders, radius and floating shadow
- reduce console card radius to a tighter 16px baseline and remove default card shadows
- use a restrained BurnCloud orange marker on active navigation/focus states rather than turning primary actions orange
- reduce page entrance motion from 12px / 450ms to 3px / 180ms
- restyle Overview status cards as neutral surfaces with a single semantic edge indicator
- demote Runtime visually and give Latest Request slightly stronger emphasis

## Scope

Only these files are changed:

- `crates/client/src/functional_layout.rs`
- `crates/client/src/critical_pages/dashboard.rs`
- `crates/client/src/product_ui.css`

No backend API, routing, billing, security, or persistence behavior is changed.

## Validation

- branch is based directly on current `main` and is ahead by three focused commits with no unrelated files
- existing product UX contract strings and navigation ordering from #396 are preserved, including `Server Configured`, setup/readiness guidance, and required Overview CTAs
- local `gh`/network execution is unavailable in the current execution environment, so compile/UI acceptance is intentionally left to repository CI on this draft PR

## Review focus

Please review the distinction between **Configured** and **Operational**, the reduced use of decorative color, and whether this visual baseline should become the default for the remaining console pages.