### PR TITLE
Establish Phase 2 visual system

### DIFF
--- a/.github/workflows/client-ui.yml
+++ b/.github/workflows/client-ui.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Check product UX contracts
         run: bash scripts/check-product-ux.sh
 
+      - name: Check visual system contracts
+        run: bash scripts/check-visual-system.sh
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/crates/client/scripts/check-visual-system.sh
+++ b/crates/client/scripts/check-visual-system.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+VISUAL="src/visual_system.css"
+APP="src/app.rs"
+
+require() {
+  local needle="$1"
+  local file="$2"
+  if ! grep -Fq -- "$needle" "$file"; then
+    echo "Missing visual-system contract: '$needle' in $file" >&2
+    exit 1
+  fi
+}
+
+[[ -f "$VISUAL" ]] || {
+  echo "Missing canonical visual system: $VISUAL" >&2
+  exit 1
+}
+
+# The canonical layer must remain last so semantic decisions win over legacy/page CSS.
+last_style=$(grep 'include_str!(".*\.css")' "$APP" | tail -n1)
+if [[ "$last_style" != *'include_str!("visual_system.css")'* ]]; then
+  echo "visual_system.css must be the final CSS layer loaded by app.rs" >&2
+  exit 1
+fi
+
+# Token families required by the Phase 2 visual system.
+for token in \
+  '--bc-color-canvas' \
+  '--bc-color-surface' \
+  '--bc-color-text-primary' \
+  '--bc-color-text-secondary' \
+  '--bc-color-border' \
+  '--bc-color-brand' \
+  '--bc-color-success' \
+  '--bc-color-warning' \
+  '--bc-color-danger' \
+  '--bc-space-4' \
+  '--bc-radius-md' \
+  '--bc-shadow-card' \
+  '--bc-control-md' \
+  '--bc-content-max' \
+  '--bc-motion-fast'; do
+  require "$token" "$VISUAL"
+done
+
+# Existing product CSS consumes these aliases; removing them causes visual drift.
+for alias in '--canvas:' '--text:' '--muted:' '--border:' '--panel:' '--surface-subtle:' '--shadow-card:'; do
+  require "$alias" "$VISUAL"
+done
+
+# Accessibility and interaction behavior are part of the visual system, not optional polish.
+require ':focus-visible' "$VISUAL"
+require '@media (prefers-reduced-motion: reduce)' "$VISUAL"
+require '.button-primary' "$VISUAL"
+require '.input:focus' "$VISUAL"
+require '.badge-success' "$VISUAL"
+require '.product-status-card.status-ready' "$VISUAL"
+require '.danger-zone' "$VISUAL"
+
+# Keep raw palette choices centralized. New page-level visual CSS should consume semantic tokens.
+if grep -En -- '#[0-9A-Fa-f]{3,8}' src/product_ui.css >/dev/null; then
+  echo "product_ui.css still contains raw color literals; consume semantic visual-system tokens instead" >&2
+  exit 1
+fi
+
+echo "Visual system contracts OK"

--- a/crates/client/src/app.rs
+++ b/crates/client/src/app.rs
@@ -85,6 +85,7 @@ pub fn App() -> Element {
             style { dangerous_inner_html: include_str!("critical_pages.css") }
             style { dangerous_inner_html: include_str!("product_ui.css") }
             style { dangerous_inner_html: include_str!("desktop_chrome.css") }
+            style { dangerous_inner_html: include_str!("visual_system.css") }
         }
         DesktopChrome {}
         Router::<Route> {}

--- a/crates/client/src/critical_pages/dashboard.rs
+++ b/crates/client/src/critical_pages/dashboard.rs
@@ -176,7 +176,9 @@ pub fn Overview() -> Element {
     let has_model = model_count > 0;
     let has_key = active_keys > 0;
     let has_request = !logs.is_empty();
-    let setup_complete = has_provider && has_model && has_key;
+    let has_successful_request = logs.iter().any(|log| (200..300).contains(&log.status_code));
+    let routing_configured = has_provider && has_model && has_key;
+    let setup_complete = routing_configured && has_successful_request;
 
     let (status_class, status_title, status_copy) = if has_errors {
         (
@@ -184,11 +186,21 @@ pub fn Overview() -> Element {
             "Some system data is unavailable",
             "BurnCloud is reachable, but one or more operational data sources could not be loaded. Review the errors below before relying on this environment.",
         )
-    } else if !setup_complete {
+    } else if !routing_configured {
         (
             "product-status-card status-attention",
             "Finish setup before sending production traffic",
-            "BurnCloud still needs one or more routing prerequisites. Complete the checklist to make a verified end-to-end request.",
+            "BurnCloud still needs one or more routing prerequisites. Complete the checklist before attempting a production request.",
+        )
+    } else if !has_successful_request {
+        (
+            "product-status-card status-attention",
+            "Verify a successful routed request",
+            if has_request {
+                "Requests are reaching BurnCloud, but no HTTP 2xx response is visible yet. Use Playground and Logs to verify the route before production traffic."
+            } else {
+                "Routing is configured, but no successful request has been observed yet. Run a controlled Playground request before production traffic."
+            },
         )
     } else if down_channels > 0 {
         (
@@ -200,7 +212,7 @@ pub fn Overview() -> Element {
         (
             "product-status-card status-ready",
             "BurnCloud is ready to serve traffic",
-            "Providers, models and API access are configured. Use Playground for a controlled test or inspect recent request activity below.",
+            "Providers, models and API access are configured, and a successful routed request has been observed. Inspect recent request activity below or run another controlled test in Playground.",
         )
     };
 
@@ -210,7 +222,7 @@ pub fn Overview() -> Element {
     let has_latest = latest.is_some();
     let request_text = compact(total_requests);
     let token_text = compact(usage.total_tokens);
-    let spend_text = format!("${:.4}", billing.total_cost_usd);
+    let spend_text = format!("${:.2}", billing.total_cost_usd);
     let provider_note = format!("{} total • {} need attention", channels.len(), down_channels);
     let request_note = if has_request { "Billing period activity".to_string() } else { "No requests observed yet".to_string() };
     let usage_note = format!("{} prompt • {} completion", compact(usage.prompt_tokens), compact(usage.completion_tokens));
@@ -269,7 +281,7 @@ pub fn Overview() -> Element {
                     div { class: "product-section-head",
                         div {
                             h3 { "Setup & readiness" }
-                            p { "The minimum path to a working routed request." }
+                            p { "The minimum path to a verified routed request." }
                         }
                         span { class: if setup_complete { "badge badge-success" } else { "badge badge-neutral" },
                             if setup_complete { "Ready" } else { "In progress" }
@@ -279,7 +291,19 @@ pub fn Overview() -> Element {
                         SetupStep { complete: has_provider, title: "Provider connected", detail: format!("{} active providers", active_channels), to: Route::Providers {}, action: "Configure" }
                         SetupStep { complete: has_model, title: "Model available", detail: format!("{} unique models exposed", model_count), to: Route::Models {}, action: "Review" }
                         SetupStep { complete: has_key, title: "API access created", detail: format!("{} active API keys", active_keys), to: Route::APIKeys {}, action: "Create" }
-                        SetupStep { complete: has_request, title: "First request observed", detail: if has_request { "Traffic is visible in Logs".to_string() } else { "Send a request from Playground".to_string() }, to: Route::Playground {}, action: "Test" }
+                        SetupStep {
+                            complete: has_successful_request,
+                            title: "Successful request observed",
+                            detail: if has_successful_request {
+                                "HTTP 2xx traffic is visible in Logs".to_string()
+                            } else if has_request {
+                                "Requests exist, but no successful response is visible yet".to_string()
+                            } else {
+                                "Send a test from Playground".to_string()
+                            },
+                            to: Route::Playground {},
+                            action: "Test"
+                        }
                     }
                 }
             }

--- a/crates/client/src/product_ui.css
+++ b/crates/client/src/product_ui.css
@@ -13,18 +13,18 @@
 }
 
 .product-status-card.status-ready {
-  border-color: color-mix(in srgb, #22c55e 30%, var(--border));
-  background: linear-gradient(135deg, color-mix(in srgb, #22c55e 7%, var(--panel)), var(--panel));
+  border-color: var(--bc-color-success-border);
+  background: linear-gradient(135deg, var(--bc-color-success-soft), var(--panel));
 }
 
 .product-status-card.status-attention {
-  border-color: color-mix(in srgb, #f59e0b 34%, var(--border));
-  background: linear-gradient(135deg, color-mix(in srgb, #f59e0b 8%, var(--panel)), var(--panel));
+  border-color: var(--bc-color-warning-border);
+  background: linear-gradient(135deg, var(--bc-color-warning-soft), var(--panel));
 }
 
 .product-status-card.status-blocked {
-  border-color: color-mix(in srgb, #ef4444 30%, var(--border));
-  background: linear-gradient(135deg, color-mix(in srgb, #ef4444 7%, var(--panel)), var(--panel));
+  border-color: var(--bc-color-danger-border);
+  background: linear-gradient(135deg, var(--bc-color-danger-soft), var(--panel));
 }
 
 .product-status-title {
@@ -84,9 +84,9 @@
 }
 
 .setup-step.complete .setup-step-dot {
-  background: color-mix(in srgb, #22c55e 15%, var(--panel));
-  color: #22c55e;
-  border-color: color-mix(in srgb, #22c55e 40%, var(--border));
+  background: var(--bc-color-success-soft);
+  color: var(--bc-color-success);
+  border-color: var(--bc-color-success-border);
 }
 
 .setup-step strong {
@@ -140,7 +140,7 @@
   border-radius: 14px;
   display: grid;
   place-items: center;
-  background: var(--surface-subtle, rgba(127,127,127,.08));
+  background: var(--surface-subtle);
 }
 
 .product-empty h3 {
@@ -167,7 +167,7 @@
   place-items: center;
   font-weight: 800;
   font-size: 12px;
-  background: var(--surface-subtle, rgba(127,127,127,.08));
+  background: var(--surface-subtle);
   border: 1px solid var(--border);
   flex: 0 0 auto;
 }
@@ -204,8 +204,8 @@
 }
 
 .danger-zone {
-  border-color: color-mix(in srgb, #ef4444 30%, var(--border));
-  background: color-mix(in srgb, #ef4444 5%, var(--panel));
+  border-color: var(--bc-color-danger-border);
+  background: var(--bc-color-danger-soft);
 }
 
 .readiness-strip {
@@ -219,31 +219,31 @@
 }
 
 .readiness-strip.ready {
-  border-color: color-mix(in srgb, #22c55e 32%, var(--border));
-  background: color-mix(in srgb, #22c55e 7%, var(--panel));
+  border-color: var(--bc-color-success-border);
+  background: var(--bc-color-success-soft);
 }
 
 .readiness-strip.blocked {
-  border-color: color-mix(in srgb, #f59e0b 34%, var(--border));
-  background: color-mix(in srgb, #f59e0b 7%, var(--panel));
+  border-color: var(--bc-color-warning-border);
+  background: var(--bc-color-warning-soft);
 }
 
 .readiness-dot {
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  background: #f59e0b;
+  background: var(--bc-color-warning);
   flex: 0 0 auto;
 }
 
 .readiness-strip.ready .readiness-dot {
-  background: #22c55e;
+  background: var(--bc-color-success);
 }
 
 .product-note {
   padding: 12px 14px;
   border-radius: 10px;
-  background: var(--surface-subtle, rgba(127,127,127,.06));
+  background: var(--surface-subtle);
   color: var(--muted);
   font-size: 12px;
   line-height: 1.55;

--- a/crates/client/src/product_ui.css
+++ b/crates/client/src/product_ui.css
@@ -1,8 +1,8 @@
 .product-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(300px, .8fr);
+  grid-template-columns: minmax(0, 1.3fr) minmax(380px, .95fr);
   gap: 18px;
-  align-items: stretch;
+  align-items: start;
 }
 
 .product-status-card {
@@ -51,19 +51,25 @@
 }
 
 .setup-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 16px;
+  row-gap: 0;
   margin-top: 8px;
 }
 
 .setup-step {
   display: grid;
-  grid-template-columns: 26px minmax(0, 1fr) auto;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
   gap: 10px;
   align-items: center;
+  min-width: 0;
   padding: 10px 0;
   border-bottom: 1px solid var(--border);
+}
+
+.setup-step:nth-last-child(-n + 2) {
+  border-bottom: 0;
 }
 
 .setup-step:last-child {
@@ -96,8 +102,12 @@
 
 .setup-step small {
   display: block;
+  min-width: 0;
+  overflow: hidden;
   color: var(--muted);
   margin-top: 2px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .product-section-head {
@@ -259,5 +269,21 @@
 @media (max-width: 1100px) {
   .product-hero {
     grid-template-columns: 1fr;
+  }
+
+  .setup-list {
+    grid-template-columns: 1fr;
+  }
+
+  .setup-step:nth-last-child(-n + 2) {
+    border-bottom: 1px solid var(--border);
+  }
+
+  .setup-step:last-child {
+    border-bottom: 0;
+  }
+
+  .setup-step small {
+    white-space: normal;
   }
 }

--- a/crates/client/src/visual_system.css
+++ b/crates/client/src/visual_system.css
@@ -1,0 +1,620 @@
+/* BurnCloud Phase 2 visual system.
+ *
+ * This file is intentionally loaded after legacy/page CSS. It is the canonical
+ * semantic visual layer for the current Dioxus console. New visual decisions
+ * should be expressed as tokens here before being consumed by page styles.
+ */
+
+:root {
+  color-scheme: light;
+
+  /* Typography */
+  --bc-font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bc-font-display: "Space Grotesk", Inter, ui-sans-serif, system-ui, sans-serif;
+  --bc-font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* Neutral surfaces */
+  --bc-color-canvas: #f7f8fa;
+  --bc-color-surface: #ffffff;
+  --bc-color-surface-subtle: #f2f4f7;
+  --bc-color-surface-muted: #eaedf1;
+  --bc-color-surface-raised: #ffffff;
+
+  /* Text */
+  --bc-color-text-primary: #111318;
+  --bc-color-text-secondary: #5d6673;
+  --bc-color-text-tertiary: #8b94a1;
+  --bc-color-text-inverse: #ffffff;
+
+  /* Borders */
+  --bc-color-border: #e3e7ed;
+  --bc-color-border-soft: #edf0f4;
+  --bc-color-border-strong: #d3d8e0;
+
+  /* Brand / interaction */
+  --bc-color-brand: #151922;
+  --bc-color-brand-hover: #272e3a;
+  --bc-color-brand-active: #0d1016;
+  --bc-color-focus: #4f6b95;
+  --bc-color-info: #3568b8;
+  --bc-color-info-soft: #edf4ff;
+
+  /* Semantic state */
+  --bc-color-success: #1f8a55;
+  --bc-color-success-soft: #eef9f3;
+  --bc-color-success-border: #ccebd9;
+  --bc-color-warning: #a96913;
+  --bc-color-warning-soft: #fff7e8;
+  --bc-color-warning-border: #f0d6aa;
+  --bc-color-danger: #c43b3b;
+  --bc-color-danger-soft: #fff1f1;
+  --bc-color-danger-border: #f1caca;
+
+  /* Spacing: 4px base rhythm */
+  --bc-space-1: 4px;
+  --bc-space-2: 8px;
+  --bc-space-3: 12px;
+  --bc-space-4: 16px;
+  --bc-space-5: 20px;
+  --bc-space-6: 24px;
+  --bc-space-7: 28px;
+  --bc-space-8: 32px;
+  --bc-space-10: 40px;
+  --bc-space-12: 48px;
+
+  /* Shape */
+  --bc-radius-xs: 6px;
+  --bc-radius-sm: 8px;
+  --bc-radius-md: 10px;
+  --bc-radius-lg: 14px;
+  --bc-radius-xl: 16px;
+  --bc-radius-pill: 999px;
+
+  /* Elevation */
+  --bc-shadow-card: 0 1px 2px rgba(17, 19, 24, .025), 0 8px 24px rgba(17, 19, 24, .025);
+  --bc-shadow-card-hover: 0 1px 3px rgba(17, 19, 24, .04), 0 12px 32px rgba(17, 19, 24, .05);
+  --bc-shadow-popover: 0 18px 50px rgba(17, 19, 24, .12);
+
+  /* Controls / layout */
+  --bc-control-sm: 32px;
+  --bc-control-md: 36px;
+  --bc-control-lg: 40px;
+  --bc-sidebar-width: 240px;
+  --bc-topbar-height: 64px;
+  --bc-content-max: 1240px;
+
+  /* Motion */
+  --bc-motion-fast: 120ms;
+  --bc-motion-normal: 180ms;
+  --bc-ease-standard: cubic-bezier(.2, .8, .2, 1);
+
+  /* Compatibility aliases used by current page CSS. */
+  --canvas: var(--bc-color-canvas);
+  --text: var(--bc-color-text-primary);
+  --muted: var(--bc-color-text-secondary);
+  --muted-2: var(--bc-color-text-tertiary);
+  --border: var(--bc-color-border);
+  --border-soft: var(--bc-color-border-soft);
+  --white: var(--bc-color-surface);
+  --panel: var(--bc-color-surface);
+  --surface-subtle: var(--bc-color-surface-subtle);
+  --shadow-card: var(--bc-shadow-card);
+}
+
+html,
+body,
+#main {
+  background: var(--bc-color-canvas);
+}
+
+body {
+  color: var(--bc-color-text-primary);
+  font-family: var(--bc-font-sans);
+}
+
+.font-display,
+.brand-name,
+.topbar-title {
+  font-family: var(--bc-font-display);
+}
+
+.font-mono,
+.mono,
+.terminal {
+  font-family: var(--bc-font-mono);
+}
+
+:where(a, button, input, textarea, select, [tabindex]):focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--bc-color-focus) 66%, transparent);
+  outline-offset: 2px;
+}
+
+::selection {
+  background: color-mix(in srgb, var(--bc-color-info) 18%, white);
+  color: var(--bc-color-text-primary);
+}
+
+/* Console frame */
+.console-shell {
+  background: var(--bc-color-canvas);
+}
+
+.sidebar {
+  width: var(--bc-sidebar-width);
+  flex-basis: var(--bc-sidebar-width);
+  border-right-color: var(--bc-color-border);
+  background: var(--bc-color-canvas);
+}
+
+.sidebar-brand {
+  height: var(--bc-topbar-height);
+  padding-inline: var(--bc-space-6);
+}
+
+.sidebar-nav {
+  padding: var(--bc-space-2) var(--bc-space-3) var(--bc-space-6);
+}
+
+.nav-group {
+  margin-bottom: var(--bc-space-5);
+}
+
+.nav-group-title {
+  margin-bottom: var(--bc-space-1);
+  color: var(--bc-color-text-tertiary);
+}
+
+.nav-item {
+  gap: var(--bc-space-3);
+  padding: 8px 12px;
+  border: 1px solid transparent;
+  border-radius: var(--bc-radius-sm);
+  color: var(--bc-color-text-secondary);
+  transition: background var(--bc-motion-fast) var(--bc-ease-standard), color var(--bc-motion-fast) var(--bc-ease-standard), border-color var(--bc-motion-fast) var(--bc-ease-standard);
+}
+
+.nav-item:hover {
+  color: var(--bc-color-text-primary);
+  background: color-mix(in srgb, var(--bc-color-surface) 70%, transparent);
+}
+
+.nav-item.active,
+.nav-item[aria-current="page"] {
+  color: var(--bc-color-text-primary);
+  background: var(--bc-color-surface);
+  border-color: var(--bc-color-border-soft);
+  box-shadow: 0 1px 2px rgba(17, 19, 24, .035);
+}
+
+.nav-icon {
+  color: var(--bc-color-text-tertiary);
+}
+
+.topbar {
+  height: var(--bc-topbar-height);
+  flex-basis: var(--bc-topbar-height);
+  padding-inline: var(--bc-space-8);
+  border-bottom-color: var(--bc-color-border-soft);
+  background: color-mix(in srgb, var(--bc-color-surface) 88%, transparent);
+  backdrop-filter: blur(16px) saturate(130%);
+}
+
+.topbar-title {
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.topbar-right {
+  gap: var(--bc-space-6);
+}
+
+.global-search input {
+  height: var(--bc-control-md);
+  border-color: transparent;
+  border-radius: var(--bc-radius-md);
+  background: var(--bc-color-surface-subtle);
+  color: var(--bc-color-text-primary);
+}
+
+.global-search input:hover {
+  background: var(--bc-color-surface-muted);
+}
+
+.global-search input:focus {
+  border-color: var(--bc-color-border-strong);
+  background: var(--bc-color-surface);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--bc-color-focus) 10%, transparent);
+}
+
+.tiny-link,
+.env-chip {
+  border-radius: var(--bc-radius-sm);
+  background: var(--bc-color-surface-subtle);
+  color: var(--bc-color-text-secondary);
+}
+
+.tiny-link:hover,
+.env-chip:hover {
+  background: var(--bc-color-surface-muted);
+}
+
+.icon-button {
+  border-radius: var(--bc-radius-sm);
+  color: var(--bc-color-text-tertiary);
+}
+
+.icon-button:hover {
+  background: var(--bc-color-surface-subtle);
+  color: var(--bc-color-text-secondary);
+}
+
+.top-divider {
+  background: var(--bc-color-border);
+}
+
+.avatar {
+  background: linear-gradient(145deg, #303744, #141820);
+  box-shadow: 0 1px 2px rgba(17, 19, 24, .12);
+}
+
+.content-scroll {
+  padding: var(--bc-space-8) clamp(24px, 3vw, 40px) var(--bc-space-12);
+}
+
+.page {
+  max-width: var(--bc-content-max);
+  gap: var(--bc-space-6);
+}
+
+.page-header {
+  gap: var(--bc-space-5);
+}
+
+.page-title {
+  font-size: 24px;
+  line-height: 1.2;
+  font-weight: 650;
+  letter-spacing: -.025em;
+}
+
+.page-subtitle {
+  max-width: 760px;
+  margin-top: var(--bc-space-2);
+  color: var(--bc-color-text-secondary);
+  line-height: 1.55;
+}
+
+/* Foundational components */
+.card {
+  border-color: var(--bc-color-border-soft);
+  border-radius: var(--bc-radius-xl);
+  background: var(--bc-color-surface);
+  box-shadow: var(--bc-shadow-card);
+}
+
+.card-hover {
+  transition: border-color var(--bc-motion-normal) var(--bc-ease-standard), box-shadow var(--bc-motion-normal) var(--bc-ease-standard), transform var(--bc-motion-normal) var(--bc-ease-standard);
+}
+
+.card-hover:hover {
+  border-color: var(--bc-color-border);
+  box-shadow: var(--bc-shadow-card-hover);
+  transform: translateY(-1px);
+}
+
+.card-pad {
+  padding: var(--bc-space-5);
+}
+
+.card-pad-lg {
+  padding: var(--bc-space-6);
+}
+
+.button {
+  min-height: var(--bc-control-md);
+  border-radius: var(--bc-radius-md);
+  padding-inline: var(--bc-space-4);
+  font-weight: 550;
+  transition: background var(--bc-motion-fast) var(--bc-ease-standard), border-color var(--bc-motion-fast) var(--bc-ease-standard), box-shadow var(--bc-motion-fast) var(--bc-ease-standard), color var(--bc-motion-fast) var(--bc-ease-standard), transform var(--bc-motion-fast) var(--bc-ease-standard);
+}
+
+.button:hover {
+  transform: none;
+}
+
+.button:active {
+  transform: translateY(1px);
+}
+
+.button-primary {
+  color: var(--bc-color-text-inverse);
+  background: var(--bc-color-brand);
+  box-shadow: 0 1px 2px rgba(17, 19, 24, .15);
+}
+
+.button-primary:hover {
+  background: var(--bc-color-brand-hover);
+}
+
+.button-primary:active {
+  background: var(--bc-color-brand-active);
+}
+
+.button-secondary {
+  color: var(--bc-color-text-primary);
+  background: var(--bc-color-surface);
+  border: 1px solid var(--bc-color-border);
+  box-shadow: 0 1px 2px rgba(17, 19, 24, .025);
+}
+
+.button-secondary:hover {
+  border-color: var(--bc-color-border-strong);
+  background: var(--bc-color-surface-subtle);
+}
+
+.button-ghost {
+  color: var(--bc-color-text-secondary);
+  background: transparent;
+}
+
+.button-ghost:hover {
+  color: var(--bc-color-text-primary);
+  background: var(--bc-color-surface-subtle);
+}
+
+.button-danger {
+  color: var(--bc-color-danger);
+  background: var(--bc-color-danger-soft);
+  border: 1px solid var(--bc-color-danger-border);
+}
+
+.button-sm {
+  min-height: var(--bc-control-sm);
+  border-radius: var(--bc-radius-sm);
+  padding-inline: var(--bc-space-3);
+}
+
+.button-lg {
+  min-height: 44px;
+  border-radius: var(--bc-radius-lg);
+  padding-inline: var(--bc-space-6);
+}
+
+.input,
+.select,
+.textarea,
+.select-wrap {
+  border-color: var(--bc-color-border);
+  border-radius: var(--bc-radius-md);
+  background: var(--bc-color-surface);
+  box-shadow: 0 1px 2px rgba(17, 19, 24, .02);
+}
+
+.input,
+.select,
+.select-wrap {
+  min-height: var(--bc-control-lg);
+}
+
+.input:hover,
+.select:hover,
+.textarea:hover,
+.select-wrap:hover {
+  border-color: var(--bc-color-border-strong);
+}
+
+.input:focus,
+.select:focus,
+.textarea:focus {
+  border-color: color-mix(in srgb, var(--bc-color-focus) 46%, var(--bc-color-border));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--bc-color-focus) 10%, transparent);
+}
+
+.badge {
+  border-radius: var(--bc-radius-pill);
+  font-weight: 600;
+}
+
+.badge-neutral {
+  background: var(--bc-color-surface-subtle);
+  color: var(--bc-color-text-secondary);
+  border-color: var(--bc-color-border-soft);
+}
+
+.badge-success {
+  background: var(--bc-color-success-soft);
+  color: var(--bc-color-success);
+  border-color: var(--bc-color-success-border);
+}
+
+.badge-warning {
+  background: var(--bc-color-warning-soft);
+  color: var(--bc-color-warning);
+  border-color: var(--bc-color-warning-border);
+}
+
+.badge-error {
+  background: var(--bc-color-danger-soft);
+  color: var(--bc-color-danger);
+  border-color: var(--bc-color-danger-border);
+}
+
+.badge-brand {
+  background: var(--bc-color-info-soft);
+  color: var(--bc-color-info);
+  border-color: color-mix(in srgb, var(--bc-color-info) 22%, white);
+}
+
+.data-table thead {
+  color: var(--bc-color-text-secondary);
+  border-bottom-color: var(--bc-color-border-soft);
+}
+
+.data-table th {
+  padding: 13px var(--bc-space-6);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.data-table td {
+  padding: 14px var(--bc-space-6);
+  border-top-color: var(--bc-color-border-soft);
+}
+
+.data-table tbody tr:hover {
+  background: color-mix(in srgb, var(--bc-color-surface-subtle) 72%, transparent);
+}
+
+.metric {
+  min-height: 100px;
+  padding: var(--bc-space-5);
+}
+
+.metric-label {
+  color: var(--bc-color-text-tertiary);
+}
+
+.metric-value {
+  color: var(--bc-color-text-primary);
+  font-size: 23px;
+}
+
+.metric-note {
+  color: var(--bc-color-text-tertiary);
+}
+
+/* Product conclusion / readiness primitives */
+.product-hero {
+  gap: var(--bc-space-5);
+}
+
+.product-status-card {
+  padding: var(--bc-space-6);
+  gap: var(--bc-space-4);
+  box-shadow: var(--bc-shadow-card);
+}
+
+.product-status-card.status-ready {
+  border-color: var(--bc-color-success-border);
+  background: linear-gradient(135deg, var(--bc-color-success-soft), var(--bc-color-surface) 64%);
+}
+
+.product-status-card.status-attention {
+  border-color: var(--bc-color-warning-border);
+  background: linear-gradient(135deg, var(--bc-color-warning-soft), var(--bc-color-surface) 64%);
+}
+
+.product-status-card.status-blocked {
+  border-color: var(--bc-color-danger-border);
+  background: linear-gradient(135deg, var(--bc-color-danger-soft), var(--bc-color-surface) 64%);
+}
+
+.product-status-title {
+  color: var(--bc-color-text-primary);
+  font-size: 21px;
+  font-weight: 680;
+}
+
+.product-status-copy {
+  color: var(--bc-color-text-secondary);
+}
+
+.setup-card {
+  padding: var(--bc-space-5);
+}
+
+.setup-step {
+  gap: var(--bc-space-3);
+  padding-block: 11px;
+  border-bottom-color: var(--bc-color-border-soft);
+}
+
+.setup-step-dot {
+  border-color: var(--bc-color-border);
+  background: var(--bc-color-surface);
+  color: var(--bc-color-text-tertiary);
+}
+
+.setup-step.complete .setup-step-dot {
+  border-color: var(--bc-color-success-border);
+  background: var(--bc-color-success-soft);
+  color: var(--bc-color-success);
+}
+
+.product-section-head p,
+.product-empty p,
+.form-section-head small,
+.product-note {
+  color: var(--bc-color-text-secondary);
+}
+
+.product-empty-icon,
+.product-note {
+  background: var(--bc-color-surface-subtle);
+}
+
+.form-section {
+  border-color: var(--bc-color-border);
+  border-radius: var(--bc-radius-lg);
+  background: var(--bc-color-surface);
+}
+
+.danger-zone {
+  border-color: var(--bc-color-danger-border);
+  background: var(--bc-color-danger-soft);
+}
+
+.readiness-strip {
+  border-color: var(--bc-color-border);
+  border-radius: var(--bc-radius-md);
+}
+
+.readiness-strip.ready {
+  border-color: var(--bc-color-success-border);
+  background: var(--bc-color-success-soft);
+}
+
+.readiness-strip.blocked {
+  border-color: var(--bc-color-warning-border);
+  background: var(--bc-color-warning-soft);
+}
+
+.readiness-dot {
+  background: var(--bc-color-warning);
+}
+
+.readiness-strip.ready .readiness-dot {
+  background: var(--bc-color-success);
+}
+
+.success { color: var(--bc-color-success); }
+.warning { color: var(--bc-color-warning); }
+.danger { color: var(--bc-color-danger); }
+.brand { color: var(--bc-color-info); }
+.muted { color: var(--bc-color-text-secondary); }
+.subtle { color: var(--bc-color-text-tertiary); }
+
+@media (max-width: 1100px) {
+  .content-scroll {
+    padding: var(--bc-space-6);
+  }
+
+  .topbar {
+    padding-inline: var(--bc-space-6);
+  }
+
+  .metrics {
+    gap: var(--bc-space-4);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important;
+  }
+}

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -3,26 +3,30 @@ doc_id: ui.index
 doc_type: engineering-standard
 truth: source-derived
 status: active
-audited_against: c7107382b8479deb44f992e9e5ae8dcac5efb417
+audited_against: 74ee1d6212f4ab796838bbd824885a3095b7bfb9
 ---
 
-# UI Standards — Gate-Aligned Index
+# UI Standards — Current Console Index
 
-These files are intentionally retained because current UI/loop tooling references `docs/ui/*` paths in diagnostics and acceptance guidance.
+These documents describe the rebuilt Dioxus console that is currently routed from `crates/client/src/app.rs`.
 
-They are not a design manifesto. They document only rules that are visible in current source/gates.
+- [`tokens.md`](tokens.md) — canonical semantic visual-system ownership and token rules.
+- [`system.md`](system.md) — current Dioxus console/CSS architecture and cascade contract.
+- [`pages.md`](pages.md) — page polish and verification protocol.
+- [`components.md`](components.md) — retained component conventions enforced by executable gates.
+- [`naming.md`](naming.md) — retained CSS naming rules enforced by executable gates.
 
-- [`components.md`](components.md) — component conventions enforced by `ui_conventions` gate.
-- [`naming.md`](naming.md) — class-name rules enforced by `css_naming` gate.
-- [`tokens.md`](tokens.md) — where current CSS token truth lives.
-- [`system.md`](system.md) — current Dioxus/UI enforcement shape.
-- [`pages.md`](pages.md) — page-change verification guidance.
+Primary executable sources for the current console:
 
-Primary executable sources:
+- `crates/client/src/visual_system.css`
+- `crates/client/src/app.rs`
+- `crates/client/src/functional_layout.rs`
+- `crates/client/src/critical_pages/`
+- `crates/client/src/functional_pages/`
+- `crates/client/scripts/check-ui-conventions.sh`
+- `crates/client/scripts/check-functional-wiring.sh`
+- `crates/client/scripts/check-product-ux.sh`
+- `crates/client/scripts/check-visual-system.sh`
+- `.github/workflows/client-ui.yml`
 
-- `crates/loops/src/gates/ui_conventions.rs`
-- `crates/loops/src/gates/css_naming.rs`
-- `crates/client/crates/client-shared/src/styles/`
-- `crates/tests/tests/e2e/`
-
-If this documentation conflicts with an executable gate, the gate wins and the doc must be updated.
+If documentation conflicts with the current routed source or an executable gate, source/gates win and the documentation must be corrected in the same change.

--- a/docs/ui/pages.md
+++ b/docs/ui/pages.md
@@ -3,17 +3,28 @@ doc_id: ui.pages
 doc_type: verification-guide
 truth: source-derived
 status: active
-audited_against: c7107382b8479deb44f992e9e5ae8dcac5efb417
+audited_against: 74ee1d6212f4ab796838bbd824885a3095b7bfb9
 ---
 
 # UI Page Change Protocol
 
-For a Console/client page change:
+For a current Console/client page change:
 
-1. locate the owning feature crate under `crates/client/crates/` or page under `crates/client/src/`;
-2. inspect shared components/styles before introducing new UI primitives;
-3. satisfy `ui_conventions` and `css_naming` gates;
-4. run the affected client crate checks;
-5. inspect/run relevant E2E coverage such as `console_pages.rs`, `css_visual_acceptance.rs`, `aesthetic_acceptance.rs`, or the specific user-flow test.
+1. locate the routed page under `crates/client/src/critical_pages/` or `crates/client/src/functional_pages/`;
+2. inspect `src/visual_system.css`, shared components and existing structural selectors before introducing a new visual primitive;
+3. keep product decisions in the page and visual decisions in semantic `--bc-*` tokens/foundational rules;
+4. avoid raw palette literals in page/product CSS; add or reuse a semantic token instead;
+5. preserve explicit loading, empty, ready, warning, error and dangerous-operation states where the workflow supports them;
+6. run `scripts/check-ui-conventions.sh`, `scripts/check-functional-wiring.sh`, `scripts/check-product-ux.sh` and `scripts/check-visual-system.sh` from `crates/client`;
+7. run the affected Rust checks and relevant E2E/visual coverage when available;
+8. inspect the result at the primary desktop target (1440×900) and at a narrower desktop width before treating pixel polish as complete.
 
-Do not use screenshots under `docs/` as acceptance truth. Visual evidence belongs to test artifacts/PR discussion; stable UI rules belong in executable gates and source.
+## Page polish order
+
+When refining an existing page, review it in this order:
+
+1. **Visual hierarchy** — can the user identify the conclusion, current state and next action immediately?
+2. **State and interaction** — are loading, empty, disabled, success, warning, error, confirmation and danger states explicit and consistent?
+3. **Pixel polish** — spacing, alignment, typography, icon sizing, table density, borders, shadows and hover/focus behavior.
+
+Do not use screenshots under `docs/` as acceptance truth. Visual evidence belongs in test artifacts or PR discussion; stable rules belong in source and executable gates.

--- a/docs/ui/system.md
+++ b/docs/ui/system.md
@@ -3,20 +3,29 @@ doc_id: ui.system
 doc_type: current-architecture
 truth: source-derived
 status: active
-audited_against: c7107382b8479deb44f992e9e5ae8dcac5efb417
+audited_against: 74ee1d6212f4ab796838bbd824885a3095b7bfb9
 ---
 
 # Current UI Engineering Shape
 
-BurnCloud's client is Dioxus-based and split across `crates/client` plus feature crates under `crates/client/crates/`.
+BurnCloud's current client is a Dioxus application rooted under `crates/client/src/`. The routed console uses the functional/critical page modules wired by `src/app.rs`; older feature-crate styling is not the source of truth for the rebuilt console.
 
-For AI-agent work, the important current control points are:
+Current control points:
 
-- shared UI/styles: `crates/client/crates/client-shared/`;
-- feature/page crates: `crates/client/crates/client-*`;
-- CSS naming enforcement: `crates/loops/src/gates/css_naming.rs`;
-- component convention enforcement: `crates/loops/src/gates/ui_conventions.rs`;
-- shell/PowerShell checks under `crates/client/scripts/`;
-- browser/aesthetic/CSS E2E coverage under `crates/tests/tests/e2e/`.
+- application routes and CSS load order: `crates/client/src/app.rs`;
+- authenticated console shell: `crates/client/src/functional_layout.rs`;
+- canonical semantic visual layer: `crates/client/src/visual_system.css`;
+- shared legacy/base selectors: `crates/client/src/styles.css`;
+- product workflow primitives: `crates/client/src/product_ui.css`;
+- critical/auth page compatibility styles: `crates/client/src/critical_pages.css`;
+- desktop chrome styles: `crates/client/src/desktop_chrome.css`;
+- current routed pages: `crates/client/src/critical_pages/` and `crates/client/src/functional_pages/`;
+- executable checks: `crates/client/scripts/check-*.sh` and `.github/workflows/client-ui.yml`.
 
-Do not infer a component or token rule from old screenshots. Check the current component implementation, current styles, and executable gate.
+## Cascade contract
+
+The console intentionally keeps compatibility CSS while Phase 2 consolidates visual decisions. `visual_system.css` must remain the final CSS layer loaded by `app.rs`. It provides semantic tokens and final foundational component decisions without forcing page logic to duplicate visual values.
+
+Page modules own information architecture and state. The visual system owns hierarchy, palette, rhythm, shape, elevation, control treatment, focus behavior and motion.
+
+Do not infer a component or token rule from old screenshots or pre-rebuild feature crates. Inspect the current routed implementation and the canonical visual layer first.

--- a/docs/ui/tokens.md
+++ b/docs/ui/tokens.md
@@ -3,22 +3,36 @@ doc_id: ui.tokens
 doc_type: engineering-standard
 truth: source-derived
 status: active
-audited_against: c7107382b8479deb44f992e9e5ae8dcac5efb417
+audited_against: 74ee1d6212f4ab796838bbd824885a3095b7bfb9
 ---
 
 # UI Token Source of Truth
 
-Do not maintain a second hand-written catalog of every token in `docs/`.
+BurnCloud's current Dioxus console has one canonical semantic visual layer:
 
-Current style/token truth lives under:
+`crates/client/src/visual_system.css`
 
-`crates/client/crates/client-shared/src/styles/`
+It is loaded last by `crates/client/src/app.rs` so semantic visual decisions win over legacy and page-local CSS. The file owns the stable token families for:
 
-Before using or adding a color, spacing, typography, radius, shadow, or layout class:
+- typography;
+- neutral surfaces and text hierarchy;
+- borders and elevation;
+- brand and interaction states;
+- success, warning and danger states;
+- spacing, radius and control sizing;
+- console layout dimensions;
+- motion and reduced-motion behavior.
 
-1. search the current styles directory;
-2. check `docs/ui/naming.md` for gate-rejected forms;
-3. reuse an existing semantic class when one exists;
-4. run the current UI/CSS gates after changes.
+Legacy/page CSS may keep structural selectors, but new color, spacing, radius, shadow or interaction decisions should consume `--bc-*` semantic tokens instead of introducing another palette or local scale.
 
-This page intentionally avoids copying token values because copied values drift from CSS faster than source-linked guidance.
+Compatibility aliases such as `--canvas`, `--muted`, `--border`, `--panel`, `--surface-subtle` and `--shadow-card` exist only to bridge current page CSS into the canonical layer. Do not treat those aliases as a second token system.
+
+Before adding a visual value:
+
+1. search `crates/client/src/visual_system.css` for an existing semantic token;
+2. prefer an existing component rule before adding a page-local override;
+3. if a genuinely new visual decision is needed, add a semantic `--bc-*` token first;
+4. keep raw palette literals centralized in `visual_system.css` rather than product/page CSS;
+5. run `bash crates/client/scripts/check-visual-system.sh` plus the existing UI gates.
+
+Do not copy token values into documentation. Source is the token catalog; this document defines ownership and usage rules.


### PR DESCRIPTION
## Goal

Establish a canonical Phase 2 visual system for the rebuilt Dioxus console, then apply the first Overview polish pass on top of that foundation.

This preserves the product information architecture from #396. The focus is visual hierarchy, consistency, readiness clarity and governance rather than another workflow redesign.

## What changed

### Canonical semantic visual layer

- added `crates/client/src/visual_system.css` as the final CSS layer loaded by `app.rs`
- introduced semantic token families for typography, surfaces, text hierarchy, borders, brand/interaction, status colors, spacing, radii, elevation, control sizing, layout and motion
- retained compatibility aliases for current page CSS while making `--bc-*` the canonical token namespace

### Console and foundational component polish

- standardized Sidebar, Topbar, page canvas and content rhythm
- reduced card radius/elevation and hover movement for a more restrained operator-console aesthetic
- standardized buttons, form controls, focus treatment, badges, tables and KPI hierarchy
- normalized Overview readiness/status primitives around semantic success/warning/danger colors
- added reduced-motion behavior and consistent `:focus-visible` treatment

### Overview density polish

- stopped the primary readiness card from stretching to the checklist height
- changed desktop Setup & readiness from a tall single list to a compact 2×2 grid
- preserved a single-column responsive layout below 1100px
- added safe truncation/wrapping behavior for readiness details

### Verified readiness semantics

- `READY` now requires providers, models and API access plus at least one observed HTTP 2xx routed request
- configured environments without a successful request remain in `ATTENTION` with a clear verification action
- readiness copy distinguishes missing configuration from failed/unverified traffic
- total Spend KPI now uses two decimal places

### Product UI migration

- migrated raw status/palette literals out of `product_ui.css`
- product readiness, danger zones, setup steps and empty-state surfaces now consume semantic visual-system tokens

### Regression gate

- added `scripts/check-visual-system.sh`
- requires the canonical layer to remain last in the CSS cascade
- verifies required token families, compatibility aliases, focus/reduced-motion contracts and foundational component rules
- rejects raw hex colors in `product_ui.css`
- wired the gate into `Client UI Conventions` CI

### Documentation

- updated `docs/ui/*` to describe the current rebuilt Dioxus console instead of the pre-rebuild `client-shared` styling architecture
- documented token ownership, cascade rules and the page polish protocol

## Product effect

The console now has a stable visual foundation and a denser, more truthful Overview. BurnCloud no longer reports the environment as ready merely because configuration exists; readiness requires evidence of a successful routed request.

## Validation

GitHub Actions is green on the current head for:

- UI conventions
- functional console wiring
- product UX contracts
- visual system contracts
- Dioxus LiveView `cargo check`
- BurnCloud application integration `cargo check`
- Windows desktop client `cargo check`
