### PR TITLE
Polish Playground smoke test workflow

### DIFF
--- a/crates/client/src/functional_pages/playground_live.rs
+++ b/crates/client/src/functional_pages/playground_live.rs
@@ -18,10 +18,24 @@ pub fn Playground() -> Element {
 
     let channel_snapshot = channels_resource.read().clone();
     let key_snapshot = keys_resource.read().clone();
-    let channel_error = channel_snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
-    let key_error = key_snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
-    let channels = channel_snapshot.and_then(Result::ok).unwrap_or_default();
-    let keys: Vec<TokenDto> = key_snapshot.and_then(Result::ok).unwrap_or_default();
+    let readiness_loading = channel_snapshot.is_none() || key_snapshot.is_none();
+    let channel_error = channel_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().err().cloned());
+    let key_error = key_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().err().cloned());
+    let readiness_error = channel_error.is_some() || key_error.is_some();
+    let channels = channel_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().ok())
+        .cloned()
+        .unwrap_or_default();
+    let keys: Vec<TokenDto> = key_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().ok())
+        .cloned()
+        .unwrap_or_default();
 
     let active_channels = channels.iter().filter(|channel| channel.status == 1).count();
     let active_keys = keys.iter().filter(|key| key.status == "active").count();
@@ -35,7 +49,11 @@ pub fn Playground() -> Element {
     }
     let available_models: Vec<String> = model_set.into_iter().collect();
     let model_count = available_models.len();
-    let ready = active_channels > 0 && model_count > 0 && active_keys > 0;
+    let ready = !readiness_loading
+        && !readiness_error
+        && active_channels > 0
+        && model_count > 0
+        && active_keys > 0;
 
     let mut model = use_signal(String::new);
     let mut prompt = use_signal(String::new);
@@ -46,11 +64,48 @@ pub fn Playground() -> Element {
     let mut error = use_signal(String::new);
     let mut trace = use_signal(RouteTrace::default);
     let mut usage = use_signal(String::new);
+    let mut last_requested_model = use_signal(String::new);
 
     let trace_value = trace();
     let trace_channel = trace_value.channel_id.unwrap_or_else(|| "-".to_string());
     let trace_model = trace_value.model_id.unwrap_or_else(|| "-".to_string());
     let has_response = messages().iter().any(|message| message.role == "assistant");
+    let test_failed = ready && !loading() && !error().is_empty();
+    let test_passed = ready && !loading() && error().is_empty() && has_response;
+
+    let (test_status_class, test_status_title, test_status_copy) = if !ready {
+        (
+            "readiness-strip blocked playground-test-status",
+            "Playground is not ready yet",
+            "Complete the missing setup item below before sending a request.".to_string(),
+        )
+    } else if loading() {
+        (
+            "readiness-strip playground-test-running playground-test-status",
+            "End-to-end test is running",
+            "The request is going through BurnCloud API access, routing, and the selected upstream model.".to_string(),
+        )
+    } else if test_failed {
+        (
+            "readiness-strip playground-test-failed playground-test-status",
+            "Last end-to-end test failed",
+            "The prerequisites are configured, but the latest request did not complete successfully. Review the error and request logs before relying on this path.".to_string(),
+        )
+    } else if test_passed {
+        (
+            "readiness-strip ready playground-test-status",
+            "End-to-end test passed",
+            "A real request completed through BurnCloud using the configured API access and routing path.".to_string(),
+        )
+    } else {
+        (
+            "readiness-strip ready playground-test-status",
+            "Ready for an end-to-end test",
+            format!(
+                "{active_channels} active providers • {model_count} models • {active_keys} active API keys"
+            ),
+        )
+    };
 
     rsx! {
         div { class: "page",
@@ -62,11 +117,12 @@ pub fn Playground() -> Element {
                 div { class: "header-actions",
                     button {
                         class: "button button-secondary",
+                        disabled: readiness_loading || loading(),
                         onclick: move |_| {
                             channels_resource.restart();
                             keys_resource.restart();
                         },
-                        "Refresh readiness"
+                        if readiness_loading { "Refreshing…" } else { "Refresh readiness" }
                     }
                     if has_response {
                         Link { class: "button button-secondary", to: Route::Logs {}, "Open request logs" }
@@ -74,201 +130,268 @@ pub fn Playground() -> Element {
                 }
             }
 
-            if let Some(message) = channel_error {
-                div { class: "terminal auth-status auth-status-error", "Providers could not be loaded: {message}" }
-            }
-            if let Some(message) = key_error {
-                div { class: "terminal auth-status auth-status-error", "API keys could not be loaded: {message}" }
-            }
-
-            div { class: if ready { "readiness-strip ready" } else { "readiness-strip blocked" },
-                span { class: "readiness-dot" }
-                if ready {
-                    strong { "Ready for an end-to-end test" }
-                    span { class: "muted", "{active_channels} active providers • {model_count} models • {active_keys} active API keys" }
-                } else {
-                    strong { "Playground is not ready yet" }
-                    span { class: "muted", "Complete the missing setup item below before sending a request." }
-                }
-            }
-
-            if active_channels == 0 {
-                div { class: "card product-empty",
+            if readiness_loading {
+                div { class: "card product-empty playground-loading-state",
                     div { class: "product-empty-inner",
-                        div { class: "product-empty-icon", Icon { name: "providers" } }
-                        h3 { "Connect an active provider first" }
-                        p { "Playground can only test real routing. Add an upstream provider and make sure it is active before choosing a model." }
-                        Link { class: "button button-primary", to: Route::Providers {}, "Go to Providers" }
+                        div { class: "product-empty-icon", Icon { name: "play" } }
+                        h3 { "Checking test prerequisites" }
+                        p { "Reading active providers, exposed model IDs, and API access before enabling a real routed request." }
                     }
                 }
-            } else if model_count == 0 {
-                div { class: "card product-empty",
-                    div { class: "product-empty-inner",
-                        div { class: "product-empty-icon", Icon { name: "models" } }
-                        h3 { "No models are exposed" }
-                        p { "Your provider exists, but it does not expose any model IDs. Add models to the provider configuration before testing traffic." }
-                        Link { class: "button button-primary", to: Route::Providers {}, "Edit Provider Models" }
+            } else if readiness_error {
+                div { class: "card card-pad stack playground-readiness-error",
+                    div { class: "product-section-head",
+                        div {
+                            h3 { class: "danger", "Playground readiness could not be verified" }
+                            p { "One or more prerequisite sources failed to load. BurnCloud will not guess that the test path is ready." }
+                        }
                     }
-                }
-            } else if active_keys == 0 {
-                div { class: "card product-empty",
-                    div { class: "product-empty-inner",
-                        div { class: "product-empty-icon", Icon { name: "key" } }
-                        h3 { "Create an API key for the test" }
-                        p { "Playground uses the same BurnCloud API access path as an external client. Create an active API key before sending the request." }
-                        Link { class: "button button-primary", to: Route::APIKeys {}, "Create API Key" }
+                    if let Some(message) = channel_error.clone() {
+                        code { class: "terminal", "Providers: {message}" }
+                    }
+                    if let Some(message) = key_error.clone() {
+                        code { class: "terminal", "API keys: {message}" }
+                    }
+                    div { class: "product-actions",
+                        button {
+                            class: "button button-primary",
+                            onclick: move |_| {
+                                channels_resource.restart();
+                                keys_resource.restart();
+                            },
+                            "Retry readiness check"
+                        }
                     }
                 }
             } else {
-                div { class: "grid-2", style: "grid-template-columns:minmax(0,1fr) 340px;align-items:start",
-                    div { class: "card stack", style: "min-height:620px",
-                        div { class: "card-pad row between", style: "border-bottom:1px solid var(--border);gap:16px",
-                            div { class: "field", style: "flex:1",
-                                label { "Model to test" }
-                                select {
-                                    class: "select mono",
-                                    value: "{model}",
-                                    onchange: move |event| model.set(event.value()),
-                                    option { value: "", "Select a configured model…" }
-                                    for available_model in available_models.iter() {
-                                        option { value: "{available_model}", "{available_model}" }
-                                    }
-                                }
-                            }
-                            button {
-                                class: "button button-secondary button-sm",
-                                onclick: move |_| {
-                                    messages.set(Vec::new());
-                                    trace.set(RouteTrace::default());
-                                    usage.set(String::new());
-                                    error.set(String::new());
-                                },
-                                "Clear conversation"
-                            }
-                        }
+                div { class: "{test_status_class}",
+                    span { class: "readiness-dot" }
+                    div { class: "playground-status-copy",
+                        strong { "{test_status_title}" }
+                        span { class: "small muted", "{test_status_copy}" }
+                    }
+                    if ready {
+                        span { class: "badge badge-neutral playground-status-meta", "3/3 prerequisites" }
+                    }
+                }
 
-                        div { class: "card-pad stack", style: "flex:1;overflow:auto;max-height:430px",
-                            if messages().is_empty() {
-                                div { class: "product-empty", style: "min-height:280px",
-                                    div { class: "product-empty-inner",
-                                        div { class: "product-empty-icon", Icon { name: "play" } }
-                                        h3 { "Run a controlled routing test" }
-                                        p { "Choose a model, send a representative prompt, then verify which provider served it and inspect the resulting request log." }
-                                    }
-                                }
-                            } else {
-                                for (index, message) in messages().iter().enumerate() {
-                                    div {
-                                        key: "{index}",
-                                        class: if message.role == "user" { "card card-pad" } else { "terminal" },
-                                        div { class: "tiny subtle mono", "{message.role}" }
-                                        div { style: "white-space:pre-wrap;line-height:1.55", "{message.content}" }
-                                    }
-                                }
-                            }
-                        }
-
-                        if !error().is_empty() {
-                            div { class: "terminal auth-status auth-status-error", style: "margin:0 20px", "{error}" }
-                        }
-                        if !usage().is_empty() {
-                            div { class: "tiny muted mono", style: "padding:0 20px", "{usage}" }
-                        }
-
-                        div { class: "card-pad stack", style: "border-top:1px solid var(--border)",
-                            textarea {
-                                class: "textarea",
-                                rows: "4",
-                                value: "{prompt}",
-                                placeholder: "Enter a prompt that represents real traffic…",
-                                disabled: loading(),
-                                oninput: move |event| prompt.set(event.value()),
-                            }
-                            div { class: "row between",
-                                span { class: "tiny subtle", "Request goes through the same BurnCloud router and API-key path used by external clients." }
-                                button {
-                                    class: "button button-primary",
-                                    disabled: loading() || model().trim().is_empty() || prompt().trim().is_empty(),
-                                    onclick: move |_| {
-                                        let model_id = model().trim().to_string();
-                                        let text = prompt().trim().to_string();
-                                        if model_id.is_empty() || text.is_empty() {
-                                            error.set("Choose a model and enter a prompt.".to_string());
-                                            return;
-                                        }
-                                        let mut request_messages = messages();
-                                        request_messages.push(ChatMessage { role: "user".to_string(), content: text });
-                                        messages.set(request_messages.clone());
-                                        prompt.set(String::new());
-                                        loading.set(true);
-                                        error.set(String::new());
-                                        usage.set("Routing request through BurnCloud…".to_string());
-                                        let temp = temperature();
-                                        let max = max_tokens();
-                                        spawn(async move {
-                                            let result = async {
-                                                let api_key = first_active_api_token().await?;
-                                                chat_completion(&request_messages, &model_id, &api_key, temp, max).await
-                                            }
-                                            .await;
-                                            match result {
-                                                Ok(response) => {
-                                                    let mut next = request_messages;
-                                                    next.push(ChatMessage { role: "assistant".to_string(), content: response.content });
-                                                    messages.set(next);
-                                                    trace.set(response.trace);
-                                                    usage.set(format!(
-                                                        "prompt={} • completion={} • total={}",
-                                                        response.usage.prompt_tokens,
-                                                        response.usage.completion_tokens,
-                                                        response.usage.total_tokens
-                                                    ));
-                                                }
-                                                Err(message) => {
-                                                    error.set(format!("Request failed: {message}"));
-                                                    usage.set(String::new());
-                                                }
-                                            }
-                                            loading.set(false);
-                                        });
-                                    },
-                                    Icon { name: "play" }
-                                    if loading() { "Sending…" } else { "Send Test Request" }
-                                }
-                            }
+                if active_channels == 0 {
+                    div { class: "card product-empty",
+                        div { class: "product-empty-inner",
+                            div { class: "product-empty-icon", Icon { name: "providers" } }
+                            h3 { "Connect an active provider first" }
+                            p { "Playground can only test real routing. Add an upstream provider and make sure it is active before choosing a model." }
+                            Link { class: "button button-primary", to: Route::Providers {}, "Go to Providers" }
                         }
                     }
+                } else if model_count == 0 {
+                    div { class: "card product-empty",
+                        div { class: "product-empty-inner",
+                            div { class: "product-empty-icon", Icon { name: "models" } }
+                            h3 { "No models are exposed" }
+                            p { "Your active provider exists, but it does not expose any model IDs. Add models to the provider configuration before testing traffic." }
+                            Link { class: "button button-primary", to: Route::Providers {}, "Edit Provider Models" }
+                        }
+                    }
+                } else if active_keys == 0 {
+                    div { class: "card product-empty",
+                        div { class: "product-empty-inner",
+                            div { class: "product-empty-icon", Icon { name: "key" } }
+                            h3 { "Create an API key for the test" }
+                            p { "Playground uses the same BurnCloud API access path as an external client. Create an active API key before sending the request." }
+                            Link { class: "button button-primary", to: Route::APIKeys {}, "Create API Key" }
+                        }
+                    }
+                } else {
+                    div { class: "playground-workspace",
+                        div { class: "card stack playground-conversation",
+                            div { class: "card-pad row between playground-toolbar",
+                                div { class: "field playground-model-field",
+                                    label { "Model to test" }
+                                    select {
+                                        class: "select mono",
+                                        value: "{model}",
+                                        disabled: loading(),
+                                        onchange: move |event| {
+                                            model.set(event.value());
+                                            error.set(String::new());
+                                        },
+                                        option { value: "", "Select a configured model…" }
+                                        for available_model in available_models.iter() {
+                                            option { value: "{available_model}", "{available_model}" }
+                                        }
+                                    }
+                                }
+                                button {
+                                    class: "button button-secondary button-sm",
+                                    disabled: loading(),
+                                    onclick: move |_| {
+                                        messages.set(Vec::new());
+                                        trace.set(RouteTrace::default());
+                                        usage.set(String::new());
+                                        error.set(String::new());
+                                        last_requested_model.set(String::new());
+                                    },
+                                    "Clear conversation"
+                                }
+                            }
 
-                    div { class: "stack-lg",
-                        div { class: "card card-pad stack",
-                            div { class: "product-section-head",
-                                div { h3 { "Request settings" } p { "Keep defaults unless your test needs specific generation behavior." } }
+                            div { class: "card-pad stack playground-thread",
+                                if messages().is_empty() {
+                                    div { class: "product-empty playground-thread-empty",
+                                        div { class: "product-empty-inner",
+                                            div { class: "product-empty-icon", Icon { name: "play" } }
+                                            h3 { "Run a controlled routing test" }
+                                            p { "Choose a model, send a representative prompt, then verify which provider served it and inspect the resulting request log." }
+                                        }
+                                    }
+                                } else {
+                                    for (index, message) in messages().iter().enumerate() {
+                                        div {
+                                            key: "{index}",
+                                            class: if message.role == "user" { "playground-message playground-message-user" } else { "playground-message playground-message-assistant" },
+                                            div { class: "tiny subtle mono playground-message-role", "{message.role}" }
+                                            div { class: "playground-message-content", "{message.content}" }
+                                        }
+                                    }
+                                }
                             }
-                            div { class: "field",
-                                label { "Temperature: {temperature}" }
-                                input { r#type: "range", min: "0", max: "2", step: "0.1", value: "{temperature}", oninput: move |event| temperature.set(event.value().parse().unwrap_or(0.7)) }
+
+                            if !error().is_empty() {
+                                div { class: "terminal auth-status auth-status-error playground-request-error", "{error}" }
                             }
-                            div { class: "field",
-                                label { "Max output tokens" }
-                                input { class: "input", r#type: "number", min: "1", value: "{max_tokens}", oninput: move |event| max_tokens.set(event.value().parse().unwrap_or(1024)) }
+                            if !usage().is_empty() {
+                                div { class: "tiny muted mono playground-usage", "{usage}" }
+                            }
+
+                            div { class: "card-pad stack playground-composer",
+                                textarea {
+                                    class: "textarea",
+                                    rows: "4",
+                                    value: "{prompt}",
+                                    placeholder: "Enter a prompt that represents real traffic…",
+                                    disabled: loading(),
+                                    oninput: move |event| {
+                                        prompt.set(event.value());
+                                        error.set(String::new());
+                                    },
+                                }
+                                div { class: "playground-composer-footer",
+                                    span { class: "tiny subtle", "Request goes through the same BurnCloud router and API-key path used by external clients." }
+                                    button {
+                                        class: "button button-primary",
+                                        disabled: loading() || model().trim().is_empty() || prompt().trim().is_empty(),
+                                        onclick: move |_| {
+                                            let model_id = model().trim().to_string();
+                                            let text = prompt().trim().to_string();
+                                            if model_id.is_empty() || text.is_empty() {
+                                                error.set("Choose a model and enter a prompt.".to_string());
+                                                return;
+                                            }
+
+                                            let prior_messages = messages();
+                                            let mut request_messages = prior_messages.clone();
+                                            request_messages.push(ChatMessage {
+                                                role: "user".to_string(),
+                                                content: text.clone(),
+                                            });
+                                            messages.set(request_messages.clone());
+                                            prompt.set(String::new());
+                                            trace.set(RouteTrace::default());
+                                            last_requested_model.set(model_id.clone());
+                                            loading.set(true);
+                                            error.set(String::new());
+                                            usage.set("Routing request through BurnCloud…".to_string());
+                                            let temp = temperature();
+                                            let max = max_tokens();
+
+                                            spawn(async move {
+                                                let result = async {
+                                                    let api_key = first_active_api_token().await?;
+                                                    chat_completion(&request_messages, &model_id, &api_key, temp, max).await
+                                                }
+                                                .await;
+
+                                                match result {
+                                                    Ok(response) => {
+                                                        let mut next = request_messages;
+                                                        next.push(ChatMessage {
+                                                            role: "assistant".to_string(),
+                                                            content: response.content,
+                                                        });
+                                                        messages.set(next);
+                                                        trace.set(response.trace);
+                                                        usage.set(format!(
+                                                            "Prompt {} • Completion {} • Total {} tokens",
+                                                            response.usage.prompt_tokens,
+                                                            response.usage.completion_tokens,
+                                                            response.usage.total_tokens
+                                                        ));
+                                                    }
+                                                    Err(message) => {
+                                                        messages.set(prior_messages);
+                                                        prompt.set(text);
+                                                        error.set(format!("Request failed: {message}"));
+                                                        usage.set(String::new());
+                                                    }
+                                                }
+                                                loading.set(false);
+                                            });
+                                        },
+                                        Icon { name: "play" }
+                                        if loading() { "Sending…" } else { "Send Test Request" }
+                                    }
+                                }
                             }
                         }
 
-                        div { class: "card card-pad stack",
-                            div { class: "product-section-head",
-                                div { h3 { "Last route" } p { "Confirm which upstream handled the test." } }
+                        div { class: "stack-lg playground-sidebar",
+                            div { class: "card card-pad stack",
+                                div { class: "product-section-head",
+                                    div { h3 { "Request settings" } p { "Keep defaults unless your test needs specific generation behavior." } }
+                                }
+                                div { class: "field",
+                                    label { "Temperature: {temperature}" }
+                                    input {
+                                        r#type: "range",
+                                        min: "0",
+                                        max: "2",
+                                        step: "0.1",
+                                        value: "{temperature}",
+                                        disabled: loading(),
+                                        oninput: move |event| temperature.set(event.value().parse().unwrap_or(0.7))
+                                    }
+                                }
+                                div { class: "field",
+                                    label { "Max output tokens" }
+                                    input {
+                                        class: "input",
+                                        r#type: "number",
+                                        min: "1",
+                                        value: "{max_tokens}",
+                                        disabled: loading(),
+                                        oninput: move |event| max_tokens.set(event.value().parse().unwrap_or(1024))
+                                    }
+                                }
                             }
-                            div { class: "receipt-row", label { "Channel" } strong { class: "mono", "{trace_channel}" } }
-                            div { class: "receipt-row", label { "Model" } strong { class: "mono", "{trace_model}" } }
-                            if has_response {
-                                Link { class: "button button-secondary", to: Route::Logs {}, "Inspect this request in Logs" }
-                            } else {
-                                p { class: "tiny subtle", "Route metadata appears after the first successful request when the router emits trace headers." }
-                            }
-                        }
 
-                        div { class: "product-note",
-                            "Playground is an operational smoke test, not a separate inference path. A successful response here is evidence that provider configuration, model exposure, API access and routing all work together."
+                            div { class: "card card-pad stack playground-evidence-card",
+                                div { class: "product-section-head",
+                                    div { h3 { "Last route" } p { "Confirm what the last successful test proved." } }
+                                }
+                                div { class: "receipt-row", label { "Requested model" } strong { class: "mono", if last_requested_model().is_empty() { "-" } else { "{last_requested_model}" } } }
+                                div { class: "receipt-row", label { "Channel trace" } strong { class: "mono", "{trace_channel}" } }
+                                div { class: "receipt-row", label { "Model trace" } strong { class: "mono", "{trace_model}" } }
+                                if has_response {
+                                    Link { class: "button button-secondary", to: Route::Logs {}, "Inspect request evidence in Logs" }
+                                } else {
+                                    p { class: "tiny subtle", "Route metadata appears after the first successful request when the router emits trace headers." }
+                                }
+                            }
+
+                            div { class: "product-note",
+                                "Playground is an operational smoke test, not a separate inference path. A successful response proves that provider configuration, model exposure, API access and routing worked together for that request."
+                            }
                         }
                     }
                 }

--- a/crates/client/src/product_ui.css
+++ b/crates/client/src/product_ui.css
@@ -334,6 +334,147 @@
   background: var(--bc-color-warning-soft);
 }
 
+.playground-loading-state {
+  min-height: 180px;
+}
+
+.playground-readiness-error {
+  border-color: var(--bc-color-danger-border);
+}
+
+.playground-test-status {
+  min-height: 62px;
+  padding: 12px 16px;
+}
+
+.playground-test-running {
+  border-color: color-mix(in srgb, var(--bc-color-info) 28%, var(--bc-color-border));
+  background: var(--bc-color-info-soft);
+}
+
+.playground-test-running .readiness-dot {
+  background: var(--bc-color-info);
+}
+
+.playground-test-failed {
+  border-color: var(--bc-color-danger-border);
+  background: var(--bc-color-danger-soft);
+}
+
+.playground-test-failed .readiness-dot {
+  background: var(--bc-color-danger);
+}
+
+.playground-status-copy {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  gap: 2px;
+}
+
+.playground-status-meta {
+  margin-left: auto;
+}
+
+.playground-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: var(--bc-space-6);
+  align-items: start;
+}
+
+.playground-conversation {
+  min-width: 0;
+  min-height: 620px;
+  overflow: hidden;
+}
+
+.playground-toolbar {
+  gap: var(--bc-space-4);
+  align-items: flex-end;
+  border-bottom: 1px solid var(--bc-color-border-soft);
+}
+
+.playground-model-field {
+  flex: 1;
+  min-width: 0;
+}
+
+.playground-thread {
+  flex: 1;
+  min-height: 300px;
+  max-height: 430px;
+  overflow: auto;
+}
+
+.playground-thread-empty {
+  min-height: 280px;
+}
+
+.playground-message {
+  padding: var(--bc-space-4);
+  border: 1px solid var(--bc-color-border-soft);
+  border-radius: var(--bc-radius-lg);
+}
+
+.playground-message-user {
+  background: var(--bc-color-surface-subtle);
+}
+
+.playground-message-assistant {
+  background: var(--bc-color-surface);
+}
+
+.playground-message-role {
+  margin-bottom: var(--bc-space-2);
+}
+
+.playground-message-content {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  line-height: 1.6;
+}
+
+.playground-request-error {
+  margin: 0 var(--bc-space-5);
+}
+
+.playground-usage {
+  padding: 0 var(--bc-space-5);
+}
+
+.playground-composer {
+  border-top: 1px solid var(--bc-color-border-soft);
+}
+
+.playground-composer-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--bc-space-4);
+}
+
+.playground-composer-footer > span {
+  max-width: 620px;
+  line-height: 1.5;
+}
+
+.playground-sidebar {
+  position: sticky;
+  top: 0;
+}
+
+.playground-sidebar input[type="range"] {
+  width: 100%;
+}
+
+.playground-evidence-card .receipt-row strong {
+  max-width: 190px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .form-section {
   display: flex;
   flex-direction: column;
@@ -432,23 +573,44 @@
   .provider-endpoint {
     max-width: 300px;
   }
+
+  .playground-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .playground-sidebar {
+    position: static;
+  }
 }
 
 @media (max-width: 760px) {
   .provider-health-strip,
   .model-health-strip,
-  .route-health-strip {
+  .route-health-strip,
+  .playground-test-status {
     align-items: flex-start;
     flex-wrap: wrap;
   }
 
   .provider-health-meta,
   .model-health-meta,
-  .route-health-meta {
+  .route-health-meta,
+  .playground-status-meta {
     margin-left: 19px;
   }
 
   .route-group-heading h3 {
     max-width: 260px;
+  }
+
+  .playground-toolbar,
+  .playground-composer-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .playground-toolbar .button,
+  .playground-composer-footer .button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Goal

Apply the Phase 2 page-by-page polish pass to Playground after Providers (#407), Models (#408), and Routes (#409).

Playground should behave like an operational smoke-test workbench: verify prerequisites, run a real routed request, surface success/failure clearly, and point the operator to request evidence.

## What changed

### Truthful readiness loading

- distinguish prerequisite loading from genuine missing setup
- stop initial provider/key fetches from flashing false "connect a provider" states
- when provider or API-key readiness data fails to load, show an explicit verification error instead of guessing that the path is not configured
- disable readiness refresh while a readiness check or request is running

### Smoke-test lifecycle

The top conclusion now distinguishes:

- prerequisites missing
- test in progress
- last test failed
- end-to-end test passed
- ready to run the first test

A successful response is promoted from hidden conversation output to an explicit `End-to-end test passed` conclusion.

### Safer failed-request behavior

- preserve the conversation as it existed before a failed request
- restore the failed prompt into the composer for correction/retry
- prevent a failed user-only message from silently becoming part of the next request context
- reset route trace when a new test begins so stale trace data is not presented as current evidence

### Request controls

- disable model/settings/clear controls while a request is in flight
- clear stale request errors when the operator edits the model or prompt
- format token usage in operator-readable language

### Route evidence

- preserve the exact model requested for the last test as local UI evidence
- separate Requested model from Channel trace and Model trace
- link successful tests directly to Logs for persisted request evidence
- clarify that trace headers may be absent even when the request itself succeeds

### Visual hierarchy

- move workspace, thread, composer, evidence, and responsive layout rules out of inline styles and into `product_ui.css`
- add restrained semantic treatments for running, passed, and failed test states
- keep desktop request settings/evidence sticky and collapse to one column on narrower layouts
- provide distinct but neutral user/assistant message surfaces

## Validation

Expected repository checks:

- UI conventions
- functional console wiring
- product UX contracts
- visual system contracts
- Dioxus LiveView `cargo check`
- BurnCloud application integration `cargo check`
- Windows desktop client `cargo check`

## Scope

Only:

- `crates/client/src/functional_pages/playground_live.rs`
- `crates/client/src/product_ui.css`
