### PR TITLE
Polish Playground end-to-end verification

### DIFF
--- a/crates/client/scripts/check-product-ux.sh
+++ b/crates/client/scripts/check-product-ux.sh
@@ -75,12 +75,17 @@ require 'Redundant' src/functional_pages/catalog.rs
 require 'Unavailable' src/functional_pages/catalog.rs
 require 'No failover redundancy' src/functional_pages/catalog.rs
 
-# Playground is a guided end-to-end test and blocks impossible workflows.
+# Playground is a guided end-to-end data-plane test and must respect one-time-secret semantics.
 require 'Playground is not ready yet' src/functional_pages/playground_live.rs
 require 'Connect an active provider first' src/functional_pages/playground_live.rs
 require 'Create an API key for the test' src/functional_pages/playground_live.rs
 require 'Select a configured model' src/functional_pages/playground_live.rs
+require 'Paste a saved BurnCloud API key' src/functional_pages/playground_live.rs
+require 'r#type: "password"' src/functional_pages/playground_live.rs
+require 'readiness_loading' src/functional_pages/playground_live.rs
 require 'Send Test Request' src/functional_pages/playground_live.rs
+require 'No previous route receipt is reused for this result.' src/functional_pages/playground_live.rs
+forbid 'first_active_api_token' src/functional_pages/playground_live.rs
 
 # Customers and staff have separate product responsibilities.
 require 'Manage business accounts' src/critical_pages/customers_portable.rs

--- a/crates/client/src/functional_pages/playground_live.rs
+++ b/crates/client/src/functional_pages/playground_live.rs
@@ -4,10 +4,7 @@ use dioxus::prelude::*;
 
 use crate::{
     app::Route,
-    backend::{
-        chat_completion, first_active_api_token, ChannelService, ChatMessage, RouteTrace, TokenDto,
-        TokenService,
-    },
+    backend::{chat_completion, ChannelService, ChatMessage, RouteTrace, TokenDto, TokenService},
     components::Icon,
 };
 
@@ -18,26 +15,52 @@ pub fn Playground() -> Element {
 
     let channel_snapshot = channels_resource.read().clone();
     let key_snapshot = keys_resource.read().clone();
-    let channel_error = channel_snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
-    let key_error = key_snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
-    let channels = channel_snapshot.and_then(Result::ok).unwrap_or_default();
-    let keys: Vec<TokenDto> = key_snapshot.and_then(Result::ok).unwrap_or_default();
+    let channels_loading = channel_snapshot.is_none();
+    let keys_loading = key_snapshot.is_none();
+    let channel_error = channel_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().err().cloned());
+    let key_error = key_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().err().cloned());
+    let channels = channel_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().ok())
+        .cloned()
+        .unwrap_or_default();
+    let keys: Vec<TokenDto> = key_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().ok())
+        .cloned()
+        .unwrap_or_default();
 
+    let readiness_loading = channels_loading || keys_loading;
+    let readiness_failed = channel_error.is_some() || key_error.is_some();
     let active_channels = channels.iter().filter(|channel| channel.status == 1).count();
     let active_keys = keys.iter().filter(|key| key.status == "active").count();
     let mut model_set = BTreeSet::new();
     for channel in &channels {
         if channel.status == 1 {
-            for model in channel.models.split(',').map(str::trim).filter(|model| !model.is_empty()) {
+            for model in channel
+                .models
+                .split(',')
+                .map(str::trim)
+                .filter(|model| !model.is_empty())
+            {
                 model_set.insert(model.to_string());
             }
         }
     }
     let available_models: Vec<String> = model_set.into_iter().collect();
     let model_count = available_models.len();
-    let ready = active_channels > 0 && model_count > 0 && active_keys > 0;
+    let prerequisites_ready = !readiness_loading
+        && !readiness_failed
+        && active_channels > 0
+        && model_count > 0
+        && active_keys > 0;
 
     let mut model = use_signal(String::new);
+    let mut api_key = use_signal(String::new);
     let mut prompt = use_signal(String::new);
     let mut messages = use_signal(|| Vec::<ChatMessage>::new());
     let mut temperature = use_signal(|| 0.7f64);
@@ -46,11 +69,57 @@ pub fn Playground() -> Element {
     let mut error = use_signal(String::new);
     let mut trace = use_signal(RouteTrace::default);
     let mut usage = use_signal(String::new);
+    let mut last_result = use_signal(String::new);
+    let mut last_requested_model = use_signal(String::new);
+
+    let model_value = model();
+    let model_available = available_models
+        .iter()
+        .any(|available| available == model_value.trim());
+    let credential_supplied = !api_key().trim().is_empty();
+    let prompt_supplied = !prompt().trim().is_empty();
+    let can_send = prerequisites_ready
+        && model_available
+        && credential_supplied
+        && prompt_supplied
+        && !loading();
 
     let trace_value = trace();
-    let trace_channel = trace_value.channel_id.unwrap_or_else(|| "-".to_string());
-    let trace_model = trace_value.model_id.unwrap_or_else(|| "-".to_string());
-    let has_response = messages().iter().any(|message| message.role == "assistant");
+    let route_trace_available = trace_value.channel_id.is_some() || trace_value.model_id.is_some();
+    let trace_provider = trace_value.channel_id.as_deref().and_then(|channel_id| {
+        channels
+            .iter()
+            .find(|channel| channel.id.to_string() == channel_id)
+            .map(|channel| {
+                if channel.name.trim().is_empty() {
+                    format!("Channel {}", channel.id)
+                } else {
+                    channel.name.clone()
+                }
+            })
+    });
+    let trace_provider_text = trace_provider
+        .or_else(|| trace_value.channel_id.clone())
+        .unwrap_or_else(|| "Trace unavailable".to_string());
+    let trace_model_text = trace_value
+        .model_id
+        .clone()
+        .unwrap_or_else(|| "Trace unavailable".to_string());
+    let last_result_value = last_result();
+    let last_success = last_result_value == "success";
+    let last_failed = last_result_value == "failed";
+    let last_running = last_result_value == "running";
+    let last_requested_model_value = last_requested_model();
+
+    let readiness_class = if readiness_loading {
+        "readiness-strip checking"
+    } else if readiness_failed {
+        "readiness-strip error"
+    } else if prerequisites_ready {
+        "readiness-strip ready"
+    } else {
+        "readiness-strip blocked"
+    };
 
     rsx! {
         div { class: "page",
@@ -62,13 +131,14 @@ pub fn Playground() -> Element {
                 div { class: "header-actions",
                     button {
                         class: "button button-secondary",
+                        disabled: readiness_loading,
                         onclick: move |_| {
                             channels_resource.restart();
                             keys_resource.restart();
                         },
-                        "Refresh readiness"
+                        if readiness_loading { "Checking…" } else { "Refresh readiness" }
                     }
-                    if has_response {
+                    if last_success {
                         Link { class: "button button-secondary", to: Route::Logs {}, "Open request logs" }
                     }
                 }
@@ -81,18 +151,48 @@ pub fn Playground() -> Element {
                 div { class: "terminal auth-status auth-status-error", "API keys could not be loaded: {message}" }
             }
 
-            div { class: if ready { "readiness-strip ready" } else { "readiness-strip blocked" },
+            div { class: readiness_class,
                 span { class: "readiness-dot" }
-                if ready {
-                    strong { "Ready for an end-to-end test" }
-                    span { class: "muted", "{active_channels} active providers • {model_count} models • {active_keys} active API keys" }
+                if readiness_loading {
+                    strong { "Checking Playground readiness" }
+                    span { class: "muted", "Loading provider, model and API-key prerequisites." }
+                } else if readiness_failed {
+                    strong { "Readiness could not be verified" }
+                    span { class: "muted", "One or more prerequisite sources failed to load. Retry before trusting this test surface." }
+                } else if prerequisites_ready {
+                    strong { "Environment prerequisites are ready" }
+                    span { class: "muted", "{active_channels} active providers • {model_count} models • {active_keys} active API keys. Paste a saved bearer secret below to run the test." }
                 } else {
                     strong { "Playground is not ready yet" }
                     span { class: "muted", "Complete the missing setup item below before sending a request." }
                 }
             }
 
-            if active_channels == 0 {
+            if readiness_loading {
+                div { class: "card product-empty playground-loading-state",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "play" } }
+                        h3 { "Checking the real request path" }
+                        p { "BurnCloud is loading providers and API-key metadata before deciding whether this environment can be tested." }
+                    }
+                }
+            } else if readiness_failed {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "warning" } }
+                        h3 { "Readiness is unavailable" }
+                        p { "The console cannot safely infer missing setup while provider or API-key data is unavailable. Retry the prerequisite checks first." }
+                        button {
+                            class: "button button-primary",
+                            onclick: move |_| {
+                                channels_resource.restart();
+                                keys_resource.restart();
+                            },
+                            "Retry readiness"
+                        }
+                    }
+                }
+            } else if active_channels == 0 {
                 div { class: "card product-empty",
                     div { class: "product-empty-inner",
                         div { class: "product-empty-icon", Icon { name: "providers" } }
@@ -115,67 +215,75 @@ pub fn Playground() -> Element {
                     div { class: "product-empty-inner",
                         div { class: "product-empty-icon", Icon { name: "key" } }
                         h3 { "Create an API key for the test" }
-                        p { "Playground uses the same BurnCloud API access path as an external client. Create an active API key before sending the request." }
+                        p { "Playground uses the same BurnCloud API access path as an external client. Create an active API key and save its one-time bearer secret before sending the request." }
                         Link { class: "button button-primary", to: Route::APIKeys {}, "Create API Key" }
                     }
                 }
             } else {
-                div { class: "grid-2", style: "grid-template-columns:minmax(0,1fr) 340px;align-items:start",
-                    div { class: "card stack", style: "min-height:620px",
-                        div { class: "card-pad row between", style: "border-bottom:1px solid var(--border);gap:16px",
-                            div { class: "field", style: "flex:1",
+                div { class: "playground-layout",
+                    div { class: "card playground-workbench",
+                        div { class: "playground-config",
+                            div { class: "field",
                                 label { "Model to test" }
                                 select {
                                     class: "select mono",
                                     value: "{model}",
+                                    disabled: loading(),
                                     onchange: move |event| model.set(event.value()),
                                     option { value: "", "Select a configured model…" }
                                     for available_model in available_models.iter() {
                                         option { value: "{available_model}", "{available_model}" }
                                     }
                                 }
+                                small { class: "muted", "Only models exposed by active providers are selectable." }
                             }
-                            button {
-                                class: "button button-secondary button-sm",
-                                onclick: move |_| {
-                                    messages.set(Vec::new());
-                                    trace.set(RouteTrace::default());
-                                    usage.set(String::new());
-                                    error.set(String::new());
-                                },
-                                "Clear conversation"
+                            div { class: "field",
+                                label { "BurnCloud API key" }
+                                input {
+                                    class: "input mono",
+                                    r#type: "password",
+                                    autocomplete: "off",
+                                    value: "{api_key}",
+                                    disabled: loading(),
+                                    placeholder: "Paste a saved bc_live_… bearer secret",
+                                    oninput: move |event| api_key.set(event.value()),
+                                }
+                                div { class: "playground-secret-help",
+                                    small { class: "muted", "Paste a saved BurnCloud API key. The bearer secret stays in this page session and is not persisted or read back from the management API." }
+                                    Link { class: "button button-secondary button-sm", to: Route::APIKeys {}, "Manage keys" }
+                                }
                             }
                         }
 
-                        div { class: "card-pad stack", style: "flex:1;overflow:auto;max-height:430px",
+                        div { class: "playground-conversation",
                             if messages().is_empty() {
-                                div { class: "product-empty", style: "min-height:280px",
+                                div { class: "product-empty playground-conversation-empty",
                                     div { class: "product-empty-inner",
                                         div { class: "product-empty-icon", Icon { name: "play" } }
                                         h3 { "Run a controlled routing test" }
-                                        p { "Choose a model, send a representative prompt, then verify which provider served it and inspect the resulting request log." }
+                                        p { "Choose a model, supply a saved API key, send a representative prompt, then verify which provider served the request." }
                                     }
                                 }
                             } else {
                                 for (index, message) in messages().iter().enumerate() {
                                     div {
                                         key: "{index}",
-                                        class: if message.role == "user" { "card card-pad" } else { "terminal" },
-                                        div { class: "tiny subtle mono", "{message.role}" }
-                                        div { style: "white-space:pre-wrap;line-height:1.55", "{message.content}" }
+                                        class: if message.role == "user" { "playground-message playground-message-user" } else { "playground-message playground-message-assistant" },
+                                        div { class: "playground-message-role mono", "{message.role}" }
+                                        div { class: "playground-message-content", "{message.content}" }
                                     }
                                 }
                             }
                         }
 
                         if !error().is_empty() {
-                            div { class: "terminal auth-status auth-status-error", style: "margin:0 20px", "{error}" }
+                            div { class: "terminal auth-status auth-status-error playground-feedback", "{error}" }
                         }
                         if !usage().is_empty() {
-                            div { class: "tiny muted mono", style: "padding:0 20px", "{usage}" }
+                            div { class: "tiny muted mono playground-usage", "{usage}" }
                         }
 
-                        div { class: "card-pad stack", style: "border-top:1px solid var(--border)",
+                        div { class: "playground-composer",
                             textarea {
                                 class: "textarea",
                                 rows: "4",
@@ -184,91 +292,161 @@ pub fn Playground() -> Element {
                                 disabled: loading(),
                                 oninput: move |event| prompt.set(event.value()),
                             }
-                            div { class: "row between",
-                                span { class: "tiny subtle", "Request goes through the same BurnCloud router and API-key path used by external clients." }
-                                button {
-                                    class: "button button-primary",
-                                    disabled: loading() || model().trim().is_empty() || prompt().trim().is_empty(),
-                                    onclick: move |_| {
-                                        let model_id = model().trim().to_string();
-                                        let text = prompt().trim().to_string();
-                                        if model_id.is_empty() || text.is_empty() {
-                                            error.set("Choose a model and enter a prompt.".to_string());
-                                            return;
-                                        }
-                                        let mut request_messages = messages();
-                                        request_messages.push(ChatMessage { role: "user".to_string(), content: text });
-                                        messages.set(request_messages.clone());
-                                        prompt.set(String::new());
-                                        loading.set(true);
-                                        error.set(String::new());
-                                        usage.set("Routing request through BurnCloud…".to_string());
-                                        let temp = temperature();
-                                        let max = max_tokens();
-                                        spawn(async move {
-                                            let result = async {
-                                                let api_key = first_active_api_token().await?;
-                                                chat_completion(&request_messages, &model_id, &api_key, temp, max).await
+                            div { class: "playground-composer-meta",
+                                span { class: "tiny subtle", "This request uses the same BurnCloud data-plane API-key and routing path as an external client." }
+                                div { class: "row", style: "gap:8px",
+                                    button {
+                                        class: "button button-secondary button-sm",
+                                        disabled: loading() || messages().is_empty(),
+                                        onclick: move |_| {
+                                            messages.set(Vec::new());
+                                            trace.set(RouteTrace::default());
+                                            usage.set(String::new());
+                                            error.set(String::new());
+                                            last_result.set(String::new());
+                                            last_requested_model.set(String::new());
+                                        },
+                                        "Clear"
+                                    }
+                                    button {
+                                        class: "button button-primary",
+                                        disabled: !can_send,
+                                        onclick: move |_| {
+                                            if !prerequisites_ready {
+                                                error.set("Refresh readiness and resolve missing prerequisites before sending a test.".to_string());
+                                                return;
                                             }
-                                            .await;
-                                            match result {
-                                                Ok(response) => {
-                                                    let mut next = request_messages;
-                                                    next.push(ChatMessage { role: "assistant".to_string(), content: response.content });
-                                                    messages.set(next);
-                                                    trace.set(response.trace);
-                                                    usage.set(format!(
-                                                        "prompt={} • completion={} • total={}",
-                                                        response.usage.prompt_tokens,
-                                                        response.usage.completion_tokens,
-                                                        response.usage.total_tokens
-                                                    ));
-                                                }
-                                                Err(message) => {
-                                                    error.set(format!("Request failed: {message}"));
-                                                    usage.set(String::new());
-                                                }
+                                            let model_id = model().trim().to_string();
+                                            if !model_available || model_id.is_empty() {
+                                                error.set("Select a currently available model before sending the test.".to_string());
+                                                return;
                                             }
-                                            loading.set(false);
-                                        });
-                                    },
-                                    Icon { name: "play" }
-                                    if loading() { "Sending…" } else { "Send Test Request" }
+                                            let bearer_token = api_key().trim().to_string();
+                                            if bearer_token.is_empty() {
+                                                error.set("Paste a saved BurnCloud API key before sending the test.".to_string());
+                                                return;
+                                            }
+                                            let text = prompt().trim().to_string();
+                                            if text.is_empty() {
+                                                error.set("Enter a prompt before sending the test.".to_string());
+                                                return;
+                                            }
+
+                                            let mut request_messages = messages();
+                                            request_messages.push(ChatMessage { role: "user".to_string(), content: text });
+                                            messages.set(request_messages.clone());
+                                            prompt.set(String::new());
+                                            loading.set(true);
+                                            error.set(String::new());
+                                            trace.set(RouteTrace::default());
+                                            usage.set("Routing request through BurnCloud…".to_string());
+                                            last_result.set("running".to_string());
+                                            last_requested_model.set(model_id.clone());
+                                            let temp = temperature();
+                                            let max = max_tokens();
+                                            spawn(async move {
+                                                match chat_completion(&request_messages, &model_id, &bearer_token, temp, max).await {
+                                                    Ok(response) => {
+                                                        let mut next = request_messages;
+                                                        next.push(ChatMessage { role: "assistant".to_string(), content: response.content });
+                                                        messages.set(next);
+                                                        trace.set(response.trace);
+                                                        usage.set(format!(
+                                                            "prompt={} • completion={} • total={}",
+                                                            response.usage.prompt_tokens,
+                                                            response.usage.completion_tokens,
+                                                            response.usage.total_tokens
+                                                        ));
+                                                        last_result.set("success".to_string());
+                                                    }
+                                                    Err(message) => {
+                                                        error.set(format!("Request failed: {message}"));
+                                                        trace.set(RouteTrace::default());
+                                                        usage.set(String::new());
+                                                        last_result.set("failed".to_string());
+                                                    }
+                                                }
+                                                loading.set(false);
+                                            });
+                                        },
+                                        Icon { name: "play" }
+                                        if loading() { "Sending…" } else { "Send Test Request" }
+                                    }
                                 }
                             }
                         }
                     }
 
-                    div { class: "stack-lg",
+                    div { class: "playground-sidebar",
                         div { class: "card card-pad stack",
                             div { class: "product-section-head",
-                                div { h3 { "Request settings" } p { "Keep defaults unless your test needs specific generation behavior." } }
+                                div { h3 { "Request settings" } p { "Keep defaults unless this smoke test needs specific generation behavior." } }
                             }
                             div { class: "field",
                                 label { "Temperature: {temperature}" }
-                                input { r#type: "range", min: "0", max: "2", step: "0.1", value: "{temperature}", oninput: move |event| temperature.set(event.value().parse().unwrap_or(0.7)) }
+                                input {
+                                    r#type: "range",
+                                    min: "0",
+                                    max: "2",
+                                    step: "0.1",
+                                    value: "{temperature}",
+                                    disabled: loading(),
+                                    oninput: move |event| temperature.set(event.value().parse().unwrap_or(0.7)),
+                                }
                             }
                             div { class: "field",
                                 label { "Max output tokens" }
-                                input { class: "input", r#type: "number", min: "1", value: "{max_tokens}", oninput: move |event| max_tokens.set(event.value().parse().unwrap_or(1024)) }
+                                input {
+                                    class: "input",
+                                    r#type: "number",
+                                    min: "1",
+                                    value: "{max_tokens}",
+                                    disabled: loading(),
+                                    oninput: move |event| max_tokens.set(event.value().parse().unwrap_or(1024)),
+                                }
                             }
                         }
 
                         div { class: "card card-pad stack",
                             div { class: "product-section-head",
-                                div { h3 { "Last route" } p { "Confirm which upstream handled the test." } }
+                                div { h3 { "Last test" } p { "The result below belongs only to the most recent send action." } }
                             }
-                            div { class: "receipt-row", label { "Channel" } strong { class: "mono", "{trace_channel}" } }
-                            div { class: "receipt-row", label { "Model" } strong { class: "mono", "{trace_model}" } }
-                            if has_response {
-                                Link { class: "button button-secondary", to: Route::Logs {}, "Inspect this request in Logs" }
+                            if last_running {
+                                div { class: "playground-route-state checking",
+                                    strong { "Routing request…" }
+                                    span { class: "muted", "Waiting for the current data-plane response." }
+                                }
+                            } else if last_success {
+                                div { class: "playground-route-state success",
+                                    strong { "Request succeeded" }
+                                    span { class: "muted", "BurnCloud returned a successful model response." }
+                                }
+                                div { class: "receipt-row", label { "Requested model" } strong { class: "mono", "{last_requested_model_value}" } }
+                                div { class: "receipt-row", label { "Provider / channel" } strong { class: "mono", "{trace_provider_text}" } }
+                                div { class: "receipt-row", label { "Routed model" } strong { class: "mono", "{trace_model_text}" } }
+                                if !route_trace_available {
+                                    p { class: "tiny subtle", "The response succeeded, but route trace headers were not present, so this page does not claim which upstream served it." }
+                                }
+                                Link { class: "button button-secondary", to: Route::Logs {}, "Inspect request logs" }
+                            } else if last_failed {
+                                div { class: "playground-route-state failed",
+                                    strong { "Last test failed" }
+                                    span { class: "muted", "No previous route receipt is reused for this result. Review the request error and Logs before retrying." }
+                                }
+                                if !last_requested_model_value.is_empty() {
+                                    div { class: "receipt-row", label { "Requested model" } strong { class: "mono", "{last_requested_model_value}" } }
+                                }
+                                Link { class: "button button-secondary", to: Route::Logs {}, "Open request logs" }
                             } else {
-                                p { class: "tiny subtle", "Route metadata appears after the first successful request when the router emits trace headers." }
+                                div { class: "playground-route-state",
+                                    strong { "No test sent yet" }
+                                    span { class: "muted", "Route evidence appears here only after this page sends a request." }
+                                }
                             }
                         }
 
                         div { class: "product-note",
-                            "Playground is an operational smoke test, not a separate inference path. A successful response here is evidence that provider configuration, model exposure, API access and routing all work together."
+                            "Playground is an operational smoke test, not a separate inference path. The management API intentionally cannot retrieve stored bearer secrets after creation or rotation, so the test credential is supplied explicitly for this page session."
                         }
                     }
                 }

--- a/crates/client/src/product_ui.css
+++ b/crates/client/src/product_ui.css
@@ -380,6 +380,15 @@
   background: var(--bc-color-warning-soft);
 }
 
+.readiness-strip.checking {
+  background: var(--surface-subtle);
+}
+
+.readiness-strip.error {
+  border-color: var(--bc-color-danger-border);
+  background: var(--bc-color-danger-soft);
+}
+
 .readiness-dot {
   width: 9px;
   height: 9px;
@@ -390,6 +399,14 @@
 
 .readiness-strip.ready .readiness-dot {
   background: var(--bc-color-success);
+}
+
+.readiness-strip.checking .readiness-dot {
+  background: var(--bc-color-text-tertiary);
+}
+
+.readiness-strip.error .readiness-dot {
+  background: var(--bc-color-danger);
 }
 
 .product-note {
@@ -406,6 +423,159 @@
   gap: 6px;
   flex-wrap: wrap;
   justify-content: flex-end;
+}
+
+.playground-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: var(--bc-space-5);
+  align-items: start;
+}
+
+.playground-workbench {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.playground-config {
+  display: grid;
+  grid-template-columns: minmax(220px, .8fr) minmax(320px, 1.2fr);
+  gap: var(--bc-space-4);
+  padding: var(--bc-space-5);
+  border-bottom: 1px solid var(--border);
+}
+
+.playground-config .field {
+  min-width: 0;
+}
+
+.playground-secret-help {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--bc-space-3);
+  margin-top: var(--bc-space-2);
+}
+
+.playground-secret-help small {
+  line-height: 1.45;
+}
+
+.playground-conversation {
+  min-height: 360px;
+  max-height: 470px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--bc-space-3);
+  padding: var(--bc-space-5);
+  background: var(--bc-color-canvas);
+}
+
+.playground-conversation-empty {
+  min-height: 320px;
+  padding-block: var(--bc-space-8);
+}
+
+.playground-message {
+  width: fit-content;
+  max-width: min(86%, 760px);
+  padding: var(--bc-space-3) var(--bc-space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--bc-radius-lg);
+  background: var(--panel);
+}
+
+.playground-message-user {
+  align-self: flex-end;
+  background: var(--surface-subtle);
+}
+
+.playground-message-assistant {
+  align-self: flex-start;
+}
+
+.playground-message-role {
+  margin-bottom: var(--bc-space-2);
+  color: var(--bc-color-text-tertiary);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.playground-message-content {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  line-height: 1.6;
+}
+
+.playground-feedback {
+  margin: var(--bc-space-3) var(--bc-space-5) 0;
+}
+
+.playground-usage {
+  padding: var(--bc-space-3) var(--bc-space-5) 0;
+}
+
+.playground-composer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--bc-space-3);
+  padding: var(--bc-space-5);
+  border-top: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.playground-composer-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--bc-space-4);
+}
+
+.playground-composer-meta > span {
+  max-width: 620px;
+  line-height: 1.45;
+}
+
+.playground-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--bc-space-4);
+  min-width: 0;
+}
+
+.playground-route-state {
+  display: grid;
+  gap: var(--bc-space-1);
+  padding: var(--bc-space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--bc-radius-md);
+  background: var(--surface-subtle);
+}
+
+.playground-route-state.success {
+  border-color: var(--bc-color-success-border);
+  background: var(--bc-color-success-soft);
+}
+
+.playground-route-state.failed {
+  border-color: var(--bc-color-danger-border);
+  background: var(--bc-color-danger-soft);
+}
+
+.playground-route-state.checking {
+  border-color: var(--bc-color-border-strong);
+}
+
+.playground-route-state span {
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.playground-loading-state {
+  min-height: 240px;
 }
 
 @media (max-width: 1100px) {
@@ -432,6 +602,20 @@
   .provider-endpoint {
     max-width: 300px;
   }
+
+  .playground-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .playground-sidebar {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .playground-sidebar .product-note {
+    grid-column: 1 / -1;
+  }
 }
 
 @media (max-width: 760px) {
@@ -450,5 +634,20 @@
 
   .route-group-heading h3 {
     max-width: 260px;
+  }
+
+  .playground-config,
+  .playground-sidebar {
+    grid-template-columns: 1fr;
+  }
+
+  .playground-secret-help,
+  .playground-composer-meta {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .playground-message {
+    max-width: 94%;
   }
 }


### PR DESCRIPTION
## Goal

Apply the next page-by-page polish pass to Playground after Providers (#407), Models (#408), and Routes (#409).

This page is the final step of Traffic Setup, so it must behave like a truthful end-to-end acceptance surface rather than a generic chat demo.

## Stacked dependency

This PR is intentionally stacked on `agent/phase-2-routes-polish` / #409 so the Traffic Setup sequence stays ordered and the shared `product_ui.css` changes do not race each other. Once #409 lands, this PR can be retargeted to `main`.

## Important security-contract correction

The current server deliberately redacts API bearer secrets from `GET /console/api/tokens`; full secrets are disclosed only once on create/rotate. The existing Playground still called `first_active_api_token()`, which attempted to recover a usable secret from the management list.

That behavior is removed.

Playground now requires the operator to paste a previously saved BurnCloud API key into a password field for the current page session. The value is passed directly to the real data-plane chat request and is not persisted or read back from the management API.

## What changed

### Truthful readiness

- distinguish provider/API-key loading from genuine empty setup
- show a neutral checking state while prerequisite resources are unresolved
- fail closed when provider or API-key metadata cannot be loaded
- disable readiness refresh while a refresh is active
- avoid flashing false "connect provider" / "create key" empty states during load/failure

### Explicit test identity

- keep model selection limited to models exposed by active providers
- add an explicit password-style BurnCloud API-key input
- explain one-time-secret behavior and link back to API Keys
- remove `first_active_api_token()` from the routed Playground implementation

### Request truthfulness

- clear the previous route receipt before every new send
- represent the most recent test as running / succeeded / failed
- a failed request never reuses an older successful route receipt
- distinguish requested model from routed model
- map a returned channel ID to the configured provider name when possible
- if route trace headers are absent, report `Trace unavailable` instead of inferring an upstream

### Visual polish

- turn the page into a focused verification workbench with test configuration, conversation, composer, request settings, and last-test evidence
- use Phase 2 semantic tokens for all new layout/state styles
- keep state color reserved for readiness/success/failure
- add responsive single-column behavior for narrower console widths
- replace nested generic cards/terminal blocks with quieter message surfaces

### Regression contract

`check-product-ux.sh` now requires:

- explicit saved-key guidance
- password treatment for the bearer secret
- truthful readiness loading
- no `first_active_api_token` call from the active Playground page
- no reuse of a previous route receipt after a failed test

## Scope

Only:

- `crates/client/src/functional_pages/playground_live.rs`
- `crates/client/src/product_ui.css`
- `crates/client/scripts/check-product-ux.sh`

No server, router, billing, provider, database, or credential-storage behavior is changed.

## Validation

Expected repository checks:

- UI conventions
- functional console wiring
- product UX contracts
- visual system contracts
- Dioxus LiveView `cargo check`
- BurnCloud application integration `cargo check`
- Windows desktop client `cargo check`
