### PR TITLE
Polish Logs operational triage

### DIFF
--- a/crates/client/src/functional_pages/logs_full.rs
+++ b/crates/client/src/functional_pages/logs_full.rs
@@ -73,7 +73,6 @@ pub fn Logs() -> Element {
     let load_error = snapshot
         .as_ref()
         .and_then(|result| result.as_ref().err().cloned());
-    let has_load_error = load_error.is_some();
     let rows = snapshot
         .as_ref()
         .and_then(|result| result.as_ref().ok())
@@ -289,8 +288,9 @@ pub fn Logs() -> Element {
                                             let tokens = log.total_tokens();
                                             let cost = format!("${:.6}", log.cost_usd());
                                             let latency = format_latency(log.latency_ms);
+                                            let selected_log = log.clone();
                                             rsx! {
-                                                tr { key: "{log.id}-{log.request_id}", class: "logs-row", onclick: move |_| selected.set(Some(log.clone())),
+                                                tr { key: "{log.id}-{log.request_id}", class: "logs-row", onclick: move |_| selected.set(Some(selected_log.clone())),
                                                     td { class: "mono muted logs-time", title: "{timestamp}", "{timestamp}" }
                                                     td {
                                                         div { class: "two-line logs-request-cell",

--- a/crates/client/src/functional_pages/logs_full.rs
+++ b/crates/client/src/functional_pages/logs_full.rs
@@ -1,6 +1,7 @@
 use dioxus::prelude::*;
 
 use crate::{
+    app::Route,
     components::{Badge, Drawer, Icon},
     observability::{full_logs, FullRouterLog},
 };
@@ -16,10 +17,18 @@ fn status_tone(status: &str) -> &'static str {
 
 fn detail_stat(label: &str, value: String) -> Element {
     rsx! {
-        div {
+        div { class: "logs-detail-stat",
             span { class: "tiny subtle", "{label}" }
             div { class: "small strong mono", "{value}" }
         }
+    }
+}
+
+fn format_latency(latency_ms: i64) -> String {
+    if latency_ms >= 1_000 {
+        format!("{:.2}s", latency_ms as f64 / 1_000.0)
+    } else {
+        format!("{latency_ms}ms")
     }
 }
 
@@ -61,8 +70,15 @@ pub fn Logs() -> Element {
 
     let snapshot = resource.read().clone();
     let loading = snapshot.is_none();
-    let load_error = snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
-    let rows = snapshot.and_then(Result::ok).unwrap_or_default();
+    let load_error = snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().err().cloned());
+    let has_load_error = load_error.is_some();
+    let rows = snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().ok())
+        .cloned()
+        .unwrap_or_default();
     let search = query().to_lowercase();
     let filter_value = filter();
 
@@ -91,61 +107,97 @@ pub fn Logs() -> Element {
     } else {
         rows.iter().map(|log| log.latency_ms).sum::<i64>() / rows.len() as i64
     };
+    let avg_latency_text = format_latency(avg_latency);
     let failure_rate = if rows.is_empty() {
         0.0
     } else {
         failures as f64 * 100.0 / rows.len() as f64
     };
     let failure_rate_text = format!("{failure_rate:.1}% of loaded requests");
+    let fallback_rate = if rows.is_empty() {
+        0.0
+    } else {
+        fallback as f64 * 100.0 / rows.len() as f64
+    };
+    let fallback_rate_text = format!("{fallback_rate:.1}% used fallback");
     let total_cost = rows.iter().map(FullRouterLog::cost_usd).sum::<f64>();
     let total_cost_text = format!("${total_cost:.4}");
     let visible_count = visible.len();
     let row_count = rows.len();
+    let success_rate = if rows.is_empty() {
+        0.0
+    } else {
+        success as f64 * 100.0 / rows.len() as f64
+    };
+    let success_rate_text = format!("{success_rate:.1}% success");
+    let health_class = if failures > 0 {
+        "readiness-strip logs-health-error logs-health-strip"
+    } else if fallback > 0 {
+        "readiness-strip blocked logs-health-strip"
+    } else {
+        "readiness-strip ready logs-health-strip"
+    };
+    let health_title = if failures > 0 {
+        "Recent request failures need attention"
+    } else if fallback > 0 {
+        "Traffic is succeeding, but fallback routes are active"
+    } else {
+        "Loaded request activity is healthy"
+    };
+    let health_copy = if failures > 0 {
+        format!("{failures} of {row_count} loaded requests ended in Error or Timeout. Filter failures first, then inspect routing and error metadata.")
+    } else if fallback > 0 {
+        format!("{fallback} of {row_count} loaded requests used fallback routing. Requests completed, but primary-route resilience should be reviewed.")
+    } else {
+        format!("All {row_count} loaded requests completed successfully without an observed fallback, timeout, or router error.")
+    };
 
     rsx! {
         div { class: "page",
-            div { class: "page-header",
+            div { class: "page-header logs-page-header",
                 div {
                     h2 { class: "page-title", "Logs" }
                     p { class: "page-subtitle", "Find failed, slow, or fallback requests first, then inspect the exact routing and usage metadata behind each request." }
                 }
-                div { class: "header-actions",
-                    div { class: "search-field", style: "width:300px",
+                div { class: "header-actions logs-toolbar",
+                    div { class: "search-field logs-search-field",
                         Icon { name: "search" }
-                        input { class: "input", placeholder: "Request, model, upstream, user…", value: "{query}", oninput: move |event| query.set(event.value()) }
+                        input {
+                            class: "input",
+                            placeholder: "Request, model, upstream, user…",
+                            value: "{query}",
+                            disabled: loading,
+                            oninput: move |event| query.set(event.value())
+                        }
                     }
-                    select { class: "select", value: "{filter}", onchange: move |event| filter.set(event.value()),
+                    select {
+                        class: "select logs-outcome-filter",
+                        value: "{filter}",
+                        disabled: loading,
+                        onchange: move |event| filter.set(event.value()),
                         option { value: "all", "All outcomes" }
                         option { value: "success", "Success" }
                         option { value: "fallback", "Fallback" }
                         option { value: "timeout", "Timeout" }
                         option { value: "error", "Error" }
                     }
-                    button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
-                }
-            }
-
-            div { class: "metrics",
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Requests Loaded" } span { class: "metric-value", "{row_count}" } span { class: "metric-note", "latest router activity" } }
-                    div { class: "metric-icon tone-blue", Icon { name: "logs" } }
-                }
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Failures" } span { class: "metric-value", "{failures}" } span { class: "metric-note", "{failure_rate_text}" } }
-                    div { class: "metric-icon tone-red", Icon { name: "shield" } }
-                }
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Fallbacks" } span { class: "metric-value", "{fallback}" } span { class: "metric-note", "alternate route used" } }
-                    div { class: "metric-icon tone-amber", Icon { name: "routes" } }
-                }
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Loaded Cost" } span { class: "metric-value", "{total_cost_text}" } span { class: "metric-note mono", "avg latency {avg_latency}ms" } }
-                    div { class: "metric-icon tone-purple", Icon { name: "dollar" } }
+                    button {
+                        class: "button button-secondary",
+                        disabled: loading,
+                        onclick: move |_| resource.restart(),
+                        if loading { "Refreshing…" } else { "Refresh" }
+                    }
                 }
             }
 
             if loading {
-                div { class: "card card-pad", "Loading request logs…" }
+                div { class: "card product-empty logs-loading-state",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "logs" } }
+                        h3 { "Loading request activity" }
+                        p { "Reading recent router outcomes, upstream decisions, latency, usage, and cost before showing operational conclusions." }
+                    }
+                }
             } else if let Some(message) = load_error {
                 div { class: "card card-pad stack",
                     strong { class: "danger", "Request logs could not be loaded" }
@@ -153,23 +205,70 @@ pub fn Logs() -> Element {
                     button { class: "button button-primary", onclick: move |_| resource.restart(), "Retry" }
                 }
             } else {
+                div { class: "metrics",
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Failures" } span { class: "metric-value", "{failures}" } span { class: "metric-note", "{failure_rate_text}" } }
+                        div { class: if failures > 0 { "metric-icon tone-red" } else { "metric-icon tone-gray" }, Icon { name: "shield" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Fallbacks" } span { class: "metric-value", "{fallback}" } span { class: "metric-note", "{fallback_rate_text}" } }
+                        div { class: if fallback > 0 { "metric-icon tone-amber" } else { "metric-icon tone-gray" }, Icon { name: "routes" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Avg Latency" } span { class: "metric-value", "{avg_latency_text}" } span { class: "metric-note", "across loaded requests" } }
+                        div { class: "metric-icon tone-gray", Icon { name: "activity" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy", span { class: "metric-label", "Loaded Cost" } span { class: "metric-value", "{total_cost_text}" } span { class: "metric-note", "{row_count} request records" } }
+                        div { class: "metric-icon tone-gray", Icon { name: "dollar" } }
+                    }
+                }
+
+                if !rows.is_empty() {
+                    div { class: "{health_class}",
+                        span { class: "readiness-dot" }
+                        div { class: "logs-health-copy",
+                            strong { "{health_title}" }
+                            span { class: "small muted", "{health_copy}" }
+                        }
+                        span { class: "badge badge-neutral logs-health-meta", "{success_rate_text}" }
+                    }
+                }
+
                 div { class: "card table-card",
                     div { class: "card-pad product-section-head",
                         div {
                             h3 { "Request activity" }
-                            p { "Showing {visible_count} of {row_count} loaded requests. Select a row for routing and cost detail." }
+                            p { "Showing {visible_count} of {row_count} loaded requests. Select a row for routing, usage, and cost detail." }
                         }
                     }
-                    if visible.is_empty() {
-                        div { class: "product-empty", style: "min-height:170px",
+                    if rows.is_empty() {
+                        div { class: "product-empty logs-empty-state",
+                            div { class: "product-empty-inner",
+                                div { class: "product-empty-icon", Icon { name: "logs" } }
+                                h3 { "No request activity yet" }
+                                p { "No router request records are loaded for this environment. Run a controlled end-to-end test in Playground to create the first traceable request." }
+                                Link { class: "button button-primary", to: Route::Playground {}, "Open Playground" }
+                            }
+                        }
+                    } else if visible.is_empty() {
+                        div { class: "product-empty logs-empty-state",
                             div { class: "product-empty-inner",
                                 h3 { "No requests match this view" }
-                                p { "Change the outcome filter or search text. If the environment has no traffic yet, use Playground for a controlled test." }
+                                p { "Change the outcome filter or search text to return to the loaded request activity." }
+                                button {
+                                    class: "button button-secondary",
+                                    onclick: move |_| {
+                                        query.set(String::new());
+                                        filter.set("all".to_string());
+                                    },
+                                    "Clear filters"
+                                }
                             }
                         }
                     } else {
                         div { class: "table-wrap",
-                            table { class: "data-table",
+                            table { class: "data-table logs-table",
                                 thead { tr {
                                     th { "Time" }
                                     th { "Request" }
@@ -189,23 +288,24 @@ pub fn Logs() -> Element {
                                             let user = log.user_id.clone().unwrap_or_else(|| "anonymous".to_string());
                                             let tokens = log.total_tokens();
                                             let cost = format!("${:.6}", log.cost_usd());
+                                            let latency = format_latency(log.latency_ms);
                                             rsx! {
-                                                tr { key: "{log.id}-{log.request_id}", style: "cursor:pointer", onclick: move |_| selected.set(Some(log.clone())),
-                                                    td { class: "mono muted", "{timestamp}" }
+                                                tr { key: "{log.id}-{log.request_id}", class: "logs-row", onclick: move |_| selected.set(Some(log.clone())),
+                                                    td { class: "mono muted logs-time", title: "{timestamp}", "{timestamp}" }
                                                     td {
-                                                        div { class: "two-line",
-                                                            strong { class: "mono table-primary", "{log.request_id}" }
-                                                            small { class: "muted", "{user} • {log.path}" }
+                                                        div { class: "two-line logs-request-cell",
+                                                            strong { class: "mono table-primary", title: "{log.request_id}", "{log.request_id}" }
+                                                            small { class: "muted", title: "{user} • {log.path}", "{user} • {log.path}" }
                                                         }
                                                     }
                                                     td {
-                                                        div { class: "two-line",
-                                                            strong { class: "mono", "{model}" }
-                                                            small { class: "muted", "{upstream}" }
+                                                        div { class: "two-line logs-route-cell",
+                                                            strong { class: "mono", title: "{model}", "{model}" }
+                                                            small { class: "muted", title: "{upstream}", "{upstream}" }
                                                         }
                                                     }
                                                     td { Badge { text: status, tone: status_tone(status) } }
-                                                    td { class: "right tabular", "{log.latency_ms}ms" }
+                                                    td { class: "right tabular", "{latency}" }
                                                     td { class: "right tabular", "{tokens}" }
                                                     td { class: "right strong tabular", "{cost}" }
                                                 }
@@ -235,30 +335,45 @@ pub fn Logs() -> Element {
                         let cost_status = log.cost_status.clone().unwrap_or_else(|| "-".to_string());
                         let pricing = log.pricing_region.clone().unwrap_or_else(|| "-".to_string());
                         let total_cost = format!("${:.9}", log.cost_usd());
-                        let is_problem = log.status_code >= 400 || log.status_label() != "Success";
+                        let detail_status_class = if status == "Error" || status == "Timeout" {
+                            "readiness-strip logs-health-error logs-detail-status"
+                        } else if status == "Fallback" {
+                            "readiness-strip blocked logs-detail-status"
+                        } else {
+                            "readiness-strip ready logs-detail-status"
+                        };
+                        let detail_status_copy = if status == "Error" || status == "Timeout" {
+                            "The request did not complete normally. Start with Outcome, then inspect routing and error metadata."
+                        } else if status == "Fallback" {
+                            "The request completed through a fallback route. Inspect the routing decision and upstream used."
+                        } else {
+                            "The request completed without an observed router error or fallback."
+                        };
                         rsx! {
                             div { class: "stack-lg",
-                                div { class: if is_problem { "readiness-strip blocked" } else { "readiness-strip ready" },
+                                div { class: "{detail_status_class}",
                                     span { class: "readiness-dot" }
-                                    strong { "{status}" }
-                                    span { class: "muted", if is_problem { "Review routing and error metadata below." } else { "Request completed without an observed router error." } }
+                                    div { class: "logs-health-copy",
+                                        strong { "{status}" }
+                                        span { class: "small muted", "{detail_status_copy}" }
+                                    }
                                 }
 
                                 div { class: "card card-pad stack",
                                     div { class: "product-section-head", div { h3 { "Outcome" } p { "The first facts needed to understand this request." } } }
-                                    div { class: "grid-2",
+                                    div { class: "grid-2 logs-detail-grid",
                                         {detail_stat("Request ID", log.request_id.clone())}
                                         {detail_stat("HTTP Status", log.status_code.to_string())}
                                         {detail_stat("Model", model)}
                                         {detail_stat("Upstream", upstream)}
-                                        {detail_stat("Latency", format!("{}ms", log.latency_ms))}
+                                        {detail_stat("Latency", format_latency(log.latency_ms))}
                                         {detail_stat("Error Type", error_type)}
                                     }
                                 }
 
                                 div { class: "card card-pad stack",
                                     div { class: "product-section-head", div { h3 { "Routing" } p { "How BurnCloud classified and routed the request." } } }
-                                    div { class: "grid-2",
+                                    div { class: "grid-2 logs-detail-grid",
                                         {detail_stat("User", user)}
                                         {detail_stat("Path", log.path.clone())}
                                         {detail_stat("Layer Decision", decision)}
@@ -270,7 +385,7 @@ pub fn Logs() -> Element {
 
                                 div { class: "card card-pad stack",
                                     div { class: "product-section-head", div { h3 { "Usage" } p { "Only token types that were actually used are shown." } } }
-                                    div { class: "grid-2",
+                                    div { class: "grid-2 logs-detail-grid",
                                         for (label, value) in token_breakdown(&log) {
                                             if value != 0 { {detail_stat(label, value.to_string())} }
                                         }
@@ -281,7 +396,7 @@ pub fn Logs() -> Element {
                                 div { class: "card card-pad stack",
                                     div { class: "product-section-head", div { h3 { "Cost" } p { "Available component costs plus the stored request total." } } }
                                     {detail_stat("Total Cost", total_cost)}
-                                    div { class: "grid-2",
+                                    div { class: "grid-2 logs-detail-grid",
                                         for (label, value) in cost_breakdown(&log) {
                                             if value != 0 {
                                                 {detail_stat(label, format!("${:.9}", FullRouterLog::cost_component_usd(value)))}

--- a/crates/client/src/product_ui.css
+++ b/crates/client/src/product_ui.css
@@ -475,6 +475,94 @@
   white-space: nowrap;
 }
 
+.logs-toolbar {
+  flex-wrap: wrap;
+}
+
+.logs-search-field {
+  width: min(300px, 34vw);
+}
+
+.logs-outcome-filter {
+  width: auto;
+  min-width: 148px;
+}
+
+.logs-loading-state {
+  min-height: 180px;
+}
+
+.logs-health-strip,
+.logs-detail-status {
+  min-height: 58px;
+  padding: 12px 16px;
+}
+
+.logs-health-error {
+  border-color: var(--bc-color-danger-border);
+  background: var(--bc-color-danger-soft);
+}
+
+.logs-health-error .readiness-dot {
+  background: var(--bc-color-danger);
+}
+
+.logs-health-copy {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  gap: 2px;
+}
+
+.logs-health-meta {
+  margin-left: auto;
+}
+
+.logs-empty-state {
+  min-height: 190px;
+}
+
+.logs-row {
+  cursor: pointer;
+}
+
+.logs-time {
+  max-width: 170px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.logs-request-cell,
+.logs-route-cell {
+  min-width: 0;
+  max-width: 280px;
+}
+
+.logs-request-cell strong,
+.logs-request-cell small,
+.logs-route-cell strong,
+.logs-route-cell small {
+  display: block;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.logs-detail-grid {
+  gap: var(--bc-space-4);
+}
+
+.logs-detail-stat {
+  min-width: 0;
+}
+
+.logs-detail-stat > div {
+  margin-top: var(--bc-space-1);
+  overflow-wrap: anywhere;
+}
+
 .form-section {
   display: flex;
   flex-direction: column;
@@ -581,13 +669,19 @@
   .playground-sidebar {
     position: static;
   }
+
+  .logs-search-field {
+    width: 240px;
+  }
 }
 
 @media (max-width: 760px) {
   .provider-health-strip,
   .model-health-strip,
   .route-health-strip,
-  .playground-test-status {
+  .playground-test-status,
+  .logs-health-strip,
+  .logs-detail-status {
     align-items: flex-start;
     flex-wrap: wrap;
   }
@@ -595,7 +689,8 @@
   .provider-health-meta,
   .model-health-meta,
   .route-health-meta,
-  .playground-status-meta {
+  .playground-status-meta,
+  .logs-health-meta {
     margin-left: 19px;
   }
 
@@ -611,6 +706,17 @@
 
   .playground-toolbar .button,
   .playground-composer-footer .button {
+    width: 100%;
+  }
+
+  .logs-toolbar {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .logs-search-field,
+  .logs-outcome-filter,
+  .logs-toolbar .button {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Goal

Apply the Phase 2 Observe polish pass to Logs after completing Traffic Setup through Playground (#407–#410).

Logs should answer the operator's first questions in order: did requests fail, did routing fall back, how slow were they, what did they cost, and which upstream actually handled a specific request?

## What changed

### Truthful loading

- stop rendering zero-valued operational KPIs before request data has loaded
- show a dedicated loading conclusion while router activity is being read
- disable search/filter/refresh while the resource is still loading

### Triage-first KPIs

Replace the lower-value `Requests Loaded` KPI with the operational priority order:

- Failures
- Fallbacks
- Avg Latency
- Loaded Cost

Request count remains visible in the activity section and cost context.

### Overall operational conclusion

- failures present → explicit failure attention state
- no failures but fallbacks present → traffic succeeds, but fallback routing is active
- no failures/fallbacks → loaded request activity is healthy
- include loaded success rate as supporting context

### Request activity readability

- keep chronology intact rather than artificially reordering requests by severity
- add safe truncation/title preservation for timestamps, request IDs, user/path, model, and upstream
- format latency as milliseconds or seconds depending on magnitude
- make rows explicitly interactive without inline cursor styling
- provide a dedicated no-traffic state that links to Playground
- provide a different no-filter-match state with one-click filter reset

### Request detail semantics

- Error/Timeout use a failure state and direct the operator to Outcome first
- Fallback is treated as a completed request with alternate routing, not as a generic error
- Success states explicitly say no router error or fallback was observed
- retain the existing Outcome → Routing → Usage → Cost order
- keep prompt/body privacy truthful: only persisted operational metadata is shown

### Visual hierarchy

- move Logs toolbar/table/detail sizing and truncation into `product_ui.css`
- reserve red for actual Error/Timeout state and amber for fallback attention
- keep latency/cost facts neutral rather than decorative

## Validation

Expected repository checks:

- UI conventions
- functional console wiring
- product UX contracts
- visual system contracts
- Dioxus LiveView `cargo check`
- BurnCloud application integration `cargo check`
- Windows desktop client `cargo check`

## Scope

Only:

- `crates/client/src/functional_pages/logs_full.rs`
- `crates/client/src/product_ui.css`
