### PR TITLE
Polish Evaluation observed evidence

### DIFF
--- a/crates/client/src/functional_pages/analytics_full.rs
+++ b/crates/client/src/functional_pages/analytics_full.rs
@@ -223,7 +223,7 @@ pub fn Evaluation() -> Element {
                     div { class: "card card-pad stack",
                         div { class: "product-section-head",
                             div {
-                                h3 { "Observed signals" }
+                                h3 { "Operational attention" }
                                 p { "These are facts about the loaded traffic sample. Configuration redundancy must be verified separately in Models and Routes." }
                             }
                         }

--- a/crates/client/src/functional_pages/analytics_full.rs
+++ b/crates/client/src/functional_pages/analytics_full.rs
@@ -20,15 +20,38 @@ fn compact(n: i64) -> String {
     }
 }
 
+fn format_latency(latency_ms: i64) -> String {
+    if latency_ms >= 1_000 {
+        format!("{:.2}s", latency_ms as f64 / 1_000.0)
+    } else {
+        format!("{latency_ms}ms")
+    }
+}
+
 #[derive(Default, Clone)]
 struct ModelEval {
     requests: i64,
     success: i64,
+    fallbacks: i64,
     latency_sum: i64,
     tokens: i64,
     cost: f64,
     upstreams: BTreeSet<String>,
     multimodal_requests: i64,
+}
+
+impl ModelEval {
+    fn failures(&self) -> i64 {
+        self.requests.saturating_sub(self.success)
+    }
+
+    fn avg_latency(&self) -> i64 {
+        if self.requests == 0 {
+            0
+        } else {
+            self.latency_sum / self.requests
+        }
+    }
 }
 
 #[component]
@@ -43,9 +66,13 @@ pub fn Evaluation() -> Element {
     for log in &logs {
         let model_name = log.model.clone().unwrap_or_else(|| "unattributed".to_string());
         let entry = models.entry(model_name).or_default();
+        let outcome = log.status_label();
         entry.requests += 1;
-        if log.status_code < 400 {
+        if outcome == "Success" || outcome == "Fallback" {
             entry.success += 1;
+        }
+        if outcome == "Fallback" {
+            entry.fallbacks += 1;
         }
         entry.latency_sum += log.latency_ms;
         entry.tokens += log.total_tokens();
@@ -64,7 +91,11 @@ pub fn Evaluation() -> Element {
     }
 
     let total_requests = logs.len() as i64;
-    let successful_requests = logs.iter().filter(|log| log.status_code < 400).count() as i64;
+    let successful_requests = logs
+        .iter()
+        .filter(|log| matches!(log.status_label(), "Success" | "Fallback"))
+        .count() as i64;
+    let fallback_requests = logs.iter().filter(|log| log.status_label() == "Fallback").count() as i64;
     let total_latency = logs.iter().map(|log| log.latency_ms).sum::<i64>();
     let overall_success = if total_requests == 0 {
         0.0
@@ -73,81 +104,148 @@ pub fn Evaluation() -> Element {
     };
     let overall_success_text = format!("{overall_success:.1}%");
     let avg_latency = if total_requests == 0 { 0 } else { total_latency / total_requests };
-    let avg_latency_text = format!("{avg_latency}ms");
+    let avg_latency_text = format_latency(avg_latency);
     let model_count = models.len();
-    let models_with_errors = models.values().filter(|model| model.success < model.requests).count();
-    let single_upstream_models = models.values().filter(|model| model.upstreams.len() <= 1).count();
+    let models_with_errors = models.values().filter(|model| model.failures() > 0).count();
+    let models_with_fallbacks = models.values().filter(|model| model.fallbacks > 0).count();
+    let one_or_fewer_observed_upstreams = models.values().filter(|model| model.upstreams.len() <= 1).count();
+
+    let sample_class = if models_with_errors > 0 {
+        "readiness-strip danger-zone"
+    } else if fallback_requests > 0 {
+        "readiness-strip blocked"
+    } else {
+        "readiness-strip ready"
+    };
+    let (sample_badge_class, sample_badge_text, sample_title, sample_copy) = if models_with_errors > 0 {
+        (
+            "badge badge-error",
+            "FAILURES OBSERVED",
+            "The loaded traffic sample contains model request failures",
+            format!("{models_with_errors} of {model_count} observed models have at least one failed request. Start with those rows, then inspect the underlying requests in Logs."),
+        )
+    } else if fallback_requests > 0 {
+        (
+            "badge badge-warning",
+            "FALLBACK OBSERVED",
+            "The loaded sample succeeded, but fallback routing was used",
+            format!("{fallback_requests} of {total_requests} observed requests completed through fallback routing. This is operational evidence about the sample, not a model-quality score."),
+        )
+    } else {
+        (
+            "badge badge-success",
+            "STABLE SAMPLE",
+            "No request failures or fallbacks were observed in the loaded sample",
+            format!("{total_requests} observed requests across {model_count} models completed without a router failure or fallback in this sample."),
+        )
+    };
+
+    let mut model_rows = models.into_iter().collect::<Vec<_>>();
+    model_rows.sort_by(|(left_name, left), (right_name, right)| {
+        right
+            .failures()
+            .cmp(&left.failures())
+            .then_with(|| right.fallbacks.cmp(&left.fallbacks))
+            .then_with(|| right.avg_latency().cmp(&left.avg_latency()))
+            .then_with(|| left_name.cmp(right_name))
+    });
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
                     h2 { class: "page-title", "Evaluation" }
-                    p { class: "page-subtitle", "Compare observed model reliability and latency from real routed traffic. This is operational evaluation, not synthetic model-quality scoring." }
+                    p { class: "page-subtitle", "Compare observed reliability, fallback behavior, latency, usage, and cost from real routed traffic. This is operational evidence, not synthetic model-quality scoring." }
                 }
                 div { class: "header-actions",
-                    button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
+                    button {
+                        class: "button button-secondary",
+                        disabled: loading,
+                        onclick: move |_| resource.restart(),
+                        if loading { "Refreshing…" } else { "Refresh" }
+                    }
                     Link { class: "button button-secondary", to: Route::Logs {}, "Inspect Logs" }
                 }
             }
 
             if loading {
-                div { class: "card card-pad", "Loading operational evaluation…" }
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "chart" } }
+                        h3 { "Building operational evaluation" }
+                        p { "Reading up to 500 recent router-log records before calculating reliability, fallback, latency, usage, and cost observations." }
+                    }
+                }
             } else if let Some(message) = load_error {
                 div { class: "card card-pad stack",
                     strong { class: "danger", "Evaluation data could not be loaded" }
                     code { class: "terminal", "{message}" }
                     button { class: "button button-primary", onclick: move |_| resource.restart(), "Retry" }
                 }
-            } else if models.is_empty() {
+            } else if model_rows.is_empty() {
                 div { class: "card product-empty",
                     div { class: "product-empty-inner",
                         div { class: "product-empty-icon", Icon { name: "chart" } }
                         h3 { "No model traffic to evaluate yet" }
-                        p { "Evaluation is built from observed router logs. Send representative requests through Playground or production clients first." }
+                        p { "Evaluation is built only from observed router logs. Send representative requests through Playground or production clients first." }
                         Link { class: "button button-primary", to: Route::Playground {}, "Run a Test Request" }
                     }
                 }
             } else {
                 div { class: "metrics",
                     div { class: "card metric",
-                        div { class: "metric-copy", span { class: "metric-label", "Observed Requests" } span { class: "metric-value", "{total_requests}" } span { class: "metric-note", "latest evaluation sample" } }
-                        div { class: "metric-icon tone-blue", Icon { name: "activity" } }
+                        div { class: "metric-copy", span { class: "metric-label", "Observed Requests" } span { class: "metric-value", "{total_requests}" } span { class: "metric-note", "up to 500 latest records" } }
+                        div { class: "metric-icon tone-gray", Icon { name: "activity" } }
                     }
                     div { class: "card metric",
-                        div { class: "metric-copy", span { class: "metric-label", "Success Rate" } span { class: "metric-value", "{overall_success_text}" } span { class: "metric-note", "HTTP success across sample" } }
-                        div { class: "metric-icon tone-green", Icon { name: "shield" } }
+                        div { class: "metric-copy", span { class: "metric-label", "Success Rate" } span { class: "metric-value", "{overall_success_text}" } span { class: "metric-note", "Success + Fallback outcomes" } }
+                        div { class: if models_with_errors == 0 { "metric-icon tone-green" } else { "metric-icon tone-red" }, Icon { name: "shield" } }
                     }
                     div { class: "card metric",
                         div { class: "metric-copy", span { class: "metric-label", "Average Latency" } span { class: "metric-value", "{avg_latency_text}" } span { class: "metric-note", "end-to-end observed" } }
-                        div { class: "metric-icon tone-purple", Icon { name: "chart" } }
+                        div { class: "metric-icon tone-gray", Icon { name: "chart" } }
                     }
                     div { class: "card metric",
                         div { class: "metric-copy", span { class: "metric-label", "Models With Errors" } span { class: "metric-value", "{models_with_errors}" } span { class: "metric-note", "of {model_count} observed models" } }
-                        div { class: "metric-icon tone-amber", Icon { name: "models" } }
+                        div { class: if models_with_errors > 0 { "metric-icon tone-red" } else { "metric-icon tone-gray" }, Icon { name: "models" } }
                     }
                 }
 
-                if models_with_errors > 0 || single_upstream_models > 0 {
+                div { class: "{sample_class}",
+                    span { class: "{sample_badge_class}", "{sample_badge_text}" }
+                    div { class: "stack", style: "gap:2px;flex:1;min-width:0",
+                        strong { "{sample_title}" }
+                        span { class: "small muted", "{sample_copy}" }
+                    }
+                }
+
+                if models_with_errors > 0 || models_with_fallbacks > 0 || one_or_fewer_observed_upstreams > 0 {
                     div { class: "card card-pad stack",
                         div { class: "product-section-head",
                             div {
-                                h3 { "Operational attention" }
-                                p { "These signals do not prove model quality, but they indicate where routing or upstream reliability deserves investigation." }
+                                h3 { "Observed signals" }
+                                p { "These are facts about the loaded traffic sample. Configuration redundancy must be verified separately in Models and Routes." }
                             }
                         }
                         if models_with_errors > 0 {
-                            div { class: "readiness-strip blocked",
-                                span { class: "readiness-dot" }
+                            div { class: "readiness-strip danger-zone",
+                                span { class: "badge badge-error", "FAILURES" }
                                 strong { "{models_with_errors} models have at least one failed request in the loaded sample." }
                                 Link { class: "button button-ghost button-sm", to: Route::Logs {}, "Inspect failures" }
                             }
                         }
-                        if single_upstream_models > 0 {
+                        if models_with_fallbacks > 0 {
                             div { class: "readiness-strip blocked",
-                                span { class: "readiness-dot" }
-                                strong { "{single_upstream_models} observed models were served by one or fewer upstreams in this sample." }
-                                Link { class: "button button-ghost button-sm", to: Route::Models {}, "Review redundancy" }
+                                span { class: "badge badge-warning", "FALLBACK" }
+                                strong { "{models_with_fallbacks} models used fallback routing at least once in the loaded sample." }
+                                Link { class: "button button-ghost button-sm", to: Route::Logs {}, "Inspect routing" }
+                            }
+                        }
+                        if one_or_fewer_observed_upstreams > 0 {
+                            div { class: "readiness-strip",
+                                span { class: "badge badge-neutral", "SAMPLE ONLY" }
+                                strong { "{one_or_fewer_observed_upstreams} models were observed on one or fewer upstream IDs in this sample; this does not prove configured single-upstream routing." }
+                                Link { class: "button button-ghost button-sm", to: Route::Models {}, "Check configured resilience" }
                             }
                         }
                     }
@@ -156,57 +254,70 @@ pub fn Evaluation() -> Element {
                 div { class: "card table-card",
                     div { class: "card-pad product-section-head",
                         div {
-                            h3 { "Model performance" }
-                            p { "Use this table to identify failures, slow models, high-cost models, and single-upstream observations." }
+                            h3 { "Observed model performance" }
+                            p { "Rows are prioritized by failures, then fallback usage, then average latency. Upstream counts describe only what appeared in this sample." }
                         }
                     }
                     div { class: "table-wrap",
                         table { class: "data-table",
                             thead { tr {
                                 th { "Model" }
-                                th { "Health" }
+                                th { "Signal" }
                                 th { class: "right", "Requests" }
                                 th { class: "right", "Success" }
+                                th { class: "right", "Fallbacks" }
                                 th { class: "right", "Avg Latency" }
                                 th { class: "right", "Tokens" }
-                                th { class: "right", "Multimodal" }
                                 th { class: "right", "Cost" }
-                                th { "Upstreams" }
+                                th { "Observed Upstreams" }
                             } }
                             tbody {
-                                for (model_name, evaluation) in models {
+                                for (model_name, evaluation) in model_rows {
                                     {
-                                        let failures = evaluation.requests - evaluation.success;
+                                        let failures = evaluation.failures();
                                         let success_rate = if evaluation.requests == 0 {
                                             0.0
                                         } else {
                                             evaluation.success as f64 * 100.0 / evaluation.requests as f64
                                         };
                                         let success_text = format!("{success_rate:.1}%");
-                                        let avg_latency = if evaluation.requests == 0 { 0 } else { evaluation.latency_sum / evaluation.requests };
-                                        let latency_text = format!("{avg_latency}ms");
+                                        let latency_text = format_latency(evaluation.avg_latency());
                                         let token_text = compact(evaluation.tokens);
                                         let cost_text = format!("${:.6}", evaluation.cost);
                                         let upstream_count = evaluation.upstreams.len();
-                                        let upstream_text = evaluation.upstreams.into_iter().collect::<Vec<_>>().join(", ");
-                                        let (health_class, health_text) = if failures > 0 {
+                                        let upstream_text = if upstream_count == 0 {
+                                            "No upstream ID recorded".to_string()
+                                        } else {
+                                            evaluation.upstreams.into_iter().collect::<Vec<_>>().join(", ")
+                                        };
+                                        let upstream_count_text = if upstream_count == 1 {
+                                            "1 observed".to_string()
+                                        } else {
+                                            format!("{upstream_count} observed")
+                                        };
+                                        let (signal_class, signal_text) = if failures > 0 {
                                             ("badge badge-error", "Errors observed")
-                                        } else if upstream_count <= 1 {
-                                            ("badge badge-warning", "Single upstream")
+                                        } else if evaluation.fallbacks > 0 {
+                                            ("badge badge-warning", "Fallback observed")
                                         } else {
                                             ("badge badge-success", "Stable sample")
                                         };
                                         rsx! {
                                             tr { key: "{model_name}",
-                                                td { class: "table-primary mono", "{model_name}" }
-                                                td { span { class: "{health_class}", "{health_text}" } }
+                                                td { class: "table-primary mono", title: "{model_name}", "{model_name}" }
+                                                td { span { class: "{signal_class}", "{signal_text}" } }
                                                 td { class: "right tabular", "{evaluation.requests}" }
                                                 td { class: "right strong tabular", "{success_text}" }
+                                                td { class: "right tabular", "{evaluation.fallbacks}" }
                                                 td { class: "right tabular", "{latency_text}" }
                                                 td { class: "right tabular", "{token_text}" }
-                                                td { class: "right tabular", "{evaluation.multimodal_requests}" }
                                                 td { class: "right tabular", "{cost_text}" }
-                                                td { class: "muted", "{upstream_text}" }
+                                                td {
+                                                    div { class: "two-line",
+                                                        strong { class: "small", "{upstream_count_text}" }
+                                                        small { class: "muted", title: "{upstream_text}", "{upstream_text}" }
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -216,7 +327,7 @@ pub fn Evaluation() -> Element {
                     }
                 }
 
-                div { class: "product-note", "Evaluation uses observed production/request-log data. Accuracy, hallucination rate, task quality, and benchmark scores require a dedicated evaluation backend and are intentionally not inferred here." }
+                div { class: "product-note", "Evaluation uses observed request-log data only. Accuracy, hallucination rate, task quality, benchmark scores, and configured failover capacity require different evidence and are intentionally not inferred here." }
             }
         }
     }


### PR DESCRIPTION
## Goal

Apply the Phase 2 Observe polish pass to Evaluation after Logs (#412).

Evaluation must summarize what recent routed traffic actually proves without turning request-log observations into model-quality scores or configuration claims.

## What changed

### Evidence boundary

- explicitly frame Evaluation as observed router-log evidence
- stop labeling a model as configured `Single upstream` merely because only one upstream ID appeared in the loaded traffic sample
- rename that signal to observed upstream diversity and state that configured redundancy must be verified in Models/Routes
- preserve the existing guardrail against inferring accuracy, hallucination, benchmark, or task-quality scores

### Outcome semantics

- use BurnCloud's persisted outcome classification rather than raw `status_code < 400`
- count `Success` and `Fallback` as completed requests
- track fallback observations separately per model and across the sample

### Operational conclusion

- failures observed → failure conclusion and Logs-first investigation
- no failures but fallback observed → successful sample with fallback-routing evidence
- neither failures nor fallback → stable loaded sample

### KPI hierarchy

Keep the product contract:

- Observed Requests
- Success Rate
- Average Latency
- Models With Errors

Neutral facts remain neutral; state colors are reserved for actual success/error evidence.

### Model prioritization

Model rows are sorted by:

1. failures
2. fallback observations
3. average latency
4. model name

This puts the most operationally actionable evidence first instead of alphabetical order.

### Table semantics

- `Health` becomes `Signal`
- distinguish Errors observed / Fallback observed / Stable sample
- add an explicit Fallbacks column
- rename Upstreams to `Observed Upstreams`
- show upstream count plus the IDs actually present in the sample
- use seconds for latency >= 1s

### Truthful loading

- use a real loading empty state before any evaluation conclusions are shown
- disable Refresh while the sample is loading

## Validation

Expected repository checks:

- UI conventions
- functional console wiring
- product UX contracts
- visual system contracts
- Dioxus LiveView `cargo check`
- BurnCloud application integration `cargo check`
- Windows desktop client `cargo check`

## Scope

Only `crates/client/src/functional_pages/analytics_full.rs`.
