### PR TITLE
Polish Customers account and funding workflow

### DIFF
--- a/crates/client/scripts/check-product-ux.sh
+++ b/crates/client/scripts/check-product-ux.sh
@@ -85,6 +85,16 @@ require 'Send Test Request' src/functional_pages/playground_live.rs
 # Customers and staff have separate product responsibilities.
 require 'Manage business accounts' src/critical_pages/customers_portable.rs
 require '!is_staff_role(&user.role)' src/critical_pages/customers_portable.rs
+require 'Loading customer accounts' src/critical_pages/customers_portable.rs
+require 'Default Status' src/critical_pages/customers_portable.rs
+require 'Status is server metadata.' src/critical_pages/customers_portable.rs
+require 'parse_positive_amount_nano' src/critical_pages/customers_portable.rs
+require 'Use no more than two decimal places.' src/critical_pages/customers_portable.rs
+require 'Funding review' src/critical_pages/customers_portable.rs
+require 'New {selected_currency} balance' src/critical_pages/customers_portable.rs
+forbid '"Disabled"' src/critical_pages/customers_portable.rs
+forbid 'enabled accounts' src/critical_pages/customers_portable.rs
+forbid 'saturating_mul(1_000_000_000)' src/critical_pages/customers_portable.rs
 require 'Environment operators' src/functional_pages/access_live.rs
 require 'is_staff_role(&user.role)' src/functional_pages/access_live.rs
 require 'Team will become editable only when the backend has explicit role-management endpoints.' src/functional_pages/access_live.rs

--- a/crates/client/src/critical_pages/customers_portable.rs
+++ b/crates/client/src/critical_pages/customers_portable.rs
@@ -5,8 +5,80 @@ use crate::{
     components::Icon,
 };
 
+const NANO_PER_UNIT: i64 = 1_000_000_000;
+const NANO_PER_CENT: i64 = 10_000_000;
+
 fn format_nano(nano: i64, symbol: &str) -> String {
-    format!("{symbol}{:.2}", nano as f64 / 1_000_000_000.0)
+    let value = nano as f64 / NANO_PER_UNIT as f64;
+    if nano != 0 && value.abs() < 1.0 {
+        format!("{symbol}{value:.6}")
+    } else {
+        format!("{symbol}{value:.2}")
+    }
+}
+
+fn format_currency_nano(nano: i64, currency: &str) -> String {
+    if currency == "USD" {
+        format_nano(nano, "$")
+    } else {
+        format_nano(nano, "CNY ")
+    }
+}
+
+fn parse_positive_amount_nano(raw: &str) -> Result<i64, String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err("Enter a funding amount.".to_string());
+    }
+    if raw.starts_with('-') {
+        return Err("Funding amount must be greater than zero.".to_string());
+    }
+
+    let mut parts = raw.split('.');
+    let whole = parts.next().unwrap_or_default();
+    let fraction = parts.next();
+    if parts.next().is_some() {
+        return Err("Enter a valid amount with at most one decimal point.".to_string());
+    }
+
+    let whole_value = if whole.is_empty() {
+        0
+    } else {
+        if !whole.chars().all(|ch| ch.is_ascii_digit()) {
+            return Err("Enter a valid positive amount.".to_string());
+        }
+        whole
+            .parse::<i64>()
+            .map_err(|_| "Funding amount is too large.".to_string())?
+    };
+
+    let cents = match fraction {
+        None => 0,
+        Some(value) if value.is_empty() => 0,
+        Some(value) => {
+            if value.len() > 2 || !value.chars().all(|ch| ch.is_ascii_digit()) {
+                return Err("Use no more than two decimal places.".to_string());
+            }
+            let parsed = value
+                .parse::<i64>()
+                .map_err(|_| "Enter a valid funding amount.".to_string())?;
+            if value.len() == 1 {
+                parsed * 10
+            } else {
+                parsed
+            }
+        }
+    };
+
+    let nano = whole_value
+        .checked_mul(NANO_PER_UNIT)
+        .and_then(|value| value.checked_add(cents * NANO_PER_CENT))
+        .ok_or_else(|| "Funding amount is too large.".to_string())?;
+
+    if nano <= 0 {
+        return Err("Funding amount must be greater than zero.".to_string());
+    }
+    Ok(nano)
 }
 
 fn is_staff_role(role: &str) -> bool {
@@ -20,47 +92,56 @@ fn is_staff_role(role: &str) -> bool {
 pub fn Customers() -> Element {
     let mut users = use_resource(move || async move { UserService::list().await });
     let mut query = use_signal(String::new);
-    let mut active_only = use_signal(|| false);
+    let mut default_status_only = use_signal(|| false);
     let mut create_open = use_signal(|| false);
     let mut topup_user = use_signal(|| None::<User>);
     let mut username = use_signal(String::new);
     let mut email = use_signal(String::new);
     let mut password = use_signal(String::new);
-    let mut amount = use_signal(|| 0i64);
+    let mut amount = use_signal(|| "100".to_string());
     let mut currency = use_signal(|| "CNY".to_string());
     let mut busy = use_signal(|| false);
     let mut notice = use_signal(String::new);
-    let mut error = use_signal(String::new);
+    let mut form_error = use_signal(String::new);
 
     let resource = users.read().clone();
     let loading = resource.is_none();
-    let load_error = resource.as_ref().and_then(|result| result.as_ref().err().cloned());
+    let load_error = resource
+        .as_ref()
+        .and_then(|result| result.as_ref().err().cloned());
     let all_users = resource.and_then(Result::ok).unwrap_or_default();
     let customer_list: Vec<User> = all_users
         .into_iter()
         .filter(|user| !is_staff_role(&user.role))
         .collect();
 
-    let search = query().to_lowercase();
+    let search = query().trim().to_lowercase();
     let filtered: Vec<User> = customer_list
         .iter()
         .filter(|user| {
-            (!active_only() || user.status == 1)
+            (!default_status_only() || user.status == 1)
                 && (search.is_empty()
                     || user.username.to_lowercase().contains(&search)
                     || user.id.to_lowercase().contains(&search)
-                    || user.email.as_deref().unwrap_or("").to_lowercase().contains(&search))
+                    || user
+                        .email
+                        .as_deref()
+                        .unwrap_or("")
+                        .to_lowercase()
+                        .contains(&search))
         })
         .cloned()
         .collect();
 
-    let active_count = customer_list.iter().filter(|user| user.status == 1).count();
+    let default_status_count = customer_list.iter().filter(|user| user.status == 1).count();
+    let non_default_status_count = customer_list.len().saturating_sub(default_status_count);
     let cny_total: i64 = customer_list.iter().map(|user| user.balance_cny).sum();
     let usd_total: i64 = customer_list.iter().map(|user| user.balance_usd).sum();
     let cny_total_text = format_nano(cny_total, "CNY ");
     let usd_total_text = format_nano(usd_total, "$");
     let filtered_count = filtered.len();
     let customer_count = customer_list.len();
+    let amount_preview = parse_positive_amount_nano(&amount()).ok();
 
     rsx! {
         div { class: "page",
@@ -70,7 +151,12 @@ pub fn Customers() -> Element {
                     p { class: "page-subtitle", "Manage business accounts, review wallet balances, and fund customer usage. Administrative staff are shown separately under Team." }
                 }
                 div { class: "header-actions",
-                    button { class: "button button-secondary", onclick: move |_| users.restart(), "Refresh" }
+                    button {
+                        class: "button button-secondary",
+                        disabled: loading,
+                        onclick: move |_| users.restart(),
+                        if loading { "Refreshing…" } else { "Refresh" }
+                    }
                     button {
                         class: "button button-primary",
                         onclick: move |_| {
@@ -78,7 +164,7 @@ pub fn Customers() -> Element {
                             email.set(String::new());
                             password.set(String::new());
                             notice.set(String::new());
-                            error.set(String::new());
+                            form_error.set(String::new());
                             create_open.set(true);
                         },
                         Icon { name: "plus" }
@@ -87,30 +173,18 @@ pub fn Customers() -> Element {
                 }
             }
 
-            div { class: "metrics",
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Customers" } span { class: "metric-value", "{customer_count}" } span { class: "metric-note", "business accounts" } }
-                    div { class: "metric-icon tone-gray", Icon { name: "users" } }
-                }
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Active" } span { class: "metric-value", "{active_count}" } span { class: "metric-note", "enabled accounts" } }
-                    div { class: "metric-icon tone-green", Icon { name: "activity" } }
-                }
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "CNY Wallets" } span { class: "metric-value", "{cny_total_text}" } span { class: "metric-note", "aggregate balance" } }
-                    div { class: "metric-icon tone-amber", Icon { name: "dollar" } }
-                }
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "USD Wallets" } span { class: "metric-value", "{usd_total_text}" } span { class: "metric-note", "aggregate balance" } }
-                    div { class: "metric-icon tone-blue", Icon { name: "dollar" } }
-                }
+            if !notice().is_empty() {
+                div { class: "terminal auth-status", "{notice}" }
             }
 
-            if !notice().is_empty() { div { class: "terminal auth-status", "{notice}" } }
-            if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
-
             if loading {
-                div { class: "card card-pad", "Loading customers…" }
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "users" } }
+                        h3 { "Loading customer accounts" }
+                        p { "Reading business accounts and wallet balances before showing customer totals or account-state conclusions." }
+                    }
+                }
             } else if let Some(message) = load_error {
                 div { class: "card card-pad stack",
                     strong { class: "danger", "Customers could not be loaded" }
@@ -123,10 +197,75 @@ pub fn Customers() -> Element {
                         div { class: "product-empty-icon", Icon { name: "users" } }
                         h3 { "Create the first customer account" }
                         p { "Customer accounts own wallet balances and can receive API keys for routed model usage. Team members are intentionally managed separately." }
-                        button { class: "button button-primary", onclick: move |_| create_open.set(true), "Create Customer" }
+                        button {
+                            class: "button button-primary",
+                            onclick: move |_| {
+                                username.set(String::new());
+                                email.set(String::new());
+                                password.set(String::new());
+                                form_error.set(String::new());
+                                create_open.set(true);
+                            },
+                            "Create Customer"
+                        }
                     }
                 }
             } else {
+                div { class: "metrics",
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "Customers" }
+                            span { class: "metric-value", "{customer_count}" }
+                            span { class: "metric-note", "business accounts" }
+                        }
+                        div { class: "metric-icon tone-gray", Icon { name: "users" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "Default Status" }
+                            span { class: "metric-value", "{default_status_count}" }
+                            span { class: "metric-note", "records reporting status = 1" }
+                        }
+                        div { class: "metric-icon tone-gray", Icon { name: "activity" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "CNY Wallets" }
+                            span { class: "metric-value", "{cny_total_text}" }
+                            span { class: "metric-note", "aggregate balance" }
+                        }
+                        div { class: "metric-icon tone-gray", Icon { name: "dollar" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "USD Wallets" }
+                            span { class: "metric-value", "{usd_total_text}" }
+                            span { class: "metric-note", "aggregate balance" }
+                        }
+                        div { class: "metric-icon tone-gray", Icon { name: "dollar" } }
+                    }
+                }
+
+                if non_default_status_count > 0 {
+                    div { class: "readiness-strip blocked",
+                        span { class: "readiness-dot" }
+                        div {
+                            strong { "{non_default_status_count} customer records have a non-default status flag" }
+                            span { class: "small muted", "Treat status as server metadata here: this console has no suspend/reactivate endpoint and does not infer login or API enforcement from non-default values." }
+                        }
+                        span { class: "badge badge-neutral", "Status review" }
+                    }
+                } else {
+                    div { class: "readiness-strip ready",
+                        span { class: "readiness-dot" }
+                        div {
+                            strong { "Customer records use the default status flag" }
+                            span { class: "small muted", "All loaded business accounts report status 1. Wallet funding remains an explicit operator action." }
+                        }
+                        span { class: "badge badge-neutral", "{customer_count} loaded" }
+                    }
+                }
+
                 div { class: "card table-card",
                     div { class: "customer-toolbar",
                         div { class: "search-field customer-search",
@@ -139,17 +278,29 @@ pub fn Customers() -> Element {
                             }
                         }
                         label { class: "row gap-2 small muted",
-                            input { r#type: "checkbox", checked: active_only(), onclick: move |_| active_only.set(!active_only()) }
-                            "Active only"
+                            input {
+                                r#type: "checkbox",
+                                checked: default_status_only(),
+                                onclick: move |_| default_status_only.set(!default_status_only()),
+                            }
+                            "Default status only"
                         }
                         span { class: "small muted", "Showing {filtered_count} of {customer_count}" }
                     }
 
                     if filtered.is_empty() {
-                        div { class: "product-empty", style: "min-height:160px",
+                        div { class: "product-empty",
                             div { class: "product-empty-inner",
                                 h3 { "No customers match this view" }
-                                p { "Change the search text or clear the Active only filter." }
+                                p { "Change the search text or clear the Default status only filter." }
+                                button {
+                                    class: "button button-secondary",
+                                    onclick: move |_| {
+                                        query.set(String::new());
+                                        default_status_only.set(false);
+                                    },
+                                    "Clear filters"
+                                }
                             }
                         }
                     } else {
@@ -157,7 +308,7 @@ pub fn Customers() -> Element {
                             table { class: "data-table",
                                 thead { tr {
                                     th { "Customer" }
-                                    th { "Status" }
+                                    th { "Status Metadata" }
                                     th { "Wallet" }
                                     th { "Preferred Currency" }
                                     th { class: "right", "Actions" }
@@ -166,7 +317,11 @@ pub fn Customers() -> Element {
                                     for user in filtered {
                                         {
                                             let email_text = user.email.clone().unwrap_or_else(|| "No email".to_string());
-                                            let status_text = if user.status == 1 { "Active" } else { "Disabled" };
+                                            let status_text = if user.status == 1 {
+                                                "Active flag".to_string()
+                                            } else {
+                                                format!("Status {}", user.status)
+                                            };
                                             let cny_text = format_nano(user.balance_cny, "CNY ");
                                             let usd_text = format_nano(user.balance_usd, "$");
                                             let preferred = user.preferred_currency.clone().unwrap_or_else(|| "Not set".to_string());
@@ -174,11 +329,13 @@ pub fn Customers() -> Element {
                                                 tr { key: "{user.id}",
                                                     td {
                                                         div { class: "two-line",
-                                                            strong { class: "table-primary", "{user.username}" }
-                                                            small { class: "muted", "{email_text} • {user.id}" }
+                                                            strong { class: "table-primary", title: "{user.username}", "{user.username}" }
+                                                            small { class: "muted", title: "{email_text} • {user.id}", "{email_text} • {user.id}" }
                                                         }
                                                     }
-                                                    td { span { class: if user.status == 1 { "badge badge-success" } else { "badge badge-neutral" }, "{status_text}" } }
+                                                    td {
+                                                        span { class: if user.status == 1 { "badge badge-success" } else { "badge badge-neutral" }, "{status_text}" }
+                                                    }
                                                     td {
                                                         div { class: "two-line",
                                                             strong { class: "tabular", "{cny_text}" }
@@ -190,10 +347,15 @@ pub fn Customers() -> Element {
                                                         button {
                                                             class: "button button-secondary button-sm",
                                                             onclick: move |_| {
-                                                                amount.set(0);
-                                                                currency.set(user.preferred_currency.clone().filter(|value| value == "USD" || value == "CNY").unwrap_or_else(|| "CNY".to_string()));
+                                                                amount.set("100".to_string());
+                                                                currency.set(
+                                                                    user.preferred_currency
+                                                                        .clone()
+                                                                        .filter(|value| value == "USD" || value == "CNY")
+                                                                        .unwrap_or_else(|| "CNY".to_string()),
+                                                                );
                                                                 notice.set(String::new());
-                                                                error.set(String::new());
+                                                                form_error.set(String::new());
                                                                 topup_user.set(Some(user.clone()));
                                                             },
                                                             "Add Funds"
@@ -208,50 +370,110 @@ pub fn Customers() -> Element {
                         }
                     }
                     div { class: "card-pad product-note",
-                        "Account status is currently read-only because the BurnCloud server does not yet expose a safe suspend/reactivate endpoint. The UI does not simulate that action."
+                        "Status is server metadata. BurnCloud does not currently expose an administrator suspend/reactivate endpoint here, so this page does not simulate access-control changes or treat non-default values as proof that sign-in or API traffic is blocked."
                     }
                 }
             }
 
             if create_open() {
-                div { class: "drawer-backdrop", onclick: move |_| create_open.set(false) }
+                div {
+                    class: "drawer-backdrop",
+                    onclick: move |_| if !busy() { create_open.set(false) },
+                }
                 aside { class: "drawer",
                     div { class: "drawer-head",
-                        div { h2 { "Create Customer" } p { class: "small muted", "Create a business account that can own wallet balance and API access." } }
-                        button { class: "close-button", onclick: move |_| create_open.set(false), "×" }
+                        div {
+                            h2 { "Create Customer" }
+                            p { class: "small muted", "Create a business account that can own wallet balance and API access." }
+                        }
+                        button {
+                            class: "close-button",
+                            disabled: busy(),
+                            onclick: move |_| create_open.set(false),
+                            "×"
+                        }
                     }
                     div { class: "drawer-body stack-lg",
                         div { class: "form-section",
-                            div { class: "form-section-head", strong { "Account identity" } small { "The username is the customer's BurnCloud login identity." } }
-                            div { class: "field", label { "Username" } input { class: "input", value: "{username}", disabled: busy(), oninput: move |event| username.set(event.value()) } }
-                            div { class: "field", label { "Email (optional)" } input { class: "input", r#type: "email", value: "{email}", disabled: busy(), oninput: move |event| email.set(event.value()) } }
-                            div { class: "field", label { "Temporary password" } input { class: "input", r#type: "password", value: "{password}", disabled: busy(), placeholder: "At least 8 characters", oninput: move |event| password.set(event.value()) } }
+                            div { class: "form-section-head",
+                                strong { "Account identity" }
+                                small { "The username becomes the customer's BurnCloud login identity. Creation uses the server's default starting wallet; add any additional balance separately." }
+                            }
+                            div { class: "field",
+                                label { "Username" }
+                                input {
+                                    class: "input",
+                                    value: "{username}",
+                                    disabled: busy(),
+                                    autocomplete: "off",
+                                    oninput: move |event| {
+                                        username.set(event.value());
+                                        form_error.set(String::new());
+                                    },
+                                }
+                            }
+                            div { class: "field",
+                                label { "Email (optional)" }
+                                input {
+                                    class: "input",
+                                    r#type: "email",
+                                    value: "{email}",
+                                    disabled: busy(),
+                                    oninput: move |event| email.set(event.value()),
+                                }
+                            }
+                            div { class: "field",
+                                label { "Temporary password" }
+                                input {
+                                    class: "input",
+                                    r#type: "password",
+                                    value: "{password}",
+                                    disabled: busy(),
+                                    placeholder: "At least 8 characters",
+                                    oninput: move |event| {
+                                        password.set(event.value());
+                                        form_error.set(String::new());
+                                    },
+                                }
+                                small { class: "muted", "Share this password with the customer through an appropriate secure channel; the admin console does not display it again after creation." }
+                            }
                         }
-                        if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
+                        if !form_error().is_empty() {
+                            div { class: "terminal auth-status auth-status-error", "{form_error}" }
+                        }
                         div { class: "row customer-form-actions",
-                            button { class: "button button-secondary", disabled: busy(), onclick: move |_| create_open.set(false), "Cancel" }
+                            button {
+                                class: "button button-secondary",
+                                disabled: busy(),
+                                onclick: move |_| create_open.set(false),
+                                "Cancel"
+                            }
                             button {
                                 class: "button button-primary",
-                                disabled: busy(),
+                                disabled: busy() || username().trim().is_empty() || password().len() < 8,
                                 onclick: move |_| {
                                     let username_value = username().trim().to_string();
                                     let email_value = email().trim().to_string();
                                     let password_value = password();
                                     if username_value.is_empty() || password_value.len() < 8 {
-                                        error.set("Username is required and the password must contain at least 8 characters.".to_string());
+                                        form_error.set("Username is required and the password must contain at least 8 characters.".to_string());
                                         return;
                                     }
                                     busy.set(true);
-                                    error.set(String::new());
+                                    form_error.set(String::new());
                                     spawn(async move {
-                                        let email_arg = if email_value.is_empty() { None } else { Some(email_value.as_str()) };
+                                        let email_arg = if email_value.is_empty() {
+                                            None
+                                        } else {
+                                            Some(email_value.as_str())
+                                        };
                                         match UserService::create(&username_value, &password_value, email_arg).await {
                                             Ok(_) => {
-                                                notice.set(format!("Customer {username_value} created."));
+                                                notice.set(format!("Customer {username_value} created. The server applied its default starting wallet."));
                                                 create_open.set(false);
                                                 users.restart();
                                             }
-                                            Err(message) => error.set(format!("Create customer failed: {message}")),
+                                            Err(message) => form_error.set(format!("Create customer failed: {message}")),
                                         }
                                         busy.set(false);
                                     });
@@ -267,67 +489,126 @@ pub fn Customers() -> Element {
                 {
                     let current_cny = format_nano(user.balance_cny, "CNY ");
                     let current_usd = format_nano(user.balance_usd, "$");
+                    let preview_text = amount_preview.map(|nano| format_currency_nano(nano, &currency()));
+                    let funding_button_label = if busy() {
+                        "Adding…".to_string()
+                    } else if let Some(preview) = preview_text.as_ref() {
+                        format!("Add {preview}")
+                    } else {
+                        "Confirm Funding".to_string()
+                    };
                     rsx! {
-                        div { class: "drawer-backdrop", onclick: move |_| topup_user.set(None) }
+                        div {
+                            class: "drawer-backdrop",
+                            onclick: move |_| if !busy() { topup_user.set(None) },
+                        }
                         aside { class: "drawer",
                             div { class: "drawer-head",
-                                div { h2 { "Add Funds" } p { class: "small muted", "Credit the customer's BurnCloud wallet." } }
-                                button { class: "close-button", onclick: move |_| topup_user.set(None), "×" }
+                                div {
+                                    h2 { "Add Funds" }
+                                    p { class: "small muted", "Credit the customer's BurnCloud wallet immediately." }
+                                }
+                                button {
+                                    class: "close-button",
+                                    disabled: busy(),
+                                    onclick: move |_| topup_user.set(None),
+                                    "×"
+                                }
                             }
                             div { class: "drawer-body stack-lg",
                                 div { class: "form-section",
-                                    div { class: "form-section-head", strong { "{user.username}" } small { "Current balances: {current_cny} • {current_usd}" } }
+                                    div { class: "form-section-head",
+                                        strong { "{user.username}" }
+                                        small { "Current balances: {current_cny} • {current_usd}" }
+                                    }
                                     div { class: "grid-2",
                                         div { class: "field",
                                             label { "Currency" }
-                                            select { class: "select", value: "{currency}", disabled: busy(), onchange: move |event| currency.set(event.value()),
+                                            select {
+                                                class: "select",
+                                                value: "{currency}",
+                                                disabled: busy(),
+                                                onchange: move |event| {
+                                                    currency.set(event.value());
+                                                    form_error.set(String::new());
+                                                },
                                                 option { value: "CNY", "CNY" }
                                                 option { value: "USD", "USD" }
                                             }
                                         }
                                         div { class: "field",
                                             label { "Amount" }
-                                            input { class: "input", r#type: "number", min: "1", value: "{amount}", disabled: busy(), oninput: move |event| amount.set(event.value().parse::<i64>().unwrap_or(0)) }
+                                            input {
+                                                class: "input",
+                                                r#type: "number",
+                                                min: "0.01",
+                                                step: "0.01",
+                                                value: "{amount}",
+                                                disabled: busy(),
+                                                oninput: move |event| {
+                                                    amount.set(event.value());
+                                                    form_error.set(String::new());
+                                                },
+                                            }
+                                            small { class: "muted", "Up to two decimal places. The client converts this exactly to the server's nanodollar balance contract." }
                                         }
                                     }
                                     div { class: "row gap-2",
-                                        button { class: "button button-secondary button-sm", onclick: move |_| amount.set(100), "100" }
-                                        button { class: "button button-secondary button-sm", onclick: move |_| amount.set(500), "500" }
-                                        button { class: "button button-secondary button-sm", onclick: move |_| amount.set(1000), "1,000" }
+                                        button { class: "button button-secondary button-sm", disabled: busy(), onclick: move |_| amount.set("100".to_string()), "100" }
+                                        button { class: "button button-secondary button-sm", disabled: busy(), onclick: move |_| amount.set("500".to_string()), "500" }
+                                        button { class: "button button-secondary button-sm", disabled: busy(), onclick: move |_| amount.set("1000".to_string()), "1,000" }
                                     }
                                 }
-                                if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
-                                if !notice().is_empty() { div { class: "terminal auth-status", "{notice}" } }
+
+                                if let Some(preview) = preview_text {
+                                    div { class: "product-note",
+                                        strong { "Funding review" }
+                                        span { "Add {preview} to {user.username}. This immediately creates a wallet credit through the real top-up endpoint." }
+                                    }
+                                }
+
+                                if !form_error().is_empty() {
+                                    div { class: "terminal auth-status auth-status-error", "{form_error}" }
+                                }
+
                                 div { class: "row customer-form-actions",
-                                    button { class: "button button-secondary", disabled: busy(), onclick: move |_| topup_user.set(None), "Cancel" }
+                                    button {
+                                        class: "button button-secondary",
+                                        disabled: busy(),
+                                        onclick: move |_| topup_user.set(None),
+                                        "Cancel"
+                                    }
                                     button {
                                         class: "button button-primary",
-                                        disabled: busy(),
+                                        disabled: busy() || amount_preview.is_none(),
                                         onclick: move |_| {
-                                            let value = amount();
                                             let selected_currency = currency();
                                             let user_id = user.id.clone();
                                             let user_name = user.username.clone();
-                                            if value <= 0 {
-                                                error.set("Funding amount must be greater than zero.".to_string());
-                                                return;
-                                            }
+                                            let amount_nano = match parse_positive_amount_nano(&amount()) {
+                                                Ok(value) => value,
+                                                Err(message) => {
+                                                    form_error.set(message);
+                                                    return;
+                                                }
+                                            };
+                                            let amount_text = format_currency_nano(amount_nano, &selected_currency);
                                             busy.set(true);
-                                            error.set(String::new());
+                                            form_error.set(String::new());
                                             spawn(async move {
-                                                let amount_nano = value.saturating_mul(1_000_000_000);
                                                 match UserService::topup(&user_id, amount_nano, &selected_currency).await {
-                                                    Ok(_) => {
-                                                        notice.set(format!("Added {value} {selected_currency} to {user_name}."));
+                                                    Ok(new_balance) => {
+                                                        let new_balance_text = format_currency_nano(new_balance, &selected_currency);
+                                                        notice.set(format!("Added {amount_text} to {user_name}. New {selected_currency} balance: {new_balance_text}."));
                                                         topup_user.set(None);
                                                         users.restart();
                                                     }
-                                                    Err(message) => error.set(format!("Add funds failed: {message}")),
+                                                    Err(message) => form_error.set(format!("Add funds failed: {message}")),
                                                 }
                                                 busy.set(false);
                                             });
                                         },
-                                        if busy() { "Adding…" } else { "Confirm Funding" }
+                                        "{funding_button_label}"
                                     }
                                 }
                             }


### PR DESCRIPTION
## Goal

Apply the next Phase 2 page-level polish pass to Customers after API Keys (#416), while staying inside the current real customer-management backend contract.

Customers should answer three operator questions clearly: which business accounts exist, what wallet balances they currently hold, and what funding action will happen next.

## What changed

### Truthful loading and account-state semantics

- stop rendering zero-valued customer/wallet KPIs before the user list has loaded
- disable Refresh while the list is unresolved
- separate business customers from staff exactly as before
- stop translating every `status != 1` record into a guaranteed `Disabled` access state
- present status as server metadata because the current admin API has no suspend/reactivate endpoint and the login path does not establish that a non-default value blocks access
- surface non-default status records as an attention conclusion instead of inventing enforcement behavior

### Wallet readability

- keep CNY and USD balances visible together per customer
- preserve sub-unit precision for non-zero balances below 1 currency unit instead of collapsing them to `0.00`
- keep aggregate CNY/USD wallet totals neutral rather than treating balance size as health state

### Customer creation

- keep creation on the real `UserService::create` endpoint
- make the temporary-password responsibility explicit
- clarify that the server applies its own default starting wallet and that additional balance should be added separately
- keep create errors inside the creation workflow instead of mixing them with page-load state

### Safer funding workflow

- replace whole-number-only funding with exact two-decimal parsing into the server nanodollar contract
- reject negative, zero, malformed, over-precision, and overflowed funding inputs before sending a request
- show a funding review statement before the mutation
- label the confirmation with the exact currency amount being credited
- keep the drawer open and controls locked while the mutation is in flight
- use the real balance returned by `UserService::topup` in the success message so the operator receives post-mutation evidence

### Regression contract

`check-product-ux.sh` now requires:

- truthful customer loading
- status-metadata wording
- exact decimal-to-nanodollar funding parsing
- funding review and returned-balance confirmation
- no regression back to the old `Disabled`/`enabled accounts` overclaim
- no regression back to integer `saturating_mul(1_000_000_000)` funding

## Backend boundary

This PR does **not** add fake customer-management capabilities. The current admin contract still does not expose:

- suspend/reactivate
- customer profile editing
- customer deletion
- admin lookup of another customer's recharge history

Those actions remain absent from the UI.

## Validation

Final head `e14621d1eab6d86b6117984c04db47d54ba08c24`, Client UI Conventions run #281:

- console button conventions ✅
- functional console wiring ✅
- product UX contracts ✅
- visual system contracts ✅
- Dioxus LiveView client ✅
- full BurnCloud application integration ✅
- Windows desktop client (`cargo check -p burncloud-client`) ✅

This is a client-only PR, so the Security & Billing server invariant workflow is not expected to run.

## Scope

Only:

- `crates/client/src/critical_pages/customers_portable.rs`
- `crates/client/scripts/check-product-ux.sh`
