### PR TITLE
Polish Team around the real console admin boundary

### DIFF
--- a/crates/client/scripts/check-product-ux.sh
+++ b/crates/client/scripts/check-product-ux.sh
@@ -82,7 +82,7 @@ require 'Create an API key for the test' src/functional_pages/playground_live.rs
 require 'Select a configured model' src/functional_pages/playground_live.rs
 require 'Send Test Request' src/functional_pages/playground_live.rs
 
-# Customers and staff have separate product responsibilities.
+# Customers and Console administrators have separate product responsibilities.
 require 'Manage business accounts' src/critical_pages/customers_portable.rs
 require '!is_staff_role(&user.role)' src/critical_pages/customers_portable.rs
 require 'Loading customer accounts' src/critical_pages/customers_portable.rs
@@ -95,9 +95,25 @@ require 'New {selected_currency} balance' src/critical_pages/customers_portable.
 forbid '"Disabled"' src/critical_pages/customers_portable.rs
 forbid 'enabled accounts' src/critical_pages/customers_portable.rs
 forbid 'saturating_mul(1_000_000_000)' src/critical_pages/customers_portable.rs
-require 'Environment operators' src/functional_pages/access_live.rs
-require 'is_staff_role(&user.role)' src/functional_pages/access_live.rs
-require 'Team will become editable only when the backend has explicit role-management endpoints.' src/functional_pages/access_live.rs
+
+# Team reflects the actual Console authorization boundary: only admin is treated as an administrator.
+require 'Loading Console administrators' src/functional_pages/access_live.rs
+require 'is_console_admin_role(&user.role)' src/functional_pages/access_live.rs
+require 'Console admin authorization' src/functional_pages/access_live.rs
+require 'Console administrators' src/functional_pages/access_live.rs
+require 'Account Status Metadata' src/functional_pages/access_live.rs
+require 'Team is read-only until the server exposes explicit role-management endpoints' src/functional_pages/access_live.rs
+require 'The current authorization boundary recognizes admin.' src/functional_pages/access_live.rs
+forbid 'is_staff_role' src/functional_pages/access_live.rs
+forbid '"Disabled"' src/functional_pages/access_live.rs
+forbid 'Invite Administrator' src/functional_pages/access_live.rs
+forbid 'Change Role' src/functional_pages/access_live.rs
+forbid 'Remove Member' src/functional_pages/access_live.rs
+
+# list_users must make the compatibility role summary deterministic for Console authorization.
+require 'fn primary_role' ../server/src/api/user.rs
+require 'roles.iter().any(|role| role == "admin")' ../server/src/api/user.rs
+require 'let role = primary_role(&roles);' ../server/src/api/user.rs
 
 # API-key management must keep opaque management references separate from bearer-secret disclosure.
 require 'Opaque management reference' src/functional_pages/api_keys_live.rs

--- a/crates/client/scripts/check-product-ux.sh
+++ b/crates/client/scripts/check-product-ux.sh
@@ -104,11 +104,9 @@ require 'Console administrators' src/functional_pages/access_live.rs
 require 'Account Status Metadata' src/functional_pages/access_live.rs
 require 'Team is read-only until the server exposes explicit role-management endpoints' src/functional_pages/access_live.rs
 require 'The current authorization boundary recognizes admin.' src/functional_pages/access_live.rs
+require 'No Invite, Change Role, Remove Member, or Suspend controls are shown' src/functional_pages/access_live.rs
 forbid 'is_staff_role' src/functional_pages/access_live.rs
 forbid '"Disabled"' src/functional_pages/access_live.rs
-forbid 'Invite Administrator' src/functional_pages/access_live.rs
-forbid 'Change Role' src/functional_pages/access_live.rs
-forbid 'Remove Member' src/functional_pages/access_live.rs
 
 # list_users must make the compatibility role summary deterministic for Console authorization.
 require 'fn primary_role' ../server/src/api/user.rs

--- a/crates/client/src/functional_pages/access_live.rs
+++ b/crates/client/src/functional_pages/access_live.rs
@@ -5,11 +5,16 @@ use crate::{
     components::Icon,
 };
 
-fn is_staff_role(role: &str) -> bool {
-    matches!(
-        role.trim().to_ascii_lowercase().as_str(),
-        "root" | "admin" | "administrator" | "operator" | "owner"
-    )
+fn is_console_admin_role(role: &str) -> bool {
+    role.trim().eq_ignore_ascii_case("admin")
+}
+
+fn status_metadata(status: i32) -> String {
+    if status == 1 {
+        "Default (1)".to_string()
+    } else {
+        format!("Status {status}")
+    }
 }
 
 #[component]
@@ -18,89 +23,224 @@ pub fn Team() -> Element {
     let session = auth.user();
     let mut resource = use_resource(move || async move { UserService::list().await });
     let snapshot = resource.read().clone();
-    let load_error = snapshot.as_ref().and_then(|result| result.as_ref().err().cloned());
+    let loading = snapshot.is_none();
+    let load_error = snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().err().cloned());
     let all_users = snapshot.and_then(Result::ok).unwrap_or_default();
-    let staff: Vec<User> = all_users
+    let admins: Vec<User> = all_users
         .iter()
-        .filter(|user| is_staff_role(&user.role))
+        .filter(|user| is_console_admin_role(&user.role))
         .cloned()
         .collect();
 
-    let username = session
+    let session_username = session
         .as_ref()
         .map(|user| user.username.clone())
         .unwrap_or_else(|| "-".to_string());
-    let user_id = session
+    let session_user_id = session
         .as_ref()
         .map(|user| user.id.clone())
         .unwrap_or_else(|| "-".to_string());
-    let roles = session
+    let session_roles = session
         .as_ref()
-        .map(|user| user.roles.join(", "))
-        .unwrap_or_else(|| "-".to_string());
+        .map(|user| user.roles.clone())
+        .unwrap_or_default();
+    let session_roles_text = if session_roles.is_empty() {
+        "No roles returned".to_string()
+    } else {
+        session_roles.join(", ")
+    };
+    let session_is_admin = session_roles
+        .iter()
+        .any(|role| role.eq_ignore_ascii_case("admin"));
+
+    let admin_count = admins.len();
+    let email_count = admins.iter().filter(|user| user.email.is_some()).count();
+    let status_attention_count = admins.iter().filter(|user| user.status != 1).count();
+    let inventory_class = if admin_count > 0 && status_attention_count == 0 {
+        "readiness-strip ready"
+    } else {
+        "readiness-strip blocked"
+    };
+    let inventory_title = if admin_count == 0 {
+        "No Console administrators returned"
+    } else if status_attention_count > 0 {
+        "Administrator records need review"
+    } else {
+        "Console administrator inventory loaded"
+    };
+    let inventory_copy = if admin_count == 0 {
+        "The account list did not return an effective admin role. BurnCloud currently grants Console administration only through the admin role."
+            .to_string()
+    } else if status_attention_count > 0 {
+        format!(
+            "{status_attention_count} administrator record(s) carry non-default account status metadata. The current login path does not prove that this flag blocks access, so Team does not label those accounts disabled."
+        )
+    } else {
+        "Every administrator returned by the current account list uses the default account status metadata. Role membership remains read-only in this Console."
+            .to_string()
+    };
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
                     h2 { class: "page-title", "Team" }
-                    p { class: "page-subtitle", "People with administrative or operator roles who manage this BurnCloud environment." }
+                    p { class: "page-subtitle", "Review identities that currently satisfy BurnCloud's Console administrator role. Customer accounts remain under Customers." }
                 }
-                button { class: "button button-secondary", onclick: move |_| resource.restart(), "Refresh" }
-            }
-
-            div { class: "grid-2",
-                div { class: "card card-pad stack",
-                    div { class: "product-section-head", div { h3 { "Your session" } p { "The identity currently operating this console." } } }
-                    div { class: "receipt-row", label { "User" } strong { "{username}" } }
-                    div { class: "receipt-row", label { "User ID" } strong { class: "mono", "{user_id}" } }
-                    div { class: "receipt-row", label { "Roles" } strong { "{roles}" } }
-                }
-                div { class: "card card-pad stack",
-                    div { class: "product-section-head", div { h3 { "Role management" } p { "Why this page is read-only today." } } }
-                    p { class: "small muted", "The current BurnCloud server exposes user roles when listing accounts, but it does not expose an API to invite a staff member or change roles safely." }
-                    div { class: "product-note", "Customer account creation remains under Customers. Team will become editable only when the backend has explicit role-management endpoints." }
+                button {
+                    class: "button button-secondary",
+                    disabled: loading,
+                    onclick: move |_| resource.restart(),
+                    if loading { "Refreshing…" } else { "Refresh" }
                 }
             }
 
-            if let Some(message) = load_error {
-                div { class: "terminal auth-status auth-status-error", "{message}" }
-            } else if staff.is_empty() {
+            if loading {
                 div { class: "card product-empty",
                     div { class: "product-empty-inner",
                         div { class: "product-empty-icon", Icon { name: "users" } }
-                        h3 { "No staff roles returned" }
-                        p { "The current session may still be authorized, but the user list did not return accounts with admin, root, owner, or operator roles." }
+                        h3 { "Loading Console administrators" }
+                        p { "Reading account-role summaries before showing administrator inventory or status conclusions." }
                     }
                 }
+            } else if let Some(message) = load_error {
+                div { class: "card card-pad stack",
+                    strong { class: "danger", "Team could not be loaded" }
+                    p { class: "small muted", "The administrator inventory is unavailable, so Team will not infer membership from the current session alone." }
+                    code { class: "terminal", "{message}" }
+                    button { class: "button button-primary", onclick: move |_| resource.restart(), "Retry" }
+                }
             } else {
-                div { class: "card table-card",
-                    div { class: "card-pad product-section-head", div { h3 { "Environment operators" } p { "Administrative identities are separated from customer accounts." } } }
-                    div { class: "table-wrap",
-                        table { class: "data-table",
-                            thead { tr { th { "Member" } th { "Email" } th { "Role" } th { "Status" } } }
-                            tbody {
-                                for user in staff {
-                                    {
-                                        let email = user.email.clone().unwrap_or_else(|| "-".to_string());
-                                        let status = if user.status == 1 { "Active" } else { "Disabled" };
-                                        rsx! {
-                                            tr { key: "{user.id}",
-                                                td {
-                                                    div { class: "two-line",
-                                                        strong { class: "table-primary", "{user.username}" }
-                                                        small { class: "mono muted", "{user.id}" }
+                div { class: "metrics",
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "Console Admins" }
+                            span { class: "metric-value", "{admin_count}" }
+                            span { class: "metric-note", "effective admin role" }
+                        }
+                        div { class: "metric-icon tone-gray", Icon { name: "users" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "Current Session" }
+                            span { class: "metric-value", if session_is_admin { "Admin" } else { "Not Admin" } }
+                            span { class: "metric-note", "from authenticated roles" }
+                        }
+                        div { class: if session_is_admin { "metric-icon tone-green" } else { "metric-icon tone-gray" }, Icon { name: "shield" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "With Email" }
+                            span { class: "metric-value", "{email_count}" }
+                            span { class: "metric-note", "administrator identities" }
+                        }
+                        div { class: "metric-icon tone-gray", Icon { name: "mail" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "Status Metadata" }
+                            span { class: "metric-value", "{status_attention_count}" }
+                            span { class: "metric-note", "non-default records" }
+                        }
+                        div { class: if status_attention_count > 0 { "metric-icon tone-amber" } else { "metric-icon tone-gray" }, Icon { name: "activity" } }
+                    }
+                }
+
+                div { class: "{inventory_class}",
+                    span { class: "readiness-dot" }
+                    div {
+                        strong { "{inventory_title}" }
+                        div { class: "small muted", "{inventory_copy}" }
+                    }
+                }
+
+                div { class: "grid-2",
+                    div { class: "card card-pad stack",
+                        div { class: "product-section-head",
+                            div {
+                                h3 { "Your session" }
+                                p { "The identity currently operating this Console." }
+                            }
+                        }
+                        div { class: "receipt-row", label { "User" } strong { "{session_username}" } }
+                        div { class: "receipt-row", label { "User ID" } strong { class: "mono", "{session_user_id}" } }
+                        div { class: "receipt-row", label { "Authenticated roles" } strong { "{session_roles_text}" } }
+                        div { class: "receipt-row",
+                            label { "Console admin authorization" }
+                            strong { if session_is_admin { "Granted by admin role" } else { "Not granted by admin role" } }
+                        }
+                    }
+                    div { class: "card card-pad stack",
+                        div { class: "product-section-head",
+                            div {
+                                h3 { "Role management" }
+                                p { "Why Team is read-only today." }
+                            }
+                        }
+                        p { class: "small muted", "BurnCloud's current Console authorization checks the admin role from the database. The server can read account roles, but it does not expose authenticated endpoints to invite an administrator, grant or revoke admin, or remove a Team member." }
+                        div { class: "product-note", "Team is read-only until the server exposes explicit role-management endpoints with authorization and audit semantics." }
+                    }
+                }
+
+                if admins.is_empty() {
+                    div { class: "card product-empty",
+                        div { class: "product-empty-inner",
+                            div { class: "product-empty-icon", Icon { name: "users" } }
+                            h3 { "No Console administrators in the loaded account list" }
+                            p { "Team intentionally does not reinterpret root, owner, operator, enterprise, or other labels as Console admin access. The current authorization boundary recognizes admin." }
+                        }
+                    }
+                } else {
+                    div { class: "card table-card",
+                        div { class: "card-pad product-section-head",
+                            div {
+                                h3 { "Console administrators" }
+                                p { "Accounts whose effective role summary is admin. Membership is informational until role-management endpoints exist." }
+                            }
+                        }
+                        div { class: "table-wrap",
+                            table { class: "data-table",
+                                thead { tr {
+                                    th { "Administrator" }
+                                    th { "Email" }
+                                    th { "Console Role" }
+                                    th { "Account Status Metadata" }
+                                } }
+                                tbody {
+                                    for user in admins {
+                                        {
+                                            let email = user.email.clone().unwrap_or_else(|| "No email".to_string());
+                                            let status = status_metadata(user.status);
+                                            let is_current = user.id == session_user_id;
+                                            rsx! {
+                                                tr { key: "{user.id}",
+                                                    td {
+                                                        div { class: "two-line",
+                                                            strong { class: "table-primary", "{user.username}" }
+                                                            small { class: "mono muted",
+                                                                "{user.id}"
+                                                                if is_current { " • Current session" }
+                                                            }
+                                                        }
+                                                    }
+                                                    td { "{email}" }
+                                                    td { span { class: "badge badge-neutral", "admin" } }
+                                                    td {
+                                                        div { class: "two-line",
+                                                            strong { "{status}" }
+                                                            small { class: "muted", "Metadata only; Team does not infer login blocking." }
+                                                        }
                                                     }
                                                 }
-                                                td { "{email}" }
-                                                td { span { class: "badge badge-neutral", "{user.role}" } }
-                                                td { span { class: if user.status == 1 { "badge badge-success" } else { "badge badge-neutral" }, "{status}" } }
                                             }
                                         }
                                     }
                                 }
                             }
                         }
+                        div { class: "card-pad product-note", "No Invite, Change Role, Remove Member, or Suspend controls are shown because the current server does not expose those management operations." }
                     }
                 }
             }

--- a/crates/client/src/functional_pages/access_live.rs
+++ b/crates/client/src/functional_pages/access_live.rs
@@ -56,7 +56,6 @@ pub fn Team() -> Element {
         .any(|role| role.eq_ignore_ascii_case("admin"));
 
     let admin_count = admins.len();
-    let email_count = admins.iter().filter(|user| user.email.is_some()).count();
     let status_attention_count = admins.iter().filter(|user| user.status != 1).count();
     let inventory_class = if admin_count > 0 && status_attention_count == 0 {
         "readiness-strip ready"
@@ -132,11 +131,11 @@ pub fn Team() -> Element {
                     }
                     div { class: "card metric",
                         div { class: "metric-copy",
-                            span { class: "metric-label", "With Email" }
-                            span { class: "metric-value", "{email_count}" }
-                            span { class: "metric-note", "administrator identities" }
+                            span { class: "metric-label", "Role Changes" }
+                            span { class: "metric-value", "Read-only" }
+                            span { class: "metric-note", "no mutation endpoint" }
                         }
-                        div { class: "metric-icon tone-gray", Icon { name: "mail" } }
+                        div { class: "metric-icon tone-gray", Icon { name: "lock" } }
                     }
                     div { class: "card metric",
                         div { class: "metric-copy",

--- a/crates/server/src/api/user.rs
+++ b/crates/server/src/api/user.rs
@@ -96,7 +96,9 @@ async fn require_admin_or_response(
 ) -> Option<axum::response::Response> {
     match is_admin(state, claims).await {
         Ok(true) => None,
-        Ok(false) => Some(err_status(StatusCode::FORBIDDEN, "Admin access required").into_response()),
+        Ok(false) => {
+            Some(err_status(StatusCode::FORBIDDEN, "Admin access required").into_response())
+        }
         Err(status) => Some(err_status(status, "Failed to authorize request").into_response()),
     }
 }

--- a/crates/server/src/api/user.rs
+++ b/crates/server/src/api/user.rs
@@ -65,6 +65,18 @@ struct UserSummary {
     group: &'static str,
 }
 
+fn primary_role(roles: &[String]) -> String {
+    if roles.iter().any(|role| role == "admin") {
+        return "admin".to_string();
+    }
+
+    roles
+        .iter()
+        .min()
+        .cloned()
+        .unwrap_or_else(|| "user".to_string())
+}
+
 pub fn routes() -> Router<AppState> {
     let authenticated = Router::new()
         .route("/console/api/user/recharges", get(list_recharges))
@@ -78,7 +90,10 @@ pub fn routes() -> Router<AppState> {
         .merge(authenticated)
 }
 
-async fn require_admin_or_response(state: &AppState, claims: &Claims) -> Option<axum::response::Response> {
+async fn require_admin_or_response(
+    state: &AppState,
+    claims: &Claims,
+) -> Option<axum::response::Response> {
     match is_admin(state, claims).await {
         Ok(true) => None,
         Ok(false) => Some(err_status(StatusCode::FORBIDDEN, "Admin access required").into_response()),
@@ -253,10 +268,7 @@ async fn list_users(
                     .get_user_roles(&state.db, &u.id)
                     .await
                     .unwrap_or_default();
-                let role = roles
-                    .into_iter()
-                    .next()
-                    .unwrap_or_else(|| "user".to_string());
+                let role = primary_role(&roles);
 
                 summaries.push(UserSummary {
                     id: u.id,
@@ -288,5 +300,23 @@ async fn list_recharges(
     {
         Ok(recharges) => ok(recharges).into_response(),
         Err(e) => err(e).into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::primary_role;
+
+    #[test]
+    fn primary_role_prefers_console_admin() {
+        let roles = vec!["user".to_string(), "admin".to_string()];
+        assert_eq!(primary_role(&roles), "admin");
+    }
+
+    #[test]
+    fn primary_role_has_a_stable_non_admin_fallback() {
+        let roles = vec!["zeta".to_string(), "alpha".to_string()];
+        assert_eq!(primary_role(&roles), "alpha");
+        assert_eq!(primary_role(&[]), "user");
     }
 }


### PR DESCRIPTION
## Goal

Apply the next Phase 2 page-level polish pass to Team after Customers (#417), while aligning the page with BurnCloud's actual authorization contract rather than generic staff-role labels.

Team should answer three questions clearly: who currently qualifies as a Console administrator, what authority the current session has, and which membership actions are intentionally unavailable.

## What changed

### Real Console authorization semantics

- Team now treats `admin` as the Console administrator role because the server's current `is_admin` authorization check resolves database roles and recognizes `admin`
- stop reinterpreting `root`, `owner`, `operator`, `enterprise`, or other role labels as Console administrator access
- rename the inventory around `Console administrators` instead of generic environment operators

### Stable user-role summary

- `list_users` previously took the first database role returned for a user even though role-query ordering is not guaranteed
- add a deterministic `primary_role` helper that always prefers `admin` when present
- use a deterministic lexical fallback for non-admin roles and `user` when no role is present
- keep the existing `role` response field for compatibility
- add small unit tests for admin preference and stable fallback

### Truthful loading and status semantics

- do not render a false empty Team state before the account list resolves
- disable Refresh while the list is loading
- surface load failures explicitly instead of inferring membership from the current session
- stop labeling `status != 1` administrators as `Disabled`
- present account status as metadata because the current login path does not establish that the flag blocks access

### Session and capability hierarchy

- show administrator count, current-session admin authorization, read-only role-management capability, and non-default status metadata as the primary facts
- show the current authenticated roles separately from the effective administrator inventory
- explain that role membership is read-only because the server has no authenticated invite/grant/revoke/remove endpoints
- do not render fake Invite, Change Role, Remove Member, or Suspend controls

### Regression contract

`check-product-ux.sh` now requires:

- Team loading truthfulness
- exact `admin`-role classification
- explicit current-session authorization wording
- status-metadata wording without `Disabled`
- explicit read-only role-management guidance
- deterministic server-side `primary_role` behavior for the compatibility role summary

## Validation

Final head `97e3dc6f7b6f6ba5856846f2bd3fcb7a5966e947` is green on both workflows.

### Client UI Conventions — run #283

- console button conventions ✅
- functional console wiring ✅
- product UX contracts ✅
- visual system contracts ✅
- Dioxus LiveView client ✅
- full BurnCloud application integration ✅
- Windows desktop client (`cargo check -p burncloud-client`) ✅

### Security & Billing Invariants — run #29

- changed-Rust formatting ✅
- server/router package compilation ✅
- Billing invariants ✅
- Security invariants ✅

## Scope

Only:

- `crates/client/src/functional_pages/access_live.rs`
- `crates/client/scripts/check-product-ux.sh`
- `crates/server/src/api/user.rs`
