### PR TITLE
Polish Guardrails around truthful protection signals

### DIFF
--- a/crates/client/scripts/check-product-ux.sh
+++ b/crates/client/scripts/check-product-ux.sh
@@ -118,6 +118,17 @@ require 'Outcome' src/functional_pages/logs_full.rs
 require 'Operational attention' src/functional_pages/analytics_full.rs
 require 'Spend by model' src/functional_pages/analytics.rs
 
+# Guardrails must describe HTTP-error-derived evidence truthfully and fail closed on unknown policy state.
+require 'Request Health' src/functional_pages/guardrails_live.rs
+require 'HTTP risk signals' src/functional_pages/guardrails_live.rs
+require 'not a threat-intelligence feed' src/functional_pages/guardrails_live.rs
+require 'BurnCloud will not show default-off controls' src/functional_pages/guardrails_live.rs
+require 'Circuit breaker state is unavailable' src/functional_pages/guardrails_live.rs
+require 'Save Protection Policy' src/functional_pages/guardrails_live.rs
+forbid 'Security Score' src/functional_pages/guardrails_live.rs
+forbid 'Threat Sources' src/functional_pages/guardrails_live.rs
+forbid 'Circuit breaker telemetry connected' src/functional_pages/guardrails_live.rs
+
 # Dangerous operational actions require explicit acknowledgement and stay in danger zones.
 require 'confirm_trip' src/functional_pages/guardrails_live.rs
 require 'DANGER ZONE' src/functional_pages/guardrails_live.rs

--- a/crates/client/src/functional_pages/guardrails_live.rs
+++ b/crates/client/src/functional_pages/guardrails_live.rs
@@ -1,12 +1,29 @@
 use dioxus::prelude::*;
 
 use crate::{
+    app::Route,
     components::Icon,
     functional_api::{
         circuit_breaker_status, emergency_circuit_break, risk_events, save_security_filters,
-        security_filters, security_summary, RiskEventPage, SecurityFilters, SecuritySummary,
+        security_filters, security_summary, SecurityFilters,
     },
 };
+
+fn event_signal(event_type: &str) -> &'static str {
+    match event_type {
+        "server_error" => "5xx server/upstream error",
+        "client_error" => "4xx client/request error",
+        _ => "HTTP error",
+    }
+}
+
+fn event_tone(event_type: &str) -> &'static str {
+    if event_type == "server_error" {
+        "badge-error"
+    } else {
+        "badge-warning"
+    }
+}
 
 #[component]
 pub fn Guardrails() -> Element {
@@ -34,10 +51,44 @@ pub fn Guardrails() -> Element {
 
     let summary_snapshot = summary_resource.read().clone();
     let event_snapshot = events_resource.read().clone();
-    let summary: SecuritySummary = summary_snapshot.clone().and_then(Result::ok).unwrap_or_default();
-    let events: RiskEventPage = event_snapshot.clone().and_then(Result::ok).unwrap_or_default();
-    let breaker_text = match breaker_resource.read().clone() {
-        Some(Ok(value)) => serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+    let breaker_snapshot = breaker_resource.read().clone();
+
+    let summary_loading = summary_snapshot.is_none();
+    let summary_error = summary_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().err().cloned());
+    let summary = summary_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().ok())
+        .cloned();
+
+    let filters_loading = filter_snapshot.is_none();
+    let filters_error = filter_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().err().cloned());
+    let server_filters = filter_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().ok())
+        .cloned();
+    let filters_ready = server_filters.is_some() && synced();
+
+    let events_loading = event_snapshot.is_none();
+    let events_error = event_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().err().cloned());
+    let events = event_snapshot
+        .as_ref()
+        .and_then(|result| result.as_ref().ok())
+        .cloned();
+
+    let breaker_loading = breaker_snapshot.is_none();
+    let breaker_connected = breaker_snapshot
+        .as_ref()
+        .is_some_and(|result| result.is_ok());
+    let breaker_text = match breaker_snapshot {
+        Some(Ok(value)) => {
+            serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+        }
         Some(Err(message)) => format!("Unavailable: {message}"),
         None => "Loading circuit breaker state…".to_string(),
     };
@@ -47,27 +98,50 @@ pub fn Guardrails() -> Element {
     let blacklist_enabled = filters.blacklist_enabled;
     let rules = filters.custom_rules.clone();
     let enabled_controls = usize::from(content_enabled) + usize::from(blacklist_enabled) + rules.len();
+    let policy_dirty = filters_ready
+        && server_filters
+            .as_ref()
+            .is_some_and(|saved| saved != &filters);
 
-    let mut load_errors = Vec::new();
-    if let Some(Err(message)) = summary_snapshot {
-        load_errors.push(format!("Security summary: {message}"));
-    }
-    if let Some(Err(message)) = filter_snapshot {
-        load_errors.push(format!("Filters: {message}"));
-    }
-    if let Some(Err(message)) = event_snapshot {
-        load_errors.push(format!("Risk events: {message}"));
-    }
+    let request_health_value = summary
+        .as_ref()
+        .map(|value| format!("{}/100", value.score))
+        .unwrap_or_else(|| "—".to_string());
+    let error_event_value = summary
+        .as_ref()
+        .map(|value| value.blocked_count.to_string())
+        .unwrap_or_else(|| "—".to_string());
+    let affected_value = summary
+        .as_ref()
+        .map(|value| value.threat_source_count.to_string())
+        .unwrap_or_else(|| "—".to_string());
+    let policy_value = if filters_ready {
+        enabled_controls.to_string()
+    } else {
+        "—".to_string()
+    };
+    let error_event_icon = summary
+        .as_ref()
+        .map(|value| {
+            if value.blocked_count > 0 {
+                "metric-icon tone-amber"
+            } else {
+                "metric-icon tone-gray"
+            }
+        })
+        .unwrap_or("metric-icon tone-gray");
+    let refreshing = summary_loading || filters_loading || events_loading || breaker_loading;
 
     rsx! {
         div { class: "page",
             div { class: "page-header",
                 div {
                     h2 { class: "page-title", "Guardrails" }
-                    p { class: "page-subtitle", "Set normal traffic protections, review security events, and keep emergency shutdown separate from routine configuration." }
+                    p { class: "page-subtitle", "Configure traffic protections, review HTTP risk signals, and keep emergency shutdown separate from routine policy changes." }
                 }
                 button {
                     class: "button button-secondary",
+                    disabled: refreshing,
                     onclick: move |_| {
                         synced.set(false);
                         summary_resource.restart();
@@ -75,35 +149,71 @@ pub fn Guardrails() -> Element {
                         events_resource.restart();
                         breaker_resource.restart();
                     },
-                    "Refresh"
+                    if refreshing { "Refreshing…" } else { "Refresh" }
                 }
             }
 
-            if !notice().is_empty() { div { class: "terminal auth-status", "{notice}" } }
-            if !error().is_empty() { div { class: "terminal auth-status auth-status-error", "{error}" } }
-            if !load_errors.is_empty() {
+            if !notice().is_empty() {
+                div { class: "terminal auth-status", "{notice}" }
+            }
+            if !error().is_empty() {
+                div { class: "terminal auth-status auth-status-error", "{error}" }
+            }
+
+            if summary_loading {
+                div { class: "card product-empty",
+                    div { class: "product-empty-inner",
+                        div { class: "product-empty-icon", Icon { name: "shield" } }
+                        h3 { "Loading protection signals" }
+                        p { "Reading recent router HTTP outcomes before showing request-health or error conclusions." }
+                    }
+                }
+            } else if let Some(message) = summary_error.clone() {
                 div { class: "card card-pad stack",
-                    strong { class: "danger", "Some security data is unavailable" }
-                    for message in load_errors { code { class: "terminal", "{message}" } }
+                    strong { class: "danger", "Request protection signals are unavailable" }
+                    p { class: "small muted", "BurnCloud will not replace a failed security-summary request with zero-valued health metrics." }
+                    code { class: "terminal", "{message}" }
+                    button { class: "button button-primary", onclick: move |_| summary_resource.restart(), "Retry" }
                 }
-            }
+            } else {
+                div { class: "metrics",
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "Request Health" }
+                            span { class: "metric-value", "{request_health_value}" }
+                            span { class: "metric-note", "derived from recent HTTP success/error ratio" }
+                        }
+                        div { class: "metric-icon tone-gray", Icon { name: "activity" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "HTTP Error Events" }
+                            span { class: "metric-value", "{error_event_value}" }
+                            span { class: "metric-note", "4xx + 5xx in the server summary sample" }
+                        }
+                        div { class: "{error_event_icon}", Icon { name: "logs" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "Affected IDs / Upstreams" }
+                            span { class: "metric-value", "{affected_value}" }
+                            span { class: "metric-note", "distinct IDs involved in HTTP errors" }
+                        }
+                        div { class: "metric-icon tone-gray", Icon { name: "routes" } }
+                    }
+                    div { class: "card metric",
+                        div { class: "metric-copy",
+                            span { class: "metric-label", "Policy Controls" }
+                            span { class: "metric-value", "{policy_value}" }
+                            span { class: "metric-note", "enabled built-ins + custom rules" }
+                        }
+                        div { class: "metric-icon tone-gray", Icon { name: "settings" } }
+                    }
+                }
 
-            div { class: "metrics",
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Security Score" } span { class: "metric-value", "{summary.score}/100" } span { class: "metric-note", "server-calculated posture" } }
-                    div { class: "metric-icon tone-green", Icon { name: "shield" } }
-                }
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Blocked / Error Events" } span { class: "metric-value", "{summary.blocked_count}" } span { class: "metric-note", "observed risk events" } }
-                    div { class: "metric-icon tone-amber", Icon { name: "logs" } }
-                }
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Threat Sources" } span { class: "metric-value", "{summary.threat_source_count}" } span { class: "metric-note", "distinct sources" } }
-                    div { class: "metric-icon tone-red", Icon { name: "users" } }
-                }
-                div { class: "card metric",
-                    div { class: "metric-copy", span { class: "metric-label", "Policy Controls" } span { class: "metric-value", "{enabled_controls}" } span { class: "metric-note", "enabled toggles + rules" } }
-                    div { class: "metric-icon tone-purple", Icon { name: "settings" } }
+                div { class: "product-note",
+                    strong { "Evidence boundary: " }
+                    "Request Health and HTTP risk signals are derived from recent router 4xx/5xx logs. They are operational traffic indicators, not a threat-intelligence feed, intrusion detector, or cryptographic security score."
                 }
             }
 
@@ -112,165 +222,254 @@ pub fn Guardrails() -> Element {
                     div { class: "product-section-head",
                         div {
                             h3 { "Traffic protection policy" }
-                            p { "Routine safeguards belong here. Changes are staged locally until Save Guardrails is pressed." }
+                            p { "Routine safeguards belong here. Changes are staged locally until Save Protection Policy is pressed." }
+                        }
+                        if filters_ready {
+                            if policy_dirty {
+                                span { class: "badge badge-warning", "Unsaved changes" }
+                            } else {
+                                span { class: "badge badge-neutral", "Saved policy" }
+                            }
                         }
                     }
 
-                    label { class: "row between",
-                        span {
-                            div { class: "strong", "Content Filter" }
-                            small { class: "muted", "Apply the server's content-filtering policy to routed traffic." }
+                    if filters_loading {
+                        div { class: "product-note", "Loading the current protection policy before controls become editable…" }
+                    } else if let Some(message) = filters_error.clone() {
+                        div { class: "stack",
+                            strong { class: "danger", "Protection policy unavailable" }
+                            p { class: "small muted", "BurnCloud will not show default-off controls when the real saved policy could not be loaded." }
+                            code { class: "terminal", "{message}" }
+                            button {
+                                class: "button button-secondary button-sm",
+                                onclick: move |_| {
+                                    synced.set(false);
+                                    filters_resource.restart();
+                                },
+                                "Retry policy load"
+                            }
                         }
-                        input {
-                            r#type: "checkbox",
-                            checked: content_enabled,
-                            onchange: move |_| {
-                                let mut next = filter_state();
-                                next.content_filter_enabled = !next.content_filter_enabled;
-                                filter_state.set(next);
-                            },
+                    } else {
+                        label { class: "row between",
+                            span {
+                                div { class: "strong", "Content Filter" }
+                                small { class: "muted", "Apply the server's persisted content-filter policy to routed traffic." }
+                            }
+                            input {
+                                r#type: "checkbox",
+                                checked: content_enabled,
+                                disabled: busy(),
+                                onchange: move |_| {
+                                    let mut next = filter_state();
+                                    next.content_filter_enabled = !next.content_filter_enabled;
+                                    filter_state.set(next);
+                                },
+                            }
                         }
-                    }
 
-                    label { class: "row between",
-                        span {
-                            div { class: "strong", "Blacklist" }
-                            small { class: "muted", "Enable the persisted blacklist protection." }
+                        label { class: "row between",
+                            span {
+                                div { class: "strong", "Blacklist" }
+                                small { class: "muted", "Enable the persisted blacklist protection." }
+                            }
+                            input {
+                                r#type: "checkbox",
+                                checked: blacklist_enabled,
+                                disabled: busy(),
+                                onchange: move |_| {
+                                    let mut next = filter_state();
+                                    next.blacklist_enabled = !next.blacklist_enabled;
+                                    filter_state.set(next);
+                                },
+                            }
                         }
-                        input {
-                            r#type: "checkbox",
-                            checked: blacklist_enabled,
-                            onchange: move |_| {
-                                let mut next = filter_state();
-                                next.blacklist_enabled = !next.blacklist_enabled;
-                                filter_state.set(next);
-                            },
-                        }
-                    }
 
-                    div { class: "field",
-                        label { "Custom rules" }
-                        if rules.is_empty() {
-                            div { class: "product-note", "No custom rules. BurnCloud will rely on the enabled built-in protections." }
-                        }
-                        for (index, rule) in rules.iter().enumerate() {
-                            {
-                                let rule_index = index;
-                                rsx! {
-                                    div { class: "row between card card-pad", key: "{rule_index}",
-                                        code { "{rule}" }
-                                        button {
-                                            class: "button button-ghost button-sm danger",
-                                            onclick: move |_| {
-                                                let mut next = filter_state();
-                                                if rule_index < next.custom_rules.len() {
-                                                    next.custom_rules.remove(rule_index);
-                                                }
-                                                filter_state.set(next);
-                                            },
-                                            "Remove"
+                        div { class: "field",
+                            label { "Custom rules" }
+                            if rules.is_empty() {
+                                div { class: "product-note", "No custom rules. BurnCloud will rely on the enabled built-in protections." }
+                            }
+                            for (index, rule) in rules.iter().enumerate() {
+                                {
+                                    let rule_index = index;
+                                    rsx! {
+                                        div { class: "row between card card-pad", key: "{rule_index}",
+                                            code { "{rule}" }
+                                            button {
+                                                class: "button button-ghost button-sm danger",
+                                                disabled: busy(),
+                                                onclick: move |_| {
+                                                    let mut next = filter_state();
+                                                    if rule_index < next.custom_rules.len() {
+                                                        next.custom_rules.remove(rule_index);
+                                                    }
+                                                    filter_state.set(next);
+                                                },
+                                                "Remove"
+                                            }
                                         }
                                     }
                                 }
                             }
-                        }
-                        div { class: "row gap-2",
-                            input { class: "input", value: "{new_rule}", placeholder: "Add a custom security rule", oninput: move |event| new_rule.set(event.value()) }
-                            button {
-                                class: "button button-secondary",
-                                onclick: move |_| {
-                                    let rule = new_rule().trim().to_string();
-                                    if !rule.is_empty() {
-                                        let mut next = filter_state();
-                                        next.custom_rules.push(rule);
-                                        filter_state.set(next);
-                                        new_rule.set(String::new());
-                                    }
-                                },
-                                "Add Rule"
+                            div { class: "row gap-2",
+                                input {
+                                    class: "input",
+                                    value: "{new_rule}",
+                                    disabled: busy(),
+                                    placeholder: "Add a custom protection rule",
+                                    oninput: move |event| new_rule.set(event.value()),
+                                }
+                                button {
+                                    class: "button button-secondary",
+                                    disabled: busy() || new_rule().trim().is_empty(),
+                                    onclick: move |_| {
+                                        let rule = new_rule().trim().to_string();
+                                        if !rule.is_empty() {
+                                            let mut next = filter_state();
+                                            if !next.custom_rules.iter().any(|existing| existing == &rule) {
+                                                next.custom_rules.push(rule);
+                                                filter_state.set(next);
+                                            }
+                                            new_rule.set(String::new());
+                                        }
+                                    },
+                                    "Add Rule"
+                                }
                             }
                         }
-                    }
 
-                    button {
-                        class: "button button-primary",
-                        disabled: busy(),
-                        onclick: move |_| {
-                            let payload = filter_state();
-                            busy.set(true);
-                            error.set(String::new());
-                            spawn(async move {
-                                match save_security_filters(&payload).await {
-                                    Ok(saved) => {
-                                        filter_state.set(saved);
-                                        notice.set("Guardrail policy saved.".to_string());
-                                        filters_resource.restart();
+                        button {
+                            class: "button button-primary",
+                            disabled: busy() || !filters_ready || !policy_dirty,
+                            onclick: move |_| {
+                                let payload = filter_state();
+                                busy.set(true);
+                                error.set(String::new());
+                                spawn(async move {
+                                    match save_security_filters(&payload).await {
+                                        Ok(saved) => {
+                                            filter_state.set(saved);
+                                            notice.set("Protection policy saved.".to_string());
+                                            filters_resource.restart();
+                                        }
+                                        Err(message) => error.set(format!("Save protection policy failed: {message}")),
                                     }
-                                    Err(message) => error.set(format!("Save guardrails failed: {message}")),
-                                }
-                                busy.set(false);
-                            });
-                        },
-                        "Save Guardrails"
+                                    busy.set(false);
+                                });
+                            },
+                            if busy() { "Saving…" } else { "Save Protection Policy" }
+                        }
                     }
                 }
 
                 div { class: "card card-pad stack-lg",
                     div { class: "product-section-head",
                         div {
-                            h3 { "Protection state" }
-                            p { "Operational circuit-breaker state is visible here without mixing it with emergency actions." }
+                            h3 { "Routing protection state" }
+                            p { "Circuit-breaker telemetry is available only when the router returns its current internal health payload." }
                         }
-                        button { class: "button button-ghost button-sm", onclick: move |_| breaker_resource.restart(), "Refresh" }
+                        button {
+                            class: "button button-ghost button-sm",
+                            disabled: breaker_loading,
+                            onclick: move |_| breaker_resource.restart(),
+                            if breaker_loading { "Checking…" } else { "Refresh" }
+                        }
                     }
-                    div { class: "readiness-strip ready",
-                        span { class: "readiness-dot" }
-                        strong { "Circuit breaker telemetry connected" }
+                    if breaker_loading {
+                        div { class: "readiness-strip",
+                            span { class: "readiness-dot" }
+                            strong { "Checking circuit breaker state" }
+                            span { class: "muted", "Waiting for the router's internal health response." }
+                        }
+                    } else if breaker_connected {
+                        div { class: "readiness-strip ready",
+                            span { class: "readiness-dot" }
+                            strong { "Circuit breaker telemetry available" }
+                            span { class: "muted", "The router returned its current internal health state." }
+                        }
+                    } else {
+                        div { class: "readiness-strip blocked",
+                            span { class: "readiness-dot" }
+                            strong { "Circuit breaker state is unavailable" }
+                            span { class: "muted", "Status could not be verified. Emergency stop remains available because a failed status check should not block incident response." }
+                        }
                     }
                     details {
-                        summary { class: "small strong", style: "cursor:pointer", "View raw circuit breaker state" }
+                        summary { class: "small strong", style: "cursor:pointer", "View raw router protection state" }
                         pre { class: "terminal", style: "margin-top:12px;max-height:260px;overflow:auto;white-space:pre-wrap", "{breaker_text}" }
                     }
-                    div { class: "product-note", "The server currently returns circuit-breaker state as structured operational data. This UI keeps the raw payload available for diagnosis rather than guessing at fields it does not own." }
+                    div { class: "product-note", "The server currently returns circuit-breaker health as an untyped structured payload. BurnCloud keeps the raw payload available for diagnosis instead of inventing unsupported per-circuit labels." }
                 }
             }
 
             div { class: "card table-card",
                 div { class: "card-pad product-section-head",
                     div {
-                        h3 { "Risk events" }
-                        p { "Recent HTTP error and security-related events derived by the server from router activity." }
+                        h3 { "HTTP risk signals" }
+                        p { "Recent request failures derived from router logs. Use Logs for full request-level diagnosis." }
                     }
-                    span { class: "small muted", "{events.total} events" }
+                    div { class: "row gap-2",
+                        if let Some(ref page) = events {
+                            span { class: "small muted", "{page.total} error events" }
+                        }
+                        Link { class: "button button-secondary button-sm", to: Route::Logs {}, "Inspect Request Logs" }
+                    }
                 }
-                if events.data.is_empty() {
-                    div { class: "product-empty", style: "min-height:170px",
+                if events_loading {
+                    div { class: "product-empty",
                         div { class: "product-empty-inner",
-                            div { class: "product-empty-icon", Icon { name: "shield" } }
-                            h3 { "No risk events in this view" }
-                            p { "No HTTP 4xx/5xx security events were returned by the current server query." }
+                            div { class: "product-empty-icon", Icon { name: "logs" } }
+                            h3 { "Loading HTTP error signals" }
+                            p { "Reading recent 4xx/5xx router events before drawing conclusions." }
                         }
                     }
-                } else {
-                    div { class: "table-wrap",
-                        table { class: "data-table",
-                            thead { tr { th { "Time" } th { "Severity" } th { "Type" } th { "Source" } th { "Target" } th { "Status" } th { "Detail" } } }
-                            tbody {
-                                for event in events.data {
-                                    tr { key: "{event.id}",
-                                        td { class: "mono muted", "{event.time}" }
-                                        td { span { class: if event.severity == "critical" { "badge badge-error" } else { "badge badge-warning" }, "{event.severity}" } }
-                                        td { "{event.event_type}" }
-                                        td { class: "mono", "{event.source}" }
-                                        td { class: "mono", "{event.target}" }
-                                        td { "{event.status}" }
-                                        td { "{event.detail}" }
+                } else if let Some(message) = events_error.clone() {
+                    div { class: "card-pad stack",
+                        strong { class: "danger", "HTTP error signals unavailable" }
+                        code { class: "terminal", "{message}" }
+                        button { class: "button button-secondary button-sm", onclick: move |_| events_resource.restart(), "Retry" }
+                    }
+                } else if let Some(page) = events.clone() {
+                    if page.data.is_empty() {
+                        div { class: "product-empty",
+                            div { class: "product-empty-inner",
+                                div { class: "product-empty-icon", Icon { name: "shield" } }
+                                h3 { "No HTTP error signals in this view" }
+                                p { "The current server query returned no 4xx or 5xx router events." }
+                            }
+                        }
+                    } else {
+                        div { class: "table-wrap",
+                            table { class: "data-table",
+                                thead { tr {
+                                    th { "Time" }
+                                    th { "Signal" }
+                                    th { "Account / Source ID" }
+                                    th { "Upstream / Path" }
+                                    th { "HTTP" }
+                                } }
+                                tbody {
+                                    for event in page.data {
+                                        {
+                                            let signal = event_signal(&event.event_type);
+                                            let tone = event_tone(&event.event_type);
+                                            rsx! {
+                                                tr { key: "{event.id}",
+                                                    td { class: "mono muted", title: "{event.time}", "{event.time}" }
+                                                    td { span { class: "badge {tone}", "{signal}" } }
+                                                    td { class: "mono", title: "{event.source}", "{event.source}" }
+                                                    td { class: "mono", title: "{event.target}", "{event.target}" }
+                                                    td { class: "mono strong", "{event.detail}" }
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
                     }
                 }
+                div { class: "card-pad product-note", "These rows are HTTP error-derived operational signals. A 4xx does not automatically mean a malicious client, and a 5xx does not automatically mean an attack." }
             }
 
             div { class: "card card-pad stack-lg danger-zone",
@@ -281,18 +480,30 @@ pub fn Guardrails() -> Element {
                     }
                     span { class: "badge badge-error", "DANGER ZONE" }
                 }
-                p { class: "small muted", "Trip All Circuits is a real operational command. It can stop upstream routing across the environment. This action is deliberately separated from normal guardrail editing." }
+                p { class: "small muted", "Trip All Circuits is a live operational command. It can stop upstream routing across the environment and is deliberately separated from normal protection-policy editing." }
                 div { class: "field",
                     label { "Incident reason" }
-                    textarea { class: "textarea", rows: "3", value: "{reason}", placeholder: "Describe why all routing must be stopped now", oninput: move |event| reason.set(event.value()) }
+                    textarea {
+                        class: "textarea",
+                        rows: "3",
+                        value: "{reason}",
+                        disabled: busy(),
+                        placeholder: "Describe why all routing must be stopped now",
+                        oninput: move |event| reason.set(event.value()),
+                    }
                 }
                 label { class: "row gap-2 small", style: "align-items:flex-start",
-                    input { r#type: "checkbox", checked: confirm_trip(), onchange: move |_| confirm_trip.set(!confirm_trip()) }
+                    input {
+                        r#type: "checkbox",
+                        checked: confirm_trip(),
+                        disabled: busy(),
+                        onchange: move |_| confirm_trip.set(!confirm_trip()),
+                    }
                     span { "I understand this can interrupt all routed traffic in the environment." }
                 }
                 div { class: "row",
                     button {
-                        class: "button button-primary",
+                        class: "button button-danger",
                         disabled: busy() || reason().trim().is_empty() || !confirm_trip(),
                         onclick: move |_| {
                             let incident_reason = reason().trim().to_string();
@@ -300,13 +511,13 @@ pub fn Guardrails() -> Element {
                             error.set(String::new());
                             spawn(async move {
                                 match emergency_circuit_break(&incident_reason).await {
-                                    Ok(value) => {
-                                        notice.set(format!("Emergency circuit break accepted: {value}"));
+                                    Ok(_) => {
+                                        notice.set("Emergency traffic stop accepted by the router.".to_string());
                                         reason.set(String::new());
                                         confirm_trip.set(false);
                                         breaker_resource.restart();
                                     }
-                                    Err(message) => error.set(format!("Emergency circuit break failed: {message}")),
+                                    Err(message) => error.set(format!("Emergency traffic stop failed: {message}")),
                                 }
                                 busy.set(false);
                             });


### PR DESCRIPTION
## Goal

Continue the Phase 2 page-level UI polish with Guardrails, while keeping the page aligned with what the current backend actually proves.

Guardrails should clearly separate three things: HTTP-error-derived operational signals, persisted traffic-protection policy, and the emergency circuit-breaker command.

## What changed

### Truthful protection signals

- rename `Security Score` to `Request Health` and explain that it is derived from the recent HTTP success/error ratio
- rename `Blocked / Error Events` to `HTTP Error Events`
- rename `Threat Sources` to `Affected IDs / Upstreams`, matching the server implementation that counts user/upstream IDs involved in 4xx/5xx rows
- explicitly state that these signals are not threat intelligence, IDS evidence, or a cryptographic security score
- stop rendering zero-valued health metrics while the summary is still loading or failed

### Fail-closed policy editing

- do not render default-off protection controls before the saved server policy has loaded
- show a dedicated unavailable state when policy loading fails
- disable Save until the real policy is loaded and actually differs from the saved snapshot
- show Saved policy vs Unsaved changes state
- prevent duplicate custom rules and lock policy controls while a mutation is in flight

### Circuit-breaker truthfulness

- only show circuit-breaker telemetry as available when the router health request succeeds
- show checking and unavailable states explicitly
- keep the raw structured payload available for diagnosis without inventing unsupported per-circuit semantics
- keep emergency stop usable even when the status query fails, so a failed health read does not block incident response

### HTTP risk-signal readability

- rename the event inventory to `HTTP risk signals`
- distinguish 4xx client/request errors from 5xx server/upstream errors
- simplify the table around Time / Signal / Account or Source ID / Upstream or Path / HTTP
- link directly to Logs for request-level diagnosis
- state explicitly that a 4xx does not automatically mean a malicious client and a 5xx does not automatically mean an attack

### Emergency action hierarchy

- retain the required incident reason and explicit acknowledgement
- use the destructive button treatment for `Trip All Circuits`
- stop dumping the raw router response into the success message
- keep emergency traffic stop visually and behaviorally separate from normal policy editing

### Regression contract

`check-product-ux.sh` now prevents Guardrails from regressing to the old `Security Score`, `Threat Sources`, fake connected circuit-breaker state, or default-off controls on failed policy load.

## Scope

Only:

- `crates/client/src/functional_pages/guardrails_live.rs`
- `crates/client/scripts/check-product-ux.sh`

## Validation

Client UI Conventions run **#284** has passed every substantive build/contract step observed on this head:

- console button conventions ✅
- functional console wiring ✅
- product UX contracts ✅
- visual system contracts ✅
- Dioxus LiveView client ✅
- BurnCloud application integration ✅
- Windows Dioxus desktop client ✅

The Windows job was still completing GitHub Actions cache/checkout post-job cleanup at the last status read; the actual Windows client compile step completed successfully.

Local clone/check was not available in the current execution environment because outbound GitHub DNS resolution is blocked, so this PR does not claim a separate local cargo run.