### PR TITLE
Define the trust-first product text prototype

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -8,14 +8,27 @@ audited_against: c314bff9646f9113c9a58a818552fc80c77543a6
 
 # UI Standards — Current Console Index
 
-These documents describe the rebuilt Dioxus console that is currently routed from `crates/client/src/app.rs`.
+These documents describe the rebuilt Dioxus console that is currently routed from `crates/client/src/app.rs` and the target product semantics that future Console work must converge on.
 
-- [`product-flow.md`](product-flow.md) — canonical Console responsibility flow, page ownership, scope/evidence rules, cross-page handoffs and migration order.
+- [`product-text-prototype.md`](product-text-prototype.md) — trust-first target product text prototype: north star, proof vocabulary, Trust Receipt, Verification and target information architecture.
+- [`product-todo.md`](product-todo.md) — Goal → TODO → Verification execution plan with audited baseline, acceptance criteria and completion gates.
+- [`product-flow.md`](product-flow.md) — canonical current Console responsibility flow, page ownership, scope/evidence rules, cross-page handoffs and migration order.
 - [`tokens.md`](tokens.md) — canonical semantic visual-system ownership and token rules.
 - [`system.md`](system.md) — current Dioxus console/CSS architecture and cascade contract.
 - [`pages.md`](pages.md) — page polish and verification protocol.
 - [`components.md`](components.md) — retained component conventions enforced by executable gates.
 - [`naming.md`](naming.md) — retained CSS naming rules enforced by executable gates.
+
+## Product decision precedence
+
+For future UI work:
+
+1. `product-text-prototype.md` defines the target product claims and trust semantics;
+2. `product-todo.md` defines what must be implemented and how completion is verified;
+3. `product-flow.md` defines current page ownership and migration boundaries;
+4. routed source and executable gates define what the current product actually does today.
+
+Target-state documentation must never be presented as current implementation truth. If routed source lacks a target proof, the UI must show the current limitation rather than the desired future state.
 
 Primary executable sources for the current console:
 
@@ -30,4 +43,4 @@ Primary executable sources for the current console:
 - `crates/client/scripts/check-visual-system.sh`
 - `.github/workflows/client-ui.yml`
 
-If documentation conflicts with the current routed source or an executable gate, source/gates win and the documentation must be corrected in the same change.
+If documentation conflicts with the current routed source or an executable gate about **current behavior**, source/gates win and the documentation must be corrected. If implementation conflicts with the agreed target product semantics, open/continue the corresponding TODO instead of rewriting the target to excuse the implementation.

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -11,6 +11,7 @@ audited_against: c314bff9646f9113c9a58a818552fc80c77543a6
 These documents describe the rebuilt Dioxus console that is currently routed from `crates/client/src/app.rs` and the target product semantics that future Console work must converge on.
 
 - [`product-text-prototype.md`](product-text-prototype.md) — trust-first target product text prototype: north star, proof vocabulary, Trust Receipt, Verification and target information architecture.
+- [`verification-profiles.md`](verification-profiles.md) — machine-testable proof dimensions, named verification profiles, downgrade/failure rules and permitted `CHAIN VERIFIED` wording.
 - [`product-todo.md`](product-todo.md) — Goal → TODO → Verification execution plan with audited baseline, acceptance criteria and completion gates.
 - [`product-flow.md`](product-flow.md) — canonical current Console responsibility flow, page ownership, scope/evidence rules, cross-page handoffs and migration order.
 - [`tokens.md`](tokens.md) — canonical semantic visual-system ownership and token rules.
@@ -24,9 +25,10 @@ These documents describe the rebuilt Dioxus console that is currently routed fro
 For future UI work:
 
 1. `product-text-prototype.md` defines the target product claims and trust semantics;
-2. `product-todo.md` defines what must be implemented and how completion is verified;
-3. `product-flow.md` defines current page ownership and migration boundaries;
-4. routed source and executable gates define what the current product actually does today.
+2. `verification-profiles.md` defines what verification labels mean and the proof required to use them;
+3. `product-todo.md` defines what must be implemented and how completion is verified;
+4. `product-flow.md` defines current page ownership and migration boundaries;
+5. routed source and executable gates define what the current product actually does today.
 
 Target-state documentation must never be presented as current implementation truth. If routed source lacks a target proof, the UI must show the current limitation rather than the desired future state.
 

--- a/docs/ui/product-text-prototype.md
+++ b/docs/ui/product-text-prototype.md
@@ -1,0 +1,752 @@
+---
+doc_id: ui.product-text-prototype
+doc_type: product-prototype
+truth: target-state-with-source-audit
+status: draft
+audited_against: c314bff9646f9113c9a58a818552fc80c77543a6
+---
+
+# BurnCloud Product Text Prototype v0.1
+
+This document defines the target product experience before visual design or page implementation.
+
+It is deliberately text-first. The purpose is to decide **what BurnCloud must prove, what each screen must communicate, and what the user should do next** before spending time on CSS, component polish, or page-specific implementation.
+
+`product-flow.md` remains the current Console responsibility contract. This prototype is the target-state product model that future implementation PRs must validate against.
+
+## 1. North star
+
+BurnCloud's primary product priority is **trust through independent verification**.
+
+The product must not ask a customer to trust a BurnCloud operator, a screenshot, a version string, or a marketing claim. It should expose enough evidence for the customer to independently determine what can and cannot be verified.
+
+Primary product statement:
+
+> **BurnCloud is a verifiable AI gateway. Every AI request should have an explainable and verifiable chain of custody.**
+
+Customer-facing promise:
+
+> **Do not trust our claim. Verify the software, the request path, and the upstream evidence yourself.**
+
+The other product pillars exist under this north star:
+
+```text
+                         TRUST
+                  Verifiable AI Gateway
+                          │
+          ┌───────────────┼───────────────┐
+          │               │               │
+          ▼               ▼               ▼
+     API ROUTER      ROUTING ENGINE    BUSINESS OS
+     can serve       stable/fast/      can operate
+     AI traffic      cost-aware        the business
+          │               │               │
+          └───────────────┴───────────────┘
+                          │
+                must remain explainable
+                  and evidence-backed
+```
+
+Priority order when goals conflict:
+
+1. truthful / verifiable claims;
+2. stable and understandable routing;
+3. complete business operations;
+4. convenience and visual polish.
+
+A visually better screen must never win over a more truthful screen.
+
+## 2. Primary user and proof scenario
+
+The highest-priority trust scenario is the **customer verifying the service sold to them**.
+
+Example:
+
+1. a customer buys access that is represented as AWS Claude;
+2. the customer uses the BurnCloud Client;
+3. the client verifies its own official release provenance;
+4. the client connects to a BurnCloud Server and evaluates what can be proven about that server runtime;
+5. the customer's request receives a stable request identity;
+6. BurnCloud records the route decision and actual upstream evidence;
+7. the client presents a Request Trust Receipt;
+8. the customer can distinguish facts that are cryptographically verified, operationally evidenced, merely declared, or unknown.
+
+Secondary users:
+
+- **Operator** — configures providers, routing, customers, credentials, guardrails and maintenance.
+- **Customer verifier** — checks the service identity and individual request evidence.
+- **Auditor / partner** — evaluates exported evidence without needing Console mutation privileges.
+- **Developer** — maps product claims to source code, tests and provider adapters.
+
+The customer-verifier path has priority over operator convenience when trust semantics conflict.
+
+## 3. Trust chain
+
+The target chain is:
+
+```text
+Official BurnCloud source
+        │
+        ▼
+Signed release manifest
+        │
+        ├── version
+        ├── git commit
+        ├── source/build identity
+        ├── client SHA-256
+        ├── server SHA-256
+        └── BurnCloud release signature
+        │
+        ▼
+BurnCloud Client verifies local package
+        │
+        ▼
+Client evaluates BurnCloud Server identity
+        │
+        ▼
+Request enters BurnCloud
+        │
+        ├── request identity
+        ├── customer / credential attribution
+        ├── requested model
+        ├── eligible route evidence
+        ├── selected upstream
+        ├── fallback / routing decision
+        └── canonical request hash
+        │
+        ▼
+Actual upstream call
+        │
+        ├── provider identity evidence
+        ├── endpoint / region evidence
+        ├── resolved provider model
+        ├── provider request metadata where available
+        └── TLS / transport evidence where meaningful
+        │
+        ▼
+Response returns
+        │
+        ├── HTTP result
+        ├── token usage
+        ├── latency
+        ├── cost evidence
+        ├── canonical response hash
+        └── receipt signature
+        │
+        ▼
+Request Trust Receipt
+```
+
+A break in the chain must remain visible. BurnCloud must not convert a partial chain into a green end-to-end `VERIFIED` claim.
+
+## 4. Claim levels — what BurnCloud is allowed to say
+
+Trust vocabulary must be stricter than normal operational status vocabulary.
+
+| Trust state | Meaning | Allowed example | Forbidden interpretation |
+| --- | --- | --- | --- |
+| `UNKNOWN` | source was not read or proof is missing | `Runtime identity: UNKNOWN` | healthy / false / zero |
+| `DECLARED` | a component reported an identity without independent proof | `Server declares v1.8.2` | official runtime verified |
+| `HASH MATCH` | bytes observed locally match an expected SHA-256 | `Client binary: HASH MATCH` | signer identity verified |
+| `SIGNATURE VERIFIED` | a signed manifest/receipt validates against an expected public key | `Release manifest: SIGNATURE VERIFIED` | remote runtime necessarily running those bytes |
+| `EVIDENCED` | an operational fact is supported by persisted/request/provider evidence | `AWS endpoint: EVIDENCED` | cryptographically attested provider execution |
+| `RUNTIME ATTESTED` | remote measurement is verified against an accepted attestation policy | `Server runtime: RUNTIME ATTESTED` | every upstream response is independently attested |
+| `CHAIN VERIFIED` | all required proof links for a defined verification profile pass | `Request chain: CHAIN VERIFIED` | proof beyond the declared profile |
+
+### Critical wording rule
+
+`VERIFIED` is not a decoration. Every `VERIFIED` label must name the verification profile or the exact proof that passed.
+
+Bad:
+
+```text
+Server VERIFIED
+```
+
+Good:
+
+```text
+Release signature     SIGNATURE VERIFIED
+Client binary hash    HASH MATCH
+Server runtime        UNKNOWN
+Request receipt       SIGNATURE VERIFIED
+AWS endpoint          EVIDENCED
+```
+
+## 5. MD5 policy
+
+MD5 may be displayed only as a compatibility or legacy file fingerprint if required by an external workflow.
+
+It must not be the security basis for official BurnCloud release trust.
+
+The target release identity uses at least:
+
+```text
+Version
+Git commit
+SHA-256 digest
+Signed release manifest
+Signer identity / public-key fingerprint
+```
+
+## 6. Release proof model
+
+Target artifact:
+
+```text
+release-manifest.json
+```
+
+Conceptual fields:
+
+```text
+schema_version
+release_version
+git_commit
+source_tree_identity
+build_profile
+build_timestamp
+client_artifacts[]
+  platform
+  filename
+  sha256
+server_artifacts[]
+  platform
+  filename
+  sha256
+signing_key_id
+signature
+```
+
+The exact canonicalization/signature format must be designed before implementation. The product prototype intentionally does not select a cryptographic library or serialization scheme.
+
+Client behavior:
+
+```text
+Local BurnCloud Client
+        │
+        ├── read local binary/package identity
+        ├── obtain official signed manifest
+        ├── verify BurnCloud release signature
+        ├── calculate local SHA-256
+        └── compare artifact digest
+        │
+        ▼
+SIGNATURE VERIFIED + HASH MATCH
+```
+
+A successful local release check proves the local artifact matches a signed BurnCloud release artifact. It does **not** by itself prove what a remote server is currently executing.
+
+## 7. Server runtime proof model
+
+The product must explicitly separate three generations of server identity.
+
+### Stage R0 — declared identity
+
+Server returns version/build information.
+
+UI wording:
+
+```text
+Server release       v1.8.2
+Runtime proof        DECLARED ONLY
+```
+
+This is useful diagnostics but not independent runtime proof.
+
+### Stage R1 — signed release identity
+
+The client can validate a signed release manifest associated with the server's claimed build.
+
+UI wording:
+
+```text
+Claimed release      v1.8.2
+Release signature    SIGNATURE VERIFIED
+Remote runtime       NOT ATTESTED
+```
+
+This proves the release exists and is officially signed. It still does not prove the remote process is executing those exact bytes.
+
+### Stage R2 — remote runtime attestation
+
+A supported deployment can return a hardware/platform-backed measurement that the client validates against an accepted measurement and policy.
+
+Possible future mechanisms include TEE/TPM-backed remote attestation. Exact infrastructure is an architecture decision, not assumed by this prototype.
+
+UI wording:
+
+```text
+Server release       v1.8.2
+Release signature    SIGNATURE VERIFIED
+Runtime measurement  MATCH
+Attestation          RUNTIME ATTESTED
+```
+
+Only this stage may support a strong remote-runtime verification profile.
+
+## 8. Request Trust Receipt
+
+The Request Trust Receipt is the central target product object.
+
+It is not a prettier log row. It is the evidence package for one routed AI request.
+
+Target conceptual schema:
+
+```text
+Receipt Identity
+  receipt_schema
+  receipt_id
+  request_id
+  created_at
+
+Software Identity
+  client_release
+  client_release_proof
+  server_release_claim
+  server_runtime_proof
+
+Request Identity
+  customer_id / privacy-safe identity
+  credential_id / management-safe identity
+  requested_model
+  request_hash
+
+Routing Decision
+  route_group
+  eligible_upstreams
+  selected_upstream
+  routing_policy
+  layer_decision
+  fallback_chain
+
+Upstream Evidence
+  provider_family
+  provider_account_identity (privacy-safe)
+  provider_region
+  endpoint_identity
+  resolved_provider_model
+  upstream_request_id / provider metadata when available
+  provider_evidence_profile
+
+Response Evidence
+  status_code
+  latency_ms
+  prompt_tokens
+  completion_tokens
+  cache_tokens
+  reasoning_tokens
+  response_hash
+
+Financial Evidence
+  pricing_region
+  cost_status
+  upstream_cost
+  customer_charge when available
+
+Receipt Proof
+  canonical_receipt_hash
+  signer_key_id
+  receipt_signature
+  verification_profile
+```
+
+Existing fields such as `request_id`, `upstream_id`, `layer_decision`, `traffic_color`, `cost_status`, token counts and cost are useful foundations, but they are not yet equivalent to a complete Trust Receipt.
+
+### Receipt signature limitation
+
+A signed receipt binds fields to a signing key. That alone does not prove the signer ran an official BurnCloud runtime.
+
+The UI therefore must keep these separate:
+
+```text
+Receipt signature       SIGNATURE VERIFIED
+Signer identity         KNOWN / UNKNOWN
+Server runtime          DECLARED / RUNTIME ATTESTED
+Upstream evidence       EVIDENCED / UNKNOWN
+Overall verification    profile-dependent
+```
+
+## 9. Upstream proof model
+
+Different providers expose different evidence. BurnCloud must use provider-specific evidence adapters instead of inventing one universal proof claim.
+
+Evidence categories may include:
+
+- configured provider family;
+- resolved endpoint host;
+- TLS certificate/connection result where available and meaningful;
+- cloud region;
+- provider-native request ID or response metadata;
+- resolved provider model identifier;
+- account/credential alias represented in a privacy-safe way;
+- provider-specific signed or attestable metadata if a provider supports it.
+
+Target UI rule:
+
+> Show the strongest evidence actually available for that provider, and show `UNKNOWN` for missing proof.
+
+Never infer:
+
+- `upstream_id = AWS` ⇒ AWS execution cryptographically verified;
+- an HTTPS hostname ⇒ model authenticity proven;
+- a successful Claude-like response ⇒ Anthropic model identity proven;
+- a configured provider ⇒ this request actually used that provider.
+
+## 10. Target information architecture
+
+This is the target product model, not an instruction to rename every route immediately.
+
+```text
+Overview
+
+TRAFFIC
+  Providers
+  Models
+  Routes
+  Playground
+
+TRUST
+  Requests
+  Verification
+
+BUSINESS
+  Customers
+  API Keys
+  Usage
+  Billing
+
+CONTROL
+  Guardrails
+  Team
+  Settings
+```
+
+### Migration note
+
+Current `Logs` may evolve into `Requests` once the request evidence object is strong enough. Do not rename the route merely for branding before the underlying product semantics change.
+
+A separate `Evidence` page is not required if Request detail + Verification can make the chain understandable. Avoid creating navigation merely to mirror database concepts.
+
+## 11. Text prototype — BurnCloud Client startup
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│ BurnCloud Client                                             │
+│ Verify before you trust                                      │
+├──────────────────────────────────────────────────────────────┤
+│ LOCAL SOFTWARE                                               │
+│                                                              │
+│ Version                 v1.8.2                               │
+│ Git commit              c314bff                              │
+│ Release signature       SIGNATURE VERIFIED                   │
+│ Client SHA-256          HASH MATCH                           │
+│                                                              │
+│ [View signed manifest]                                       │
+├──────────────────────────────────────────────────────────────┤
+│ CONNECTED SERVER                                             │
+│                                                              │
+│ Endpoint                https://gateway.example.com           │
+│ Claimed release         v1.8.2                               │
+│ Release signature       SIGNATURE VERIFIED                   │
+│ Runtime proof           NOT ATTESTED                         │
+│                                                              │
+│ This server matches an official release claim, but the       │
+│ remote process has not supplied hardware-backed attestation. │
+│                                                              │
+│ [Open Verification]                                          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The important behavior is the truthful limitation message. The UI must not turn `NOT ATTESTED` into a green generic `VERIFIED` banner.
+
+## 12. Text prototype — Overview
+
+```text
+┌────────────────────────────────────────────────────────────────────┐
+│ OVERVIEW                                                           │
+│ Trust first. Operate from evidence.                                │
+├────────────────────────────────────────────────────────────────────┤
+│ TRUST STATUS                                                       │
+│                                                                    │
+│ Client release        SIGNATURE VERIFIED / HASH MATCH              │
+│ Server runtime        NOT ATTESTED                                 │
+│ Request evidence      98.7% receipt coverage                       │
+│ Upstream evidence     7 evidenced / 1 limited / 1 unknown          │
+│                                                                    │
+│ Primary conclusion:                                               │
+│ Request traffic is operating, but remote runtime identity is       │
+│ not yet independently attested.                                   │
+│                                                                    │
+│ [Open Verification]                                                │
+├────────────────────────────────────────────────────────────────────┤
+│ NEEDS ATTENTION                                                    │
+│                                                                    │
+│ • 12 requests have incomplete upstream evidence   → Open Requests │
+│ • 1 provider has no active supply                 → Providers     │
+│                                                                    │
+├────────────────────────────────────────────────────────────────────┤
+│ OPERATING FLOW                                                     │
+│                                                                    │
+│ Supply     AVAILABLE       8 providers / 21 models / 4 groups     │
+│ Access     AVAILABLE       55 active credentials                  │
+│ Traffic    OBSERVED        1,240 recent requests                  │
+│ Business   AVAILABLE       billing source loaded                  │
+│                                                                    │
+├────────────────────────────────────────────────────────────────────┤
+│ LATEST REQUEST                                                     │
+│                                                                    │
+│ req_01J...                                                         │
+│ claude-sonnet → AWS Bedrock → HTTP 200                            │
+│ Trust receipt: PARTIAL CHAIN                                      │
+│                                                                    │
+│ [Open Request]                                                     │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Overview owns the conclusion and handoff only. It must not become the detailed release verifier, provider inspector, request receipt, or billing ledger.
+
+## 13. Text prototype — Requests
+
+Target evolution of today's operational Logs surface:
+
+```text
+┌────────────────────────────────────────────────────────────────────┐
+│ REQUESTS                                                           │
+│ Every routed request and the evidence BurnCloud retained.          │
+├────────────────────────────────────────────────────────────────────┤
+│ Search request ID...                 [Trust: Any ▼] [Provider ▼]   │
+├────────────────────────────────────────────────────────────────────┤
+│ TIME      REQUEST       MODEL         UPSTREAM       RESULT  TRUST  │
+│ 21:42     req_01J...    sonnet        AWS Bedrock    200     FULL   │
+│ 21:41     req_01K...    sonnet        Anthropic     200     PARTIAL│
+│ 21:40     req_01L...    gemini        UNKNOWN       502     LIMITED│
+│                                                                    │
+│ Selecting a row opens its Request Trust Receipt.                   │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The Trust column represents a defined verification profile, not a subjective confidence score.
+
+## 14. Text prototype — Request Trust Receipt
+
+```text
+┌────────────────────────────────────────────────────────────────────┐
+│ REQUEST TRUST RECEIPT                                              │
+│ req_01J...                                        PARTIAL CHAIN    │
+├────────────────────────────────────────────────────────────────────┤
+│ 1. SOFTWARE                                                       │
+│ Client release          v1.8.2  SIGNATURE VERIFIED / HASH MATCH   │
+│ Server release          v1.8.2  SIGNATURE VERIFIED                │
+│ Server runtime                  NOT ATTESTED                       │
+├────────────────────────────────────────────────────────────────────┤
+│ 2. REQUEST                                                        │
+│ Customer                customer_***                              │
+│ Credential              key_mgmt_***                              │
+│ Requested model         claude-sonnet                             │
+│ Request hash            sha256:...                                │
+├────────────────────────────────────────────────────────────────────┤
+│ 3. ROUTING DECISION                                               │
+│ Route group             premium-claude                            │
+│ Eligible upstreams      AWS / Anthropic                           │
+│ Selected                AWS Bedrock                               │
+│ Decision                primary                                  │
+│ Failover                none                                     │
+├────────────────────────────────────────────────────────────────────┤
+│ 4. UPSTREAM EVIDENCE                                              │
+│ Provider                AWS Bedrock                               │
+│ Region                  us-east-1                                 │
+│ Endpoint                bedrock-runtime...                        │
+│ Provider model          anthropic.claude-...                      │
+│ Provider request ID     ...                                       │
+│ Evidence profile        EVIDENCED                                 │
+├────────────────────────────────────────────────────────────────────┤
+│ 5. RESPONSE                                                       │
+│ HTTP                    200                                       │
+│ Latency                 1,284 ms                                  │
+│ Prompt / completion     12,482 / 2,194                            │
+│ Response hash           sha256:...                                │
+├────────────────────────────────────────────────────────────────────┤
+│ 6. RECEIPT PROOF                                                  │
+│ Receipt hash            sha256:...                                │
+│ Receipt signature       SIGNATURE VERIFIED                        │
+│ Runtime attestation     NOT AVAILABLE                             │
+│                                                                    │
+│ Why PARTIAL CHAIN?                                                 │
+│ The request and upstream evidence are signed and retained, but     │
+│ this server did not provide an accepted remote-runtime attestation.│
+│                                                                    │
+│ [Export Receipt] [Verify Receipt]                                 │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The explanation of *why* a chain is partial is mandatory. A score without reasons is not useful trust UX.
+
+## 15. Text prototype — Verification
+
+```text
+┌────────────────────────────────────────────────────────────────────┐
+│ VERIFICATION                                                       │
+│ Independently inspect BurnCloud software and proof capabilities.   │
+├────────────────────────────────────────────────────────────────────┤
+│ RELEASE                                                           │
+│ Version                 v1.8.2                                    │
+│ Commit                  c314bff                                   │
+│ Manifest                SIGNATURE VERIFIED                         │
+│ Signer                  BurnCloud Release Key ...                  │
+│ Client SHA-256          HASH MATCH                                │
+│ Server artifact SHA-256 manifest-known                            │
+│                                                                    │
+│ [View Manifest] [Copy Digests]                                    │
+├────────────────────────────────────────────────────────────────────┤
+│ RUNTIME                                                           │
+│ Server claim            v1.8.2                                    │
+│ Runtime attestation     NOT AVAILABLE                             │
+│                                                                    │
+│ What this proves: official release metadata can be verified.       │
+│ What this does not prove: exact remote process bytes at this time. │
+├────────────────────────────────────────────────────────────────────┤
+│ REQUEST EVIDENCE PROFILES                                         │
+│ Signed receipt          AVAILABLE                                 │
+│ AWS evidence adapter    AVAILABLE                                 │
+│ Anthropic adapter       LIMITED                                   │
+│ Runtime-bound receipt   NOT AVAILABLE                             │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Verification is an explanation surface. It must always expose both **what is proven** and **what is not proven**.
+
+## 16. Text prototype — Traffic
+
+Traffic configuration remains operationally simple:
+
+```text
+Providers → Models → Routes → Playground
+```
+
+But each page must help produce evidence for the trust chain.
+
+### Providers
+
+Must answer:
+
+- what provider is configured;
+- what provider family BurnCloud believes it is;
+- which endpoint/region/account alias will be used;
+- what upstream evidence profile the adapter can collect;
+- current operational availability.
+
+### Models
+
+Must answer:
+
+- which model IDs are derived from providers;
+- which are currently available;
+- which have multiple active upstreams;
+- which upstream identity profiles can support them.
+
+### Routes
+
+Must answer:
+
+- what candidates are eligible;
+- priority/weight/policy;
+- failover behavior;
+- what routing facts will be retained in the request receipt.
+
+### Playground
+
+Must be the easiest way to create one real request and immediately open its Request Trust Receipt.
+
+The success path should become:
+
+```text
+Send test request
+       ↓
+Receive response
+       ↓
+Persist request evidence
+       ↓
+Open Trust Receipt
+       ↓
+Verify what happened
+```
+
+## 17. Text prototype — Business OS
+
+Business capability remains important, but it must inherit trust semantics instead of competing with them.
+
+Target business chain:
+
+```text
+Customer
+   ↓
+Wallet / commercial terms
+   ↓
+API Key
+   ↓
+Request
+   ↓
+Usage
+   ↓
+Upstream cost
+   ↓
+Customer charge
+   ↓
+Margin / settlement
+```
+
+Future business pages must be able to trace aggregate numbers back to request evidence when the source contracts permit it.
+
+Do not reconstruct billing truth from an arbitrary bounded log sample.
+
+## 18. Product completion loop
+
+No feature is complete because its UI exists.
+
+Every product task follows:
+
+```text
+GOAL
+  ↓
+TEXT PROTOTYPE
+  ↓
+TODO WITH ACCEPTANCE CRITERIA
+  ↓
+IMPLEMENTATION
+  ↓
+SOURCE-OF-TRUTH CHECK
+  ↓
+STATE / ERROR CHECK
+  ↓
+CROSS-PAGE HANDOFF CHECK
+  ↓
+EXECUTABLE CONTRACT / TEST
+  ↓
+VISUAL REVIEW
+  ↓
+GOAL VERIFICATION
+```
+
+If goal verification fails, reopen the TODO even when implementation and CI are green.
+
+## 19. Definition of done for trust features
+
+A trust-related feature is complete only when:
+
+1. the exact claim is defined;
+2. the source of proof is named;
+3. missing proof has an explicit `UNKNOWN`/`NOT AVAILABLE` state;
+4. the UI distinguishes declaration, evidence, signature verification and runtime attestation;
+5. the proof can be independently checked by the intended verifier;
+6. the result explains why it passed, failed or remained partial;
+7. negative tests prove BurnCloud does not overclaim when evidence is absent or invalid;
+8. exported evidence does not leak credentials or sensitive raw secrets;
+9. the product TODO links to implementation and verification evidence;
+10. the north-star question is answered: **does this make the customer's request chain more independently verifiable?**
+
+## 20. Immediate product decision
+
+Until this prototype and the linked TODO are reviewed, new page-polish work should not introduce additional navigation concepts, trust scores, generic `VERIFIED` labels, or new ownership boundaries.
+
+Existing draft implementation PRs are candidates to be re-validated against this prototype rather than treated as acceptance truth merely because they compile.

--- a/docs/ui/product-todo.md
+++ b/docs/ui/product-todo.md
@@ -1,0 +1,369 @@
+---
+doc_id: ui.product-todo
+doc_type: product-execution-plan
+truth: target-state-with-source-audit
+status: draft
+audited_against: c314bff9646f9113c9a58a818552fc80c77543a6
+---
+
+# BurnCloud Goal → TODO → Verification Plan v0.1
+
+This document converts `product-text-prototype.md` into an executable product backlog.
+
+The unit of completion is a **verified product goal**, not a page, component, or merged PR.
+
+## 1. Status vocabulary
+
+Use these statuses until a task has explicit implementation evidence:
+
+- `DEFINED` — target behavior and acceptance criteria are documented.
+- `EXISTS` — the current audited source directly contains the required primitive.
+- `PARTIAL` — useful implementation exists, but the target product contract is incomplete.
+- `GAP` — no matching implementation was located in the baseline source audit; this is a backlog item, not a proof of impossibility.
+- `DESIGN REQUIRED` — architecture/security/provider design must be resolved before implementation.
+- `BLOCKED EXTERNAL` — completion depends on a provider/platform capability BurnCloud does not control.
+- `VERIFIED DONE` — implementation, negative states, tests and goal-level verification all pass.
+
+Do not mark a task `VERIFIED DONE` because a PR merged or CI is green.
+
+## 2. Current audited foundation
+
+The baseline audit found useful request-observability primitives in the current router log model, including:
+
+- `request_id`;
+- `user_id`;
+- `upstream_id`;
+- `model`;
+- HTTP status and latency;
+- detailed token/cost fields;
+- `pricing_region`;
+- `layer_decision`;
+- `traffic_color`;
+- `cost_status`;
+- `error_type`.
+
+These fields are **PARTIAL request evidence**, not a complete Trust Receipt.
+
+The baseline repository search did not locate a complete implementation of:
+
+- signed BurnCloud release manifests;
+- release artifact SHA-256 verification as a product feature;
+- BurnCloud release signer/public-key verification;
+- canonical request/response hashes for Trust Receipts;
+- signed Request Trust Receipts;
+- remote runtime attestation;
+- provider-specific upstream evidence profiles sufficient for the target trust UI.
+
+These findings are the starting backlog, not permanent assumptions. Re-audit source whenever implementation changes.
+
+## 3. Goal hierarchy
+
+```text
+G0  TRUST NORTH STAR
+    Every customer request has an independently understandable,
+    evidence-backed verification chain.
+
+    ├── G1  API ROUTER
+    │       A customer can reliably send a real AI request.
+    │
+    ├── G2  ROUTING ENGINE
+    │       The route decision is stable, resilient and explainable.
+    │
+    └── G3  BUSINESS OS
+            The operator can run customer, usage, cost and billing operations.
+
+All G1/G2/G3 claims inherit G0 truth and evidence rules.
+```
+
+## 4. G0 — Trust north star
+
+### G0 success statement
+
+For a selected routed request, the intended verifier can determine:
+
+1. what BurnCloud Client release they are using;
+2. whether that local release matches a signed official artifact;
+3. what the remote BurnCloud Server claims to run;
+4. whether remote runtime identity is independently attested or only declared;
+5. who/what initiated the request using privacy-safe identities;
+6. which model was requested;
+7. how routing selected an upstream;
+8. what actual upstream evidence was retained;
+9. what response/result/tokens/cost were recorded;
+10. which receipt fields are integrity-bound;
+11. exactly why the verification result is full, partial, limited or unknown.
+
+### G0 verification test
+
+A reviewer must be able to take one test request and answer all eleven questions from product evidence without relying on a screenshot or an operator's verbal explanation.
+
+If any unsupported claim is rendered as generic `VERIFIED`, G0 fails.
+
+## 5. P0 — Freeze product semantics before more page polish
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| P0.1 | Define trust-first north star | `DEFINED` | Product prototype names independent verification as priority #1 |
+| P0.2 | Define claim vocabulary | `DEFINED` | `UNKNOWN`, `DECLARED`, `HASH MATCH`, `SIGNATURE VERIFIED`, `EVIDENCED`, `RUNTIME ATTESTED`, `CHAIN VERIFIED` have non-overlapping meanings |
+| P0.3 | Define Request Trust Receipt target | `DEFINED` | Receipt sections and proof limitations are documented |
+| P0.4 | Define verification profiles | `DESIGN REQUIRED` | Exact requirements for `FULL`, `PARTIAL`, `LIMITED` (or final names) are machine-testable |
+| P0.5 | Revalidate existing draft UI PRs | `GAP` | Every draft states which prototype goal it satisfies and removes conflicting semantics |
+
+**Gate:** do not introduce new generic trust scores or `VERIFIED` badges before P0.4 is resolved.
+
+## 6. P1 — Official release provenance
+
+Goal: a customer can independently verify that the local BurnCloud Client package matches an official signed release.
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| P1.1 | Specify signed release manifest schema | `DESIGN REQUIRED` | Canonical fields, serialization/canonicalization, versioning and signature envelope documented |
+| P1.2 | Choose release signing algorithm/key lifecycle | `DESIGN REQUIRED` | Public verification key distribution, rotation, compromise and revocation behavior documented |
+| P1.3 | Generate SHA-256 for supported artifacts | `GAP` | CI/release pipeline publishes digest for every declared artifact |
+| P1.4 | Sign release manifest in official release workflow | `GAP` | Signature produced by protected release key and independently verifiable |
+| P1.5 | Publish git commit/source identity | `GAP` | Manifest binds release to repository source/build identity |
+| P1.6 | Implement client-side manifest verification | `GAP` | Invalid signature fails closed and displays reason |
+| P1.7 | Implement local artifact SHA-256 verification | `GAP` | Mutated local artifact produces mismatch, never generic verified |
+| P1.8 | Add release-provenance negative tests | `GAP` | Tampered manifest, wrong key, changed artifact and unsupported schema all fail explicitly |
+
+### P1 goal verification
+
+Given an official client package, a mutated package, and a forged manifest, the verifier must distinguish:
+
+- valid signature + matching SHA-256;
+- valid signature + mismatching artifact;
+- invalid/unknown signer;
+- unknown/unsupported proof.
+
+## 7. P2 — Server identity and runtime proof
+
+Goal: the client tells the truth about what it can prove about the remote server.
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| P2.1 | Define server build identity API | `DESIGN REQUIRED` | Endpoint exposes version/commit/build identity without calling it attestation |
+| P2.2 | Bind server claim to signed release manifest | `GAP` | Client can verify the claimed release exists in an official signed manifest |
+| P2.3 | UI state `DECLARED / NOT ATTESTED` | `GAP` | Signed release claim is not rendered as remote-runtime verified |
+| P2.4 | Select first remote-attestation deployment target | `DESIGN REQUIRED` | TEE/TPM/cloud mechanism, threat model and accepted measurements are explicit |
+| P2.5 | Implement attestation verifier | `GAP` | Invalid measurement/challenge/certificate fails closed |
+| P2.6 | Bind attestation to server release measurement | `GAP` | Accepted attestation proves a measurement covered by policy |
+| P2.7 | Define attestation freshness/replay defense | `DESIGN REQUIRED` | Challenge/nonce/expiry behavior prevents stale proof reuse |
+| P2.8 | Runtime-attestation negative tests | `GAP` | Wrong measurement, stale evidence and unsupported platform become non-attested states |
+
+### P2 goal verification
+
+A non-attested server that claims the correct official version must still display `NOT ATTESTED`.
+
+This is a mandatory negative acceptance test.
+
+## 8. P3 — Request Trust Receipt foundation
+
+Goal: every eligible routed request can produce a stable, privacy-safe evidence object.
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| P3.1 | Stable request identity | `EXISTS` | `request_id` is persisted and queryable |
+| P3.2 | User/account attribution | `PARTIAL` | current `user_id` is usable; target privacy-safe customer/credential semantics are specified |
+| P3.3 | Requested model | `EXISTS` | persisted request model available |
+| P3.4 | Selected upstream identity | `PARTIAL` | `upstream_id` exists but is mapped to a clear provider evidence identity |
+| P3.5 | Routing decision field | `PARTIAL` | `layer_decision` exists; receipt semantics and candidate snapshot are defined |
+| P3.6 | Traffic classification | `PARTIAL` | `traffic_color` exists; receipt meaning is documented or omitted from trust claims |
+| P3.7 | Token/cost evidence | `PARTIAL` | detailed counts/cost fields exist; receipt scope/source contract is documented |
+| P3.8 | Canonical request hash | `GAP` | canonicalization excludes secrets and produces stable digest for eligible request classes |
+| P3.9 | Canonical response hash | `GAP` | streaming/non-streaming behavior is defined and tested |
+| P3.10 | Receipt schema + version | `DESIGN REQUIRED` | backward-compatible schema/version policy exists |
+| P3.11 | Persist receipt proof fields | `GAP` | receipt hash, signer key id, signature/profile can be queried |
+| P3.12 | Sign Trust Receipt | `GAP` | modified receipt fails verification |
+| P3.13 | Receipt privacy/security review | `DESIGN REQUIRED` | no bearer secrets, raw provider credentials or unsafe payload leakage |
+| P3.14 | Export receipt | `GAP` | customer/auditor can export a stable verification artifact |
+| P3.15 | Offline/client receipt verifier | `GAP` | exported artifact can be verified without trusting Console rendering |
+
+### P3 goal verification
+
+Mutating any integrity-covered receipt field after signing must fail verification.
+
+Removing optional upstream evidence must downgrade the chain instead of invalidating unrelated verified links.
+
+## 9. P4 — Provider-specific upstream evidence
+
+Goal: BurnCloud proves only the strongest upstream facts actually supported by each provider path.
+
+Common adapter contract to design:
+
+```text
+provider_family
+endpoint_identity
+region
+resolved_provider_model
+privacy_safe_account_alias
+provider_request_id / response metadata
+transport evidence
+provider-specific evidence fields
+coverage / limitation reason
+```
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| P4.1 | Generic upstream evidence interface | `DESIGN REQUIRED` | provider adapters return typed evidence + limitations |
+| P4.2 | AWS Bedrock evidence adapter | `GAP` | captures only evidence actually available from the AWS path |
+| P4.3 | Anthropic evidence adapter | `GAP` | captures only evidence actually available from the Anthropic path |
+| P4.4 | Google/Gemini evidence adapter | `GAP` | provider-specific metadata mapped without fabricated parity |
+| P4.5 | Azure/OpenAI evidence adapter | `GAP` | provider-specific metadata mapped without fabricated parity |
+| P4.6 | Evidence redaction contract | `DESIGN REQUIRED` | secrets/credential material can never enter exported receipts |
+| P4.7 | Unsupported-provider state | `GAP` | unknown adapter produces `LIMITED/UNKNOWN`, never fake verification |
+| P4.8 | Provider-evidence negative tests | `GAP` | missing request ID/region/metadata downgrades only relevant claims |
+
+### P4 goal verification
+
+For an AWS-labelled channel with missing provider-native evidence, the UI must not claim that AWS execution is cryptographically verified merely because `upstream_id` points to that channel.
+
+## 10. P5 — BurnCloud Client trust UX
+
+Goal: the customer can verify without understanding internal Rust/database implementation.
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| P5.1 | Local release verification screen | `GAP` | signature, SHA-256, version/commit and failure reasons visible |
+| P5.2 | Connected server verification screen | `GAP` | declared release and runtime-attestation state separated |
+| P5.3 | Request list trust column/profile | `GAP` | value has defined profile, not subjective score |
+| P5.4 | Request Trust Receipt detail | `GAP` | six-section text prototype can be implemented from real data |
+| P5.5 | `Why partial?` explanation | `GAP` | every degraded chain names missing/failed links |
+| P5.6 | Export + verify receipt action | `GAP` | verifier can check artifact independently |
+| P5.7 | Verification help | `GAP` | UI states what each proof does and does not establish |
+| P5.8 | Trust UX accessibility/clarity test | `GAP` | non-expert test user can distinguish declared, signed and attested |
+
+## 11. G1 — API Router product goal
+
+### G1 success statement
+
+Starting from a clean supported environment, an operator can configure upstream supply and produce a successful customer-callable AI API request through BurnCloud.
+
+Current product chain:
+
+```text
+Providers → Models → Routes → API access → Playground/real API → Request evidence
+```
+
+### G1 TODO
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| G1.1 | Provider configuration | `PARTIAL` | supported provider can be configured with truthful state/error UX |
+| G1.2 | Derived model availability | `PARTIAL` | configured vs available vs redundant remain distinct |
+| G1.3 | Route/failover configuration story | `PARTIAL` | operator can understand how model traffic can be served |
+| G1.4 | Customer/credential ownership | `PARTIAL` | owner identity and bearer-secret lifecycle remain safe |
+| G1.5 | Real Playground verification | `PARTIAL` | successful test is persisted as request evidence |
+| G1.6 | Clean-environment E2E acceptance | `GAP` | one documented scenario proves setup → successful routed request |
+
+G1 must not be marked done until its successful request can enter the G0 evidence chain.
+
+## 12. G2 — Routing Engine product goal
+
+### G2 success statement
+
+For a routed request, an operator/customer can understand what candidates were eligible, what policy chose the selected upstream, whether fallback occurred, and which evidence proves the actual outcome.
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| G2.1 | Provider candidate model | `PARTIAL` | current provider/model/group configuration exists |
+| G2.2 | Persist eligible candidate snapshot | `GAP` | receipt can explain candidates at decision time, not only current config |
+| G2.3 | Persist selected policy/decision reason | `PARTIAL` | existing `layer_decision` becomes defined receipt evidence |
+| G2.4 | Persist failover chain | `PARTIAL` | failover steps are explicit enough for request explanation |
+| G2.5 | Health/capacity decision evidence | `DESIGN REQUIRED` | only inputs actually used by router are retained/explained |
+| G2.6 | Cost-aware decision evidence | `DESIGN REQUIRED` | if cost participates in routing, exact source/policy is explainable |
+| G2.7 | Routing explanation UI | `GAP` | Request detail explains `why this upstream` without reconstructing history from current config |
+| G2.8 | Routing invariants tests | `PARTIAL` | existing router tests are extended to receipt/explanation invariants |
+
+## 13. G3 — Business OS product goal
+
+### G3 success statement
+
+An operator can manage a customer lifecycle from account/funding through credentials, usage, upstream cost, customer charge and settlement/margin evidence, while retaining request-level traceability where supported.
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| G3.1 | Customer account lifecycle | `PARTIAL` | current customer/funding capability mapped to explicit business semantics |
+| G3.2 | Credential ownership/lifecycle | `PARTIAL` | account-owned credential management is safe and auditable |
+| G3.3 | Usage source contract | `PARTIAL` | account/environment scope is explicit everywhere |
+| G3.4 | Billing source contract | `PARTIAL` | billing truth is not reconstructed from bounded Logs samples |
+| G3.5 | Upstream cost evidence | `PARTIAL` | current cost fields mapped to exact pricing/source semantics |
+| G3.6 | Customer charge model | `DESIGN REQUIRED` | selling price/discount/charge semantics defined independently of upstream cost |
+| G3.7 | Margin model | `GAP` | revenue - upstream cost can be explained by period/customer/model/request source |
+| G3.8 | Settlement workflow | `DESIGN REQUIRED` | receivable/prepaid/postpaid behavior and authoritative ledger defined |
+| G3.9 | Business-to-request drilldown | `GAP` | aggregate metric can reach supporting request evidence when contract permits |
+
+## 14. UI migration backlog after trust semantics freeze
+
+Do not use this as a page-polish checklist. Each item must link to a goal above.
+
+| Order | Surface | Product reason |
+| --- | --- | --- |
+| 1 | Overview | trust conclusion + highest-value next action |
+| 2 | Providers | establish truthful upstream identity/evidence capability |
+| 3 | Models | expose model availability without overstating identity proof |
+| 4 | Routes | make routing candidates/decisions explainable |
+| 5 | Playground | create one real verifiable request |
+| 6 | Logs → Requests evolution | make request evidence the primary object |
+| 7 | Request Trust Receipt | expose complete per-request chain |
+| 8 | Verification | explain release/runtime/evidence profiles |
+| 9 | Customers / API Keys | business identity → credential lifecycle |
+| 10 | Usage / Billing | business truth with explicit scope |
+| 11 | Guardrails / Team / Settings | governance and runtime boundaries |
+| 12 | Cross-page visual polish | only after semantics and handoffs converge |
+
+## 15. Verification matrix
+
+Use this table in product reviews. A goal remains open until its final verification row passes.
+
+| Goal | User question | Required evidence | Final verification |
+| --- | --- | --- | --- |
+| G0 Trust | Can I verify what happened without simply trusting the operator? | signed release proof + truthful runtime state + request receipt + upstream evidence | one real request can be independently evaluated, including limitations |
+| G1 Router | Can BurnCloud reliably serve my API request? | configured supply + available model/route + credential + successful request | clean-environment E2E succeeds and persists evidence |
+| G2 Routing | Why did this request use this upstream? | candidate snapshot + policy/decision + failover + selected upstream evidence | request detail reconstructs decision from persisted facts, not current config guesses |
+| G3 Business | Can I run the customer/token business from authoritative data? | customer + credential + usage + cost + charge/settlement sources | period/customer drilldown reconciles business totals to authoritative sources |
+
+## 16. Per-TODO completion template
+
+Every implementation PR that closes a TODO must answer:
+
+```text
+TODO ID:
+Goal:
+User question:
+Claim being added/changed:
+Source of truth:
+Scope:
+Proof/evidence level:
+Unknown/loading/error behavior:
+Negative test:
+Cross-page handoff:
+Security/privacy impact:
+Automated validation:
+Manual/visual validation:
+Goal verification result:
+```
+
+`Goal verification result` must be one of:
+
+- `PASS` — goal-level acceptance is demonstrably satisfied;
+- `PARTIAL` — this TODO moved the goal forward but did not complete it;
+- `FAIL` — implementation exists but product acceptance is not met.
+
+## 17. Near-term execution order
+
+The next work should be deliberately narrow:
+
+```text
+1. Merge/agree product spine (#420)
+2. Agree Product Text Prototype + this TODO
+3. Define verification profiles (P0.4)
+4. Design signed release manifest + key lifecycle (P1.1/P1.2)
+5. Implement official release SHA-256 + signatures (P1)
+6. Define Trust Receipt schema/canonical hashes (P3.8-P3.13)
+7. Add first upstream evidence adapter (P4)
+8. Build client Request Trust Receipt UX (P5)
+9. Revalidate Overview and current pages against G0-G3
+10. Only then continue broad page migration/pixel polish
+```
+
+Runtime attestation (P2.4+) can proceed as a separate architecture track because it is materially harder and platform-dependent. Until it exists, the product must truthfully show `NOT ATTESTED` rather than delaying all other verifiable-evidence work.

--- a/docs/ui/product-todo.md
+++ b/docs/ui/product-todo.md
@@ -8,187 +8,172 @@ audited_against: c314bff9646f9113c9a58a818552fc80c77543a6
 
 # BurnCloud Goal → TODO → Verification Plan v0.1
 
-This document converts `product-text-prototype.md` into an executable product backlog.
-
-The unit of completion is a **verified product goal**, not a page, component, or merged PR.
+This backlog converts `product-text-prototype.md` into goal-driven execution. The unit of completion is a **verified product goal**, not a page, component, merged PR, or green CI run.
 
 ## 1. Status vocabulary
 
-Use these statuses until a task has explicit implementation evidence:
-
 - `DEFINED` — target behavior and acceptance criteria are documented.
-- `EXISTS` — the current audited source directly contains the required primitive.
-- `PARTIAL` — useful implementation exists, but the target product contract is incomplete.
-- `GAP` — no matching implementation was located in the baseline source audit; this is a backlog item, not a proof of impossibility.
-- `DESIGN REQUIRED` — architecture/security/provider design must be resolved before implementation.
-- `BLOCKED EXTERNAL` — completion depends on a provider/platform capability BurnCloud does not control.
+- `EXISTS` — the audited source directly contains the required primitive.
+- `PARTIAL` — useful implementation exists, but the target contract is incomplete.
+- `GAP` — no matching implementation was located in the baseline audit.
+- `DESIGN REQUIRED` — architecture/security/provider design must be resolved first.
+- `BLOCKED EXTERNAL` — completion depends on an external capability BurnCloud does not control.
 - `VERIFIED DONE` — implementation, negative states, tests and goal-level verification all pass.
 
-Do not mark a task `VERIFIED DONE` because a PR merged or CI is green.
+Never mark `VERIFIED DONE` merely because a PR merged or CI is green.
 
 ## 2. Current audited foundation
 
-The baseline audit found useful request-observability primitives in the current router log model, including:
+The current router log model already contains useful request evidence:
 
-- `request_id`;
-- `user_id`;
-- `upstream_id`;
-- `model`;
-- HTTP status and latency;
-- detailed token/cost fields;
-- `pricing_region`;
-- `layer_decision`;
-- `traffic_color`;
-- `cost_status`;
-- `error_type`.
+```text
+request_id
+user_id
+upstream_id
+model
+HTTP status / latency
+prompt/completion/cache/reasoning/etc token counts
+cost breakdown
+pricing_region
+layer_decision
+traffic_color
+cost_status
+error_type
+```
 
-These fields are **PARTIAL request evidence**, not a complete Trust Receipt.
+These are **PARTIAL request evidence**, not a complete Trust Receipt.
 
-The baseline repository search did not locate a complete implementation of:
+The baseline repository audit did not locate a complete product implementation of:
 
-- signed BurnCloud release manifests;
-- release artifact SHA-256 verification as a product feature;
-- BurnCloud release signer/public-key verification;
-- canonical request/response hashes for Trust Receipts;
-- signed Request Trust Receipts;
-- remote runtime attestation;
-- provider-specific upstream evidence profiles sufficient for the target trust UI.
+```text
+signed BurnCloud release manifest
+release-artifact SHA-256 verification
+BurnCloud release signer verification
+canonical Trust Receipt request/response hashes
+signed Request Trust Receipt
+remote runtime attestation
+complete provider-specific upstream evidence profiles
+```
 
-These findings are the starting backlog, not permanent assumptions. Re-audit source whenever implementation changes.
+Re-audit the source whenever implementation changes; `GAP` is a backlog state, not a permanent claim.
 
 ## 3. Goal hierarchy
 
 ```text
-G0  TRUST NORTH STAR
-    Every customer request has an independently understandable,
-    evidence-backed verification chain.
+G0 TRUST NORTH STAR
+   Every customer request has an independently understandable,
+   evidence-backed verification chain.
 
-    ├── G1  API ROUTER
-    │       A customer can reliably send a real AI request.
-    │
-    ├── G2  ROUTING ENGINE
-    │       The route decision is stable, resilient and explainable.
-    │
-    └── G3  BUSINESS OS
-            The operator can run customer, usage, cost and billing operations.
+   ├── G1 API ROUTER
+   │      A customer can reliably send a real AI request.
+   │
+   ├── G2 ROUTING ENGINE
+   │      The route decision is stable, resilient and explainable.
+   │
+   └── G3 BUSINESS OS
+          The operator can run customer, usage, cost and billing operations.
 
-All G1/G2/G3 claims inherit G0 truth and evidence rules.
+G1/G2/G3 inherit G0 truth and evidence rules.
 ```
 
-## 4. G0 — Trust north star
+## 4. G0 success test
 
-### G0 success statement
+For one selected real request, the intended verifier must be able to determine from product evidence:
 
-For a selected routed request, the intended verifier can determine:
-
-1. what BurnCloud Client release they are using;
-2. whether that local release matches a signed official artifact;
-3. what the remote BurnCloud Server claims to run;
-4. whether remote runtime identity is independently attested or only declared;
-5. who/what initiated the request using privacy-safe identities;
-6. which model was requested;
-7. how routing selected an upstream;
-8. what actual upstream evidence was retained;
-9. what response/result/tokens/cost were recorded;
+1. local BurnCloud Client release identity;
+2. whether the local artifact matches an official signed release;
+3. remote server release claim;
+4. whether runtime identity is attested or only declared;
+5. privacy-safe request/customer/credential identity;
+6. requested model;
+7. route decision and eligible candidates;
+8. selected upstream and retained provider evidence;
+9. response/result/token/cost evidence;
 10. which receipt fields are integrity-bound;
-11. exactly why the verification result is full, partial, limited or unknown.
+11. exactly why the chain passes, fails, or remains partial.
 
-### G0 verification test
+If an unsupported claim is rendered as generic `VERIFIED`, G0 fails.
 
-A reviewer must be able to take one test request and answer all eleven questions from product evidence without relying on a screenshot or an operator's verbal explanation.
-
-If any unsupported claim is rendered as generic `VERIFIED`, G0 fails.
-
-## 5. P0 — Freeze product semantics before more page polish
+## 5. P0 — Product semantics gate
 
 | ID | TODO | Status | Acceptance |
 | --- | --- | --- | --- |
-| P0.1 | Define trust-first north star | `DEFINED` | Product prototype names independent verification as priority #1 |
-| P0.2 | Define claim vocabulary | `DEFINED` | `UNKNOWN`, `DECLARED`, `HASH MATCH`, `SIGNATURE VERIFIED`, `EVIDENCED`, `RUNTIME ATTESTED`, `CHAIN VERIFIED` have non-overlapping meanings |
-| P0.3 | Define Request Trust Receipt target | `DEFINED` | Receipt sections and proof limitations are documented |
-| P0.4 | Define verification profiles | `DESIGN REQUIRED` | Exact requirements for `FULL`, `PARTIAL`, `LIMITED` (or final names) are machine-testable |
-| P0.5 | Revalidate existing draft UI PRs | `GAP` | Every draft states which prototype goal it satisfies and removes conflicting semantics |
+| P0.1 | Trust-first north star | `DEFINED` | independent verification is priority #1 |
+| P0.2 | Claim vocabulary | `DEFINED` | declaration, hash match, signature, evidence and attestation are distinct |
+| P0.3 | Request Trust Receipt target | `DEFINED` | target receipt sections + limitations documented |
+| P0.4 | Machine-testable verification profiles | `DEFINED` | `verification-profiles.md` defines dimensions, profile requirements and downgrade/failure rules |
+| P0.5 | Revalidate existing draft UI PRs | `PARTIAL` | #421 revalidated as PARTIAL; remaining draft UI work must be checked the same way |
 
-**Gate:** do not introduce new generic trust scores or `VERIFIED` badges before P0.4 is resolved.
+**Gate:** no new bare `VERIFIED`, `FULL`, trust score, or confidence score may be introduced. Verification must name a profile.
 
 ## 6. P1 — Official release provenance
 
-Goal: a customer can independently verify that the local BurnCloud Client package matches an official signed release.
+Goal: the customer independently verifies that the local BurnCloud Client matches an official signed release.
 
 | ID | TODO | Status | Acceptance |
 | --- | --- | --- | --- |
-| P1.1 | Specify signed release manifest schema | `DESIGN REQUIRED` | Canonical fields, serialization/canonicalization, versioning and signature envelope documented |
-| P1.2 | Choose release signing algorithm/key lifecycle | `DESIGN REQUIRED` | Public verification key distribution, rotation, compromise and revocation behavior documented |
-| P1.3 | Generate SHA-256 for supported artifacts | `GAP` | CI/release pipeline publishes digest for every declared artifact |
-| P1.4 | Sign release manifest in official release workflow | `GAP` | Signature produced by protected release key and independently verifiable |
-| P1.5 | Publish git commit/source identity | `GAP` | Manifest binds release to repository source/build identity |
-| P1.6 | Implement client-side manifest verification | `GAP` | Invalid signature fails closed and displays reason |
-| P1.7 | Implement local artifact SHA-256 verification | `GAP` | Mutated local artifact produces mismatch, never generic verified |
-| P1.8 | Add release-provenance negative tests | `GAP` | Tampered manifest, wrong key, changed artifact and unsupported schema all fail explicitly |
+| P1.1 | Signed release manifest schema | `DESIGN REQUIRED` | canonical fields/serialization/versioning/signature envelope defined |
+| P1.2 | Release signing algorithm + key lifecycle | `DESIGN REQUIRED` | public key distribution, rotation, revocation and compromise handling defined |
+| P1.3 | Publish SHA-256 for supported artifacts | `GAP` | release workflow emits digest for every declared artifact |
+| P1.4 | Sign official release manifest | `GAP` | protected release key signs canonical manifest |
+| P1.5 | Bind release to git/source/build identity | `GAP` | manifest identifies the source/build the artifact represents |
+| P1.6 | Client manifest verification | `GAP` | wrong signer/invalid signature fails closed |
+| P1.7 | Client local artifact SHA-256 check | `GAP` | mutated artifact becomes mismatch, not verified |
+| P1.8 | Negative tests | `GAP` | forged manifest/wrong key/changed artifact/unsupported schema explicitly fail |
 
-### P1 goal verification
+### P1 final verification
 
-Given an official client package, a mutated package, and a forged manifest, the verifier must distinguish:
-
-- valid signature + matching SHA-256;
-- valid signature + mismatching artifact;
-- invalid/unknown signer;
-- unknown/unsupported proof.
+Official package, mutated package and forged manifest must produce three distinguishable outcomes without operator interpretation.
 
 ## 7. P2 — Server identity and runtime proof
 
-Goal: the client tells the truth about what it can prove about the remote server.
+Goal: the client accurately states what it can prove about the remote server.
 
 | ID | TODO | Status | Acceptance |
 | --- | --- | --- | --- |
-| P2.1 | Define server build identity API | `DESIGN REQUIRED` | Endpoint exposes version/commit/build identity without calling it attestation |
-| P2.2 | Bind server claim to signed release manifest | `GAP` | Client can verify the claimed release exists in an official signed manifest |
-| P2.3 | UI state `DECLARED / NOT ATTESTED` | `GAP` | Signed release claim is not rendered as remote-runtime verified |
-| P2.4 | Select first remote-attestation deployment target | `DESIGN REQUIRED` | TEE/TPM/cloud mechanism, threat model and accepted measurements are explicit |
-| P2.5 | Implement attestation verifier | `GAP` | Invalid measurement/challenge/certificate fails closed |
-| P2.6 | Bind attestation to server release measurement | `GAP` | Accepted attestation proves a measurement covered by policy |
-| P2.7 | Define attestation freshness/replay defense | `DESIGN REQUIRED` | Challenge/nonce/expiry behavior prevents stale proof reuse |
-| P2.8 | Runtime-attestation negative tests | `GAP` | Wrong measurement, stale evidence and unsupported platform become non-attested states |
+| P2.1 | Server build identity API | `DESIGN REQUIRED` | exposes version/commit/build claim without calling it attestation |
+| P2.2 | Verify claimed release against official manifest | `GAP` | client can prove the claim references an official signed release |
+| P2.3 | `DECLARED / NOT ATTESTED` UX | `GAP` | signed release claim never becomes runtime-verified by implication |
+| P2.4 | Choose first attestation target + threat model | `DESIGN REQUIRED` | concrete TEE/TPM/cloud mechanism and accepted measurements defined |
+| P2.5 | Implement attestation verifier | `GAP` | invalid chain/challenge/measurement fails closed |
+| P2.6 | Bind attestation to receipt signer identity | `GAP` | attested workload controls/binds the key used for request receipts |
+| P2.7 | Freshness/replay defense | `DESIGN REQUIRED` | nonce/challenge/expiry policy prevents stale proof reuse |
+| P2.8 | Negative tests | `GAP` | wrong measurement/stale evidence/unsupported platform stay non-attested |
 
-### P2 goal verification
+### P2 final verification
 
-A non-attested server that claims the correct official version must still display `NOT ATTESTED`.
+A server claiming the correct official version but supplying no accepted attestation must still display `NOT ATTESTED`.
 
-This is a mandatory negative acceptance test.
+## 8. P3 — Request Trust Receipt
 
-## 8. P3 — Request Trust Receipt foundation
-
-Goal: every eligible routed request can produce a stable, privacy-safe evidence object.
+Goal: every eligible routed request produces a stable, privacy-safe evidence object.
 
 | ID | TODO | Status | Acceptance |
 | --- | --- | --- | --- |
-| P3.1 | Stable request identity | `EXISTS` | `request_id` is persisted and queryable |
-| P3.2 | User/account attribution | `PARTIAL` | current `user_id` is usable; target privacy-safe customer/credential semantics are specified |
-| P3.3 | Requested model | `EXISTS` | persisted request model available |
-| P3.4 | Selected upstream identity | `PARTIAL` | `upstream_id` exists but is mapped to a clear provider evidence identity |
-| P3.5 | Routing decision field | `PARTIAL` | `layer_decision` exists; receipt semantics and candidate snapshot are defined |
-| P3.6 | Traffic classification | `PARTIAL` | `traffic_color` exists; receipt meaning is documented or omitted from trust claims |
-| P3.7 | Token/cost evidence | `PARTIAL` | detailed counts/cost fields exist; receipt scope/source contract is documented |
-| P3.8 | Canonical request hash | `GAP` | canonicalization excludes secrets and produces stable digest for eligible request classes |
-| P3.9 | Canonical response hash | `GAP` | streaming/non-streaming behavior is defined and tested |
-| P3.10 | Receipt schema + version | `DESIGN REQUIRED` | backward-compatible schema/version policy exists |
-| P3.11 | Persist receipt proof fields | `GAP` | receipt hash, signer key id, signature/profile can be queried |
-| P3.12 | Sign Trust Receipt | `GAP` | modified receipt fails verification |
-| P3.13 | Receipt privacy/security review | `DESIGN REQUIRED` | no bearer secrets, raw provider credentials or unsafe payload leakage |
-| P3.14 | Export receipt | `GAP` | customer/auditor can export a stable verification artifact |
-| P3.15 | Offline/client receipt verifier | `GAP` | exported artifact can be verified without trusting Console rendering |
+| P3.1 | Stable request identity | `EXISTS` | `request_id` persisted/queryable |
+| P3.2 | Customer/credential attribution | `PARTIAL` | current identity primitives mapped to privacy-safe receipt semantics |
+| P3.3 | Requested model | `EXISTS` | persisted model available |
+| P3.4 | Selected upstream | `PARTIAL` | `upstream_id` mapped to explicit provider evidence identity |
+| P3.5 | Routing decision | `PARTIAL` | `layer_decision` exists; candidate snapshot + final receipt semantics remain |
+| P3.6 | Token/cost evidence | `PARTIAL` | existing detailed fields mapped to exact source/scope contract |
+| P3.7 | Canonical request hash | `GAP` | canonicalization excludes secrets and is request-class aware |
+| P3.8 | Canonical response hash | `GAP` | streaming/non-streaming rules separately specified |
+| P3.9 | Versioned receipt schema | `DESIGN REQUIRED` | backward compatibility policy exists |
+| P3.10 | Persist receipt hash/key/signature/profile | `GAP` | proof fields queryable with request |
+| P3.11 | Sign receipt | `GAP` | post-sign mutation fails VP1 integrity verification |
+| P3.12 | Privacy/security export policy | `DESIGN REQUIRED` | bearer/provider secrets cannot enter exported artifact |
+| P3.13 | Export receipt | `GAP` | customer/auditor can obtain stable artifact |
+| P3.14 | Offline/client verifier | `GAP` | verifier does not need to trust Console rendering |
 
-### P3 goal verification
+### P3 final verification
 
-Mutating any integrity-covered receipt field after signing must fail verification.
-
-Removing optional upstream evidence must downgrade the chain instead of invalidating unrelated verified links.
+Changing an integrity-covered field after signing must produce `FAIL`. Missing optional provider evidence must downgrade only the relevant profile.
 
 ## 9. P4 — Provider-specific upstream evidence
 
-Goal: BurnCloud proves only the strongest upstream facts actually supported by each provider path.
+Goal: BurnCloud shows the strongest evidence actually available for each upstream path, never fabricated parity.
 
-Common adapter contract to design:
+Common adapter target:
 
 ```text
 provider_family
@@ -204,166 +189,144 @@ coverage / limitation reason
 
 | ID | TODO | Status | Acceptance |
 | --- | --- | --- | --- |
-| P4.1 | Generic upstream evidence interface | `DESIGN REQUIRED` | provider adapters return typed evidence + limitations |
-| P4.2 | AWS Bedrock evidence adapter | `GAP` | captures only evidence actually available from the AWS path |
-| P4.3 | Anthropic evidence adapter | `GAP` | captures only evidence actually available from the Anthropic path |
-| P4.4 | Google/Gemini evidence adapter | `GAP` | provider-specific metadata mapped without fabricated parity |
-| P4.5 | Azure/OpenAI evidence adapter | `GAP` | provider-specific metadata mapped without fabricated parity |
-| P4.6 | Evidence redaction contract | `DESIGN REQUIRED` | secrets/credential material can never enter exported receipts |
-| P4.7 | Unsupported-provider state | `GAP` | unknown adapter produces `LIMITED/UNKNOWN`, never fake verification |
-| P4.8 | Provider-evidence negative tests | `GAP` | missing request ID/region/metadata downgrades only relevant claims |
+| P4.1 | Generic evidence adapter interface | `DESIGN REQUIRED` | typed evidence + limitation reasons returned |
+| P4.2 | AWS Bedrock profile | `GAP` | only evidence available on real AWS path is claimed |
+| P4.3 | Anthropic profile | `GAP` | only Anthropic-supported metadata is claimed |
+| P4.4 | Google/Gemini profile | `GAP` | provider-specific evidence mapped truthfully |
+| P4.5 | Azure/OpenAI profile | `GAP` | provider-specific evidence mapped truthfully |
+| P4.6 | Redaction contract | `DESIGN REQUIRED` | credentials/authorization material excluded |
+| P4.7 | Unsupported provider state | `GAP` | profile becomes UNKNOWN/LIMITED, not fake verified |
+| P4.8 | Negative tests | `GAP` | missing metadata downgrades relevant proof only |
 
-### P4 goal verification
+### P4 final verification
 
-For an AWS-labelled channel with missing provider-native evidence, the UI must not claim that AWS execution is cryptographically verified merely because `upstream_id` points to that channel.
+An AWS-labelled channel with only `upstream_id` and no provider-native evidence must never be described as cryptographically verified AWS execution.
 
 ## 10. P5 — BurnCloud Client trust UX
 
-Goal: the customer can verify without understanding internal Rust/database implementation.
+Goal: a non-expert customer can understand verification without knowing BurnCloud internals.
 
 | ID | TODO | Status | Acceptance |
 | --- | --- | --- | --- |
-| P5.1 | Local release verification screen | `GAP` | signature, SHA-256, version/commit and failure reasons visible |
-| P5.2 | Connected server verification screen | `GAP` | declared release and runtime-attestation state separated |
-| P5.3 | Request list trust column/profile | `GAP` | value has defined profile, not subjective score |
-| P5.4 | Request Trust Receipt detail | `GAP` | six-section text prototype can be implemented from real data |
-| P5.5 | `Why partial?` explanation | `GAP` | every degraded chain names missing/failed links |
-| P5.6 | Export + verify receipt action | `GAP` | verifier can check artifact independently |
-| P5.7 | Verification help | `GAP` | UI states what each proof does and does not establish |
-| P5.8 | Trust UX accessibility/clarity test | `GAP` | non-expert test user can distinguish declared, signed and attested |
+| P5.1 | Local release verification screen | `GAP` | signature/SHA-256/version/commit + failure reasons visible |
+| P5.2 | Connected server verification | `GAP` | release claim separated from runtime attestation |
+| P5.3 | Requests trust profile column | `GAP` | named profile, not subjective score |
+| P5.4 | Request Trust Receipt detail | `GAP` | product prototype sections populated from real evidence |
+| P5.5 | `Why partial?` explanation | `GAP` | missing/failed dimensions listed |
+| P5.6 | Export + Verify actions | `GAP` | independent verification path works |
+| P5.7 | Verification explanation | `GAP` | UI says what each proof does and does not prove |
+| P5.8 | Clarity/accessibility test | `GAP` | test user distinguishes declared vs signed vs attested |
 
-## 11. G1 — API Router product goal
+## 11. G1 — API Router
 
-### G1 success statement
+Goal: from a clean supported environment, an operator can produce a successful customer-callable AI request through BurnCloud.
 
-Starting from a clean supported environment, an operator can configure upstream supply and produce a successful customer-callable AI API request through BurnCloud.
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| G1.1 | Provider configuration | `PARTIAL` | truthful state/error UX for supported provider |
+| G1.2 | Derived model availability | `PARTIAL` | configured/available/redundant distinct |
+| G1.3 | Route/failover configuration | `PARTIAL` | operator understands how traffic can be served |
+| G1.4 | Customer/credential ownership | `PARTIAL` | safe account-owned bearer lifecycle |
+| G1.5 | Real Playground request | `PARTIAL` | successful test persists request evidence |
+| G1.6 | Clean-environment E2E | `GAP` | one scenario proves setup → routed request → evidence |
 
-Current product chain:
+G1 cannot be `VERIFIED DONE` until its request enters the G0 evidence chain.
+
+## 12. G2 — Routing Engine
+
+Goal: for one request, the operator/customer can understand candidates, policy, selected upstream and fallback from persisted decision-time facts.
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| G2.1 | Candidate model | `PARTIAL` | provider/model/group primitives exist |
+| G2.2 | Persist eligible candidate snapshot | `GAP` | no reconstruction from current config required |
+| G2.3 | Persist decision reason | `PARTIAL` | `layer_decision` becomes defined evidence |
+| G2.4 | Persist failover chain | `PARTIAL` | each fallback step explicit enough to explain |
+| G2.5 | Health/capacity decision evidence | `DESIGN REQUIRED` | only actual router inputs retained/explained |
+| G2.6 | Cost-aware decision evidence | `DESIGN REQUIRED` | actual cost source/policy explainable if used |
+| G2.7 | Routing explanation UI | `GAP` | answers `why this upstream?` from receipt facts |
+| G2.8 | Explanation invariants tests | `PARTIAL` | existing router tests extended to evidence contract |
+
+## 13. G3 — Business OS
+
+Goal: manage customer → credential → usage → upstream cost → customer charge → margin/settlement from authoritative sources.
+
+| ID | TODO | Status | Acceptance |
+| --- | --- | --- | --- |
+| G3.1 | Customer lifecycle/funding | `PARTIAL` | existing capability mapped to explicit business semantics |
+| G3.2 | Credential lifecycle | `PARTIAL` | ownership and secret handling safe/auditable |
+| G3.3 | Usage scope contract | `PARTIAL` | account/environment scope explicit |
+| G3.4 | Billing source contract | `PARTIAL` | not reconstructed from bounded request samples |
+| G3.5 | Upstream cost evidence | `PARTIAL` | cost/pricing fields mapped to authoritative source |
+| G3.6 | Customer charge model | `DESIGN REQUIRED` | selling price/discount separate from upstream cost |
+| G3.7 | Margin model | `GAP` | revenue minus cost explainable by period/customer/model/request |
+| G3.8 | Settlement workflow | `DESIGN REQUIRED` | prepaid/postpaid/receivable authoritative ledger defined |
+| G3.9 | Business → request drilldown | `GAP` | aggregate numbers reach supporting evidence where permitted |
+
+## 14. UI migration order after semantics freeze
 
 ```text
-Providers → Models → Routes → API access → Playground/real API → Request evidence
+1. Overview                 trust conclusion + next action
+2. Providers                truthful upstream identity/evidence capability
+3. Models                   availability without proof overclaim
+4. Routes                   candidate/decision explanation
+5. Playground               create one real verifiable request
+6. Logs → Requests          request evidence becomes primary object
+7. Request Trust Receipt    complete per-request chain
+8. Verification             release/runtime/profile explanation
+9. Customers / API Keys     business identity → credential
+10. Usage / Billing         explicit authoritative scope
+11. Guardrails/Team/Settings governance/runtime boundaries
+12. Cross-page visual polish
 ```
 
-### G1 TODO
-
-| ID | TODO | Status | Acceptance |
-| --- | --- | --- | --- |
-| G1.1 | Provider configuration | `PARTIAL` | supported provider can be configured with truthful state/error UX |
-| G1.2 | Derived model availability | `PARTIAL` | configured vs available vs redundant remain distinct |
-| G1.3 | Route/failover configuration story | `PARTIAL` | operator can understand how model traffic can be served |
-| G1.4 | Customer/credential ownership | `PARTIAL` | owner identity and bearer-secret lifecycle remain safe |
-| G1.5 | Real Playground verification | `PARTIAL` | successful test is persisted as request evidence |
-| G1.6 | Clean-environment E2E acceptance | `GAP` | one documented scenario proves setup → successful routed request |
-
-G1 must not be marked done until its successful request can enter the G0 evidence chain.
-
-## 12. G2 — Routing Engine product goal
-
-### G2 success statement
-
-For a routed request, an operator/customer can understand what candidates were eligible, what policy chose the selected upstream, whether fallback occurred, and which evidence proves the actual outcome.
-
-| ID | TODO | Status | Acceptance |
-| --- | --- | --- | --- |
-| G2.1 | Provider candidate model | `PARTIAL` | current provider/model/group configuration exists |
-| G2.2 | Persist eligible candidate snapshot | `GAP` | receipt can explain candidates at decision time, not only current config |
-| G2.3 | Persist selected policy/decision reason | `PARTIAL` | existing `layer_decision` becomes defined receipt evidence |
-| G2.4 | Persist failover chain | `PARTIAL` | failover steps are explicit enough for request explanation |
-| G2.5 | Health/capacity decision evidence | `DESIGN REQUIRED` | only inputs actually used by router are retained/explained |
-| G2.6 | Cost-aware decision evidence | `DESIGN REQUIRED` | if cost participates in routing, exact source/policy is explainable |
-| G2.7 | Routing explanation UI | `GAP` | Request detail explains `why this upstream` without reconstructing history from current config |
-| G2.8 | Routing invariants tests | `PARTIAL` | existing router tests are extended to receipt/explanation invariants |
-
-## 13. G3 — Business OS product goal
-
-### G3 success statement
-
-An operator can manage a customer lifecycle from account/funding through credentials, usage, upstream cost, customer charge and settlement/margin evidence, while retaining request-level traceability where supported.
-
-| ID | TODO | Status | Acceptance |
-| --- | --- | --- | --- |
-| G3.1 | Customer account lifecycle | `PARTIAL` | current customer/funding capability mapped to explicit business semantics |
-| G3.2 | Credential ownership/lifecycle | `PARTIAL` | account-owned credential management is safe and auditable |
-| G3.3 | Usage source contract | `PARTIAL` | account/environment scope is explicit everywhere |
-| G3.4 | Billing source contract | `PARTIAL` | billing truth is not reconstructed from bounded Logs samples |
-| G3.5 | Upstream cost evidence | `PARTIAL` | current cost fields mapped to exact pricing/source semantics |
-| G3.6 | Customer charge model | `DESIGN REQUIRED` | selling price/discount/charge semantics defined independently of upstream cost |
-| G3.7 | Margin model | `GAP` | revenue - upstream cost can be explained by period/customer/model/request source |
-| G3.8 | Settlement workflow | `DESIGN REQUIRED` | receivable/prepaid/postpaid behavior and authoritative ledger defined |
-| G3.9 | Business-to-request drilldown | `GAP` | aggregate metric can reach supporting request evidence when contract permits |
-
-## 14. UI migration backlog after trust semantics freeze
-
-Do not use this as a page-polish checklist. Each item must link to a goal above.
-
-| Order | Surface | Product reason |
-| --- | --- | --- |
-| 1 | Overview | trust conclusion + highest-value next action |
-| 2 | Providers | establish truthful upstream identity/evidence capability |
-| 3 | Models | expose model availability without overstating identity proof |
-| 4 | Routes | make routing candidates/decisions explainable |
-| 5 | Playground | create one real verifiable request |
-| 6 | Logs → Requests evolution | make request evidence the primary object |
-| 7 | Request Trust Receipt | expose complete per-request chain |
-| 8 | Verification | explain release/runtime/evidence profiles |
-| 9 | Customers / API Keys | business identity → credential lifecycle |
-| 10 | Usage / Billing | business truth with explicit scope |
-| 11 | Guardrails / Team / Settings | governance and runtime boundaries |
-| 12 | Cross-page visual polish | only after semantics and handoffs converge |
+Do not treat this as a page-completion checklist; every item must close goal/TODO acceptance criteria.
 
 ## 15. Verification matrix
 
-Use this table in product reviews. A goal remains open until its final verification row passes.
-
 | Goal | User question | Required evidence | Final verification |
 | --- | --- | --- | --- |
-| G0 Trust | Can I verify what happened without simply trusting the operator? | signed release proof + truthful runtime state + request receipt + upstream evidence | one real request can be independently evaluated, including limitations |
-| G1 Router | Can BurnCloud reliably serve my API request? | configured supply + available model/route + credential + successful request | clean-environment E2E succeeds and persists evidence |
-| G2 Routing | Why did this request use this upstream? | candidate snapshot + policy/decision + failover + selected upstream evidence | request detail reconstructs decision from persisted facts, not current config guesses |
-| G3 Business | Can I run the customer/token business from authoritative data? | customer + credential + usage + cost + charge/settlement sources | period/customer drilldown reconciles business totals to authoritative sources |
+| G0 Trust | Can I verify what happened without trusting the operator? | signed release + truthful runtime state + receipt + upstream evidence | one real request independently evaluated including limitations |
+| G1 Router | Can BurnCloud reliably serve my API request? | supply + route + credential + successful request | clean-environment E2E succeeds and persists evidence |
+| G2 Routing | Why did this request use this upstream? | candidate snapshot + decision + failover + selected upstream evidence | explanation uses persisted request-time facts |
+| G3 Business | Can I run the token/API business from authoritative data? | customer + credential + usage + cost + charge/settlement | totals reconcile to authoritative sources and request evidence where applicable |
 
-## 16. Per-TODO completion template
+## 16. Per-PR completion template
 
-Every implementation PR that closes a TODO must answer:
+Every implementation PR that advances a TODO must answer:
 
 ```text
 TODO ID:
 Goal:
 User question:
-Claim being added/changed:
+Claim added/changed:
 Source of truth:
 Scope:
-Proof/evidence level:
+Verification profile/evidence level:
 Unknown/loading/error behavior:
 Negative test:
 Cross-page handoff:
 Security/privacy impact:
 Automated validation:
 Manual/visual validation:
-Goal verification result:
+Goal verification result: PASS / PARTIAL / FAIL
 ```
 
-`Goal verification result` must be one of:
-
-- `PASS` — goal-level acceptance is demonstrably satisfied;
-- `PARTIAL` — this TODO moved the goal forward but did not complete it;
-- `FAIL` — implementation exists but product acceptance is not met.
+`PASS` here means that PR's declared goal acceptance passed. It does not automatically close the parent product goal.
 
 ## 17. Near-term execution order
 
-The next work should be deliberately narrow:
-
 ```text
-1. Merge/agree product spine (#420)
-2. Agree Product Text Prototype + this TODO
-3. Define verification profiles (P0.4)
-4. Design signed release manifest + key lifecycle (P1.1/P1.2)
-5. Implement official release SHA-256 + signatures (P1)
-6. Define Trust Receipt schema/canonical hashes (P3.8-P3.13)
-7. Add first upstream evidence adapter (P4)
-8. Build client Request Trust Receipt UX (P5)
-9. Revalidate Overview and current pages against G0-G3
-10. Only then continue broad page migration/pixel polish
+1. Agree product spine (#420)
+2. Agree Product Text Prototype + TODO (#422)
+3. Agree verification profiles (P0.4)        ← defined in this PR
+4. Design signed release manifest/key lifecycle (P1.1/P1.2)
+5. Implement SHA-256 + official release signatures (P1)
+6. Design Trust Receipt schema/canonical hashing (P3)
+7. Implement first provider evidence profile (P4)
+8. Build Client Trust Receipt / Verification UX (P5)
+9. Revalidate Overview/current pages against G0-G3
+10. Resume broad page migration/pixel polish only after semantic convergence
 ```
 
-Runtime attestation (P2.4+) can proceed as a separate architecture track because it is materially harder and platform-dependent. Until it exists, the product must truthfully show `NOT ATTESTED` rather than delaying all other verifiable-evidence work.
+Runtime attestation is a separate harder architecture track. Until P2 is implemented, the product must truthfully show `NOT ATTESTED`; other evidence work does not need to wait for it.

--- a/docs/ui/verification-profiles.md
+++ b/docs/ui/verification-profiles.md
@@ -1,0 +1,609 @@
+---
+doc_id: ui.verification-profiles
+doc_type: trust-semantics-standard
+truth: target-state
+status: draft
+---
+
+# BurnCloud Verification Profiles v0.1
+
+This document makes BurnCloud trust labels machine-testable.
+
+It exists to prevent a generic `VERIFIED`, `FULL`, `PARTIAL`, confidence score, or green badge from acquiring different meanings on different pages.
+
+A verification result is always:
+
+```text
+claim + profile + evidence + result + limitation reason
+```
+
+Never just:
+
+```text
+VERIFIED
+```
+
+## 1. Core distinction: proof dimensions vs profiles
+
+BurnCloud verifies independent dimensions first. A profile then defines which dimensions are required for a specific claim.
+
+This matters because:
+
+- a valid receipt signature does not prove the server runtime;
+- an attested server runtime does not prove the upstream provider;
+- an AWS endpoint does not prove a particular model executed there;
+- an official client binary does not prove the remote server;
+- a persisted request record does not prove integrity after persistence.
+
+The UI must expose those distinctions.
+
+## 2. Result vocabulary
+
+Every verification check returns one of these states:
+
+| Result | Meaning |
+| --- | --- |
+| `PASS` | required evidence exists and the defined check succeeded |
+| `FAIL` | evidence exists but is invalid, mismatched, expired, rejected, or otherwise failed the defined check |
+| `UNKNOWN` | the verifier cannot evaluate the check because the proof/source is unavailable, unsupported, unreadable, or not queried |
+| `NOT_APPLICABLE` | the check is intentionally outside this request/profile |
+
+`UNKNOWN` and `FAIL` are different.
+
+Examples:
+
+```text
+No attestation supplied       → UNKNOWN
+Attestation signature invalid → FAIL
+Provider adapter unsupported  → UNKNOWN
+Provider request ID mismatch  → FAIL
+```
+
+No failed cryptographic check may be downgraded to `UNKNOWN` merely to avoid a red state.
+
+## 3. Proof dimensions
+
+### D1 — Official client release provenance
+
+Question:
+
+> Does the local BurnCloud Client match an artifact in an official BurnCloud signed release manifest?
+
+Required checks:
+
+```text
+D1.manifest_schema_supported
+D1.release_signature_valid
+D1.signing_key_accepted
+D1.local_artifact_sha256_calculated
+D1.local_artifact_sha256_matches_manifest
+```
+
+D1 passes only if all required checks pass.
+
+D1 does not prove the remote server.
+
+### D2 — Official server release claim
+
+Question:
+
+> Does the remote server's claimed release identity correspond to an official signed BurnCloud release artifact?
+
+Required checks:
+
+```text
+D2.server_claim_present
+D2.release_manifest_signature_valid
+D2.signing_key_accepted
+D2.claimed_version_matches_manifest
+D2.claimed_build_identity_matches_manifest
+D2.claimed_server_artifact_exists_in_manifest
+```
+
+D2 means the **claim references a valid official release**.
+
+D2 does not prove the remote process is executing the declared artifact.
+
+### D3 — Remote runtime attestation
+
+Question:
+
+> Does accepted platform/hardware-backed attestation prove a fresh runtime measurement that satisfies BurnCloud's attestation policy?
+
+Required checks:
+
+```text
+D3.attestation_supported
+D3.attestation_signature_chain_valid
+D3.challenge_nonce_matches
+D3.attestation_fresh
+D3.measurement_accepted
+D3.release_measurement_binding_valid
+D3.receipt_signing_identity_binding_valid
+```
+
+The final binding is critical: an attested runtime must bind the request receipt signer (or a session/key derivation chain) to the attested workload. Otherwise an attacker could present a valid attestation from one process and sign receipts from another.
+
+D3 design must define the concrete platform before implementation.
+
+### D4 — Receipt integrity
+
+Question:
+
+> Is this Request Trust Receipt structurally supported and cryptographically intact?
+
+Required checks:
+
+```text
+D4.schema_supported
+D4.canonicalization_supported
+D4.canonical_receipt_hash_matches
+D4.signature_present
+D4.signer_key_id_present
+D4.signer_key_resolved
+D4.receipt_signature_valid
+```
+
+D4 proves integrity/authenticity relative to the resolved signer identity.
+
+Without D3, D4 does not prove the signer is running an official BurnCloud runtime.
+
+### D5 — Local request/response binding
+
+Question:
+
+> Does the receipt describe the same request and response observed by the verifying client?
+
+Required checks for request classes that support canonical hashing:
+
+```text
+D5.request_hash_present
+D5.local_request_hash_calculated
+D5.local_request_hash_matches_receipt
+D5.response_hash_present
+D5.local_response_hash_calculated
+D5.local_response_hash_matches_receipt
+```
+
+Streaming requires a separately specified canonical transcript or hash-chain algorithm. Until that specification exists, streaming request/response binding must remain unsupported/unknown rather than reusing a non-streaming hash incorrectly.
+
+D5 is applicable only when the verifier possesses the corresponding local request/response material.
+
+### D6 — Persisted routing decision evidence
+
+Question:
+
+> Does the receipt contain enough persisted facts to explain the route decision at request time without reconstructing history from current configuration?
+
+Minimum target checks:
+
+```text
+D6.requested_model_present
+D6.route_group_or_policy_scope_present
+D6.eligible_candidate_snapshot_present
+D6.selected_upstream_present
+D6.decision_reason_present
+D6.failover_chain_present_or_explicit_none
+```
+
+Current `layer_decision` is a useful primitive but is not alone sufficient for D6.
+
+### D7 — Upstream evidence profile
+
+Question:
+
+> Does the selected provider adapter supply the evidence required by the declared provider verification profile?
+
+Common checks:
+
+```text
+D7.provider_family_present
+D7.endpoint_identity_present
+D7.resolved_provider_model_present
+D7.provider_evidence_profile_known
+D7.profile_required_fields_present
+D7.profile_consistency_checks_pass
+```
+
+Additional checks are provider-specific, for example region or provider-native request metadata where available.
+
+D7 must not pretend all providers expose equivalent proof.
+
+### D8 — Financial evidence consistency
+
+Question:
+
+> Are receipt-level cost/usage fields internally consistent with the authoritative pricing/billing source contract used for this request?
+
+Target checks may include:
+
+```text
+D8.token_counts_present
+D8.cost_status_ok_or_explained
+D8.pricing_region_present_when_required
+D8.upstream_cost_source_known
+D8.customer_charge_source_known_when_applicable
+```
+
+D8 is not required for basic request identity verification, but is required by business verification profiles that claim cost/charge traceability.
+
+### D9 — Privacy-safe export
+
+Question:
+
+> Can this proof artifact be shared with the intended verifier without exposing secrets?
+
+Required safety checks:
+
+```text
+D9.no_bearer_secret
+D9.no_raw_provider_credential
+D9.no_sensitive_authorization_header
+D9.identities_redacted_or_scoped_by_policy
+D9.payload_disclosure_matches_export_policy
+```
+
+D9 is a mandatory export gate. A receipt that fails D9 must not be exportable even if other cryptographic checks pass.
+
+## 4. Request evidence maturity states
+
+These are **maturity descriptions**, not verification profiles.
+
+### `RECORDED`
+
+A request has persisted operational fields such as request identity, selected upstream and result.
+
+This is not a cryptographic trust claim.
+
+### `SIGNED RECEIPT`
+
+D4 passes.
+
+Allowed wording:
+
+```text
+Receipt integrity: SIGNATURE VERIFIED
+Server runtime: NOT ATTESTED / UNKNOWN
+```
+
+Do not render `CHAIN VERIFIED` from D4 alone.
+
+### `UPSTREAM EVIDENCED`
+
+D4 + D6 + D7 pass for a declared provider evidence profile.
+
+Allowed wording:
+
+```text
+Receipt integrity: SIGNATURE VERIFIED
+Routing evidence: PASS
+Upstream evidence (AWS profile v1): PASS
+Runtime attestation: UNKNOWN
+```
+
+This is still not a runtime-bound chain.
+
+### `RUNTIME BOUND`
+
+D3 + D4 pass and D3 proves the receipt signing identity is bound to the accepted attested runtime.
+
+This proves a stronger server-to-receipt link but still does not automatically satisfy D7 upstream evidence.
+
+## 5. Named verification profiles
+
+A profile is a versioned set of required dimensions.
+
+The profile name must be shown next to `CHAIN VERIFIED`.
+
+### VP1 — `RECEIPT_INTEGRITY_V1`
+
+Purpose:
+
+> Verify that the Trust Receipt is intact and signed by a resolved receipt signer.
+
+Required:
+
+```text
+D4 = PASS
+```
+
+Optional/not required:
+
+```text
+D1, D2, D3, D5, D6, D7, D8
+```
+
+Result wording:
+
+```text
+Receipt signature: SIGNATURE VERIFIED
+Profile: RECEIPT_INTEGRITY_V1 PASS
+```
+
+Never:
+
+```text
+Request chain VERIFIED
+```
+
+### VP2 — `ROUTE_EVIDENCE_V1`
+
+Purpose:
+
+> Verify receipt integrity plus persisted routing explanation.
+
+Required:
+
+```text
+D4 = PASS
+D6 = PASS
+```
+
+Result wording:
+
+```text
+Profile: ROUTE_EVIDENCE_V1 PASS
+Runtime: NOT INCLUDED
+Upstream identity: NOT INCLUDED
+```
+
+### VP3 — `UPSTREAM_EVIDENCE_V1`
+
+Purpose:
+
+> Verify an intact receipt, persisted route decision and provider-specific upstream evidence.
+
+Required:
+
+```text
+D4 = PASS
+D6 = PASS
+D7 = PASS
+```
+
+Result wording:
+
+```text
+Profile: UPSTREAM_EVIDENCE_V1 PASS
+Provider profile: <provider-profile-name/version>
+Runtime attestation: NOT INCLUDED
+```
+
+This profile may support a customer claim such as:
+
+> BurnCloud retained evidence consistent with the declared AWS Bedrock upstream profile for this request.
+
+It must not claim hardware-attested BurnCloud runtime execution.
+
+### VP4 — `RUNTIME_BOUND_REQUEST_V1`
+
+Purpose:
+
+> Verify that an intact receipt was signed by an identity bound to an accepted fresh BurnCloud runtime attestation.
+
+Required:
+
+```text
+D2 = PASS
+D3 = PASS
+D4 = PASS
+D6 = PASS
+```
+
+Result wording:
+
+```text
+CHAIN VERIFIED — RUNTIME_BOUND_REQUEST_V1
+Upstream evidence: separate dimension
+```
+
+The profile does not imply D7 unless explicitly composed with an upstream profile.
+
+### VP5 — `CLIENT_TO_UPSTREAM_V1`
+
+Purpose:
+
+> Highest target customer-verifier profile: verify local official client provenance, bind the locally observed request/response to a runtime-bound receipt, and verify provider-specific upstream evidence.
+
+Required:
+
+```text
+D1 = PASS
+D2 = PASS
+D3 = PASS
+D4 = PASS
+D5 = PASS
+D6 = PASS
+D7 = PASS
+```
+
+D9 must pass before export.
+
+Result wording:
+
+```text
+CHAIN VERIFIED — CLIENT_TO_UPSTREAM_V1
+```
+
+This label is permitted only when every required dimension passes.
+
+Financial traceability is not included unless a future business profile also requires D8.
+
+### VP6 — `BUSINESS_TRACE_V1`
+
+Purpose:
+
+> Verify request-level usage/cost/charge traceability for Business OS workflows.
+
+Target required dimensions:
+
+```text
+D4 = PASS
+D6 = PASS
+D8 = PASS
+```
+
+If the business claim includes upstream identity, compose with VP3 requirements.
+
+The exact authoritative customer-charge/ledger contract must be designed before VP6 can become implementable.
+
+## 6. Overall UI chain state
+
+The UI may show a simple chain summary for orientation, but it must derive from profile results.
+
+### `UNKNOWN`
+
+No meaningful profile could be evaluated because required proof is unavailable or unsupported.
+
+### `FAILED`
+
+At least one explicitly evaluated security/integrity check failed for the selected profile.
+
+A failure must be prominent and must not be hidden behind a lower profile that happened to pass unless the user explicitly switches profiles.
+
+### `PARTIAL`
+
+One or more lower profiles pass, but the highest expected/requested profile cannot pass because required evidence is `UNKNOWN`, `NOT_APPLICABLE`, or not yet supported.
+
+The UI must list missing dimensions.
+
+Example:
+
+```text
+PARTIAL
+✓ Receipt integrity
+✓ Routing evidence
+✓ AWS upstream evidence
+? Runtime attestation unavailable
+```
+
+### `CHAIN VERIFIED — <PROFILE>`
+
+Every required dimension for the named profile passes.
+
+The profile name is mandatory.
+
+Do not use bare `FULL` as a technical verification state.
+
+## 7. Downgrade and failure rules
+
+1. Missing evidence downgrades only profiles that require that evidence.
+2. Invalid evidence fails every profile that requires the failed dimension.
+3. A passed lower profile remains factually passed, but cannot mask a failed higher-profile check.
+4. Unsupported providers may pass receipt integrity/routing profiles while upstream-evidence profiles remain `UNKNOWN`.
+5. No runtime attestation means VP4/VP5 cannot pass.
+6. No local request/response material means D5 is `NOT_APPLICABLE` for server-side/auditor-only verification; VP5 cannot be claimed in that context.
+7. Receipt signer identity must never be treated as official runtime identity unless D3 binding passes.
+8. Clock/freshness uncertainty must fail or mark unknown according to the concrete proof specification; never silently ignore expiry.
+
+## 8. Example results
+
+### Example A — current-style log evidence only
+
+```text
+request_id             present
+upstream_id            present
+layer_decision         present
+receipt signature      unavailable
+provider evidence      limited
+runtime attestation    unavailable
+
+Result:
+RECORDED
+No verification profile passed.
+```
+
+### Example B — signed receipt + AWS evidence, no runtime attestation
+
+```text
+D4 Receipt integrity   PASS
+D6 Routing evidence    PASS
+D7 AWS evidence v1     PASS
+D3 Runtime             UNKNOWN
+
+Profiles:
+VP1 PASS
+VP2 PASS
+VP3 PASS
+VP4 UNKNOWN
+VP5 UNKNOWN
+
+UI:
+PARTIAL
+Strongest passed profile: UPSTREAM_EVIDENCE_V1
+Missing for runtime-bound verification: runtime attestation
+```
+
+### Example C — attested server but unsupported provider evidence
+
+```text
+D2 Server release      PASS
+D3 Runtime             PASS
+D4 Receipt integrity   PASS
+D6 Routing evidence    PASS
+D7 Provider evidence   UNKNOWN
+
+Profiles:
+VP1 PASS
+VP2 PASS
+VP4 PASS
+VP3 UNKNOWN
+VP5 UNKNOWN
+
+UI:
+CHAIN VERIFIED — RUNTIME_BOUND_REQUEST_V1
+Upstream verification: UNKNOWN / unsupported profile
+```
+
+### Example D — receipt signature mismatch
+
+```text
+D4 Receipt integrity   FAIL
+
+Result:
+FAILED
+Reason: receipt signature mismatch
+```
+
+The UI must not fall back to `RECORDED` and present a reassuring green state after a signature failure.
+
+## 9. Machine-readable target
+
+Future implementation should expose a structured verification result rather than deriving labels from prose in the UI.
+
+Conceptual shape:
+
+```text
+verification_result
+  schema_version
+  requested_profile
+  overall_result
+  strongest_passed_profile
+  dimensions[]
+    id
+    result
+    evidence_type
+    reason_code
+    detail_safe
+  limitations[]
+  evaluated_at
+```
+
+UI copy should map from stable `reason_code` values, not parse free-form error strings.
+
+## 10. Acceptance tests for P0.4
+
+P0.4 is `DEFINED` when product/engineering agree that:
+
+- every generic verification label maps to a named profile;
+- `PASS`, `FAIL`, `UNKNOWN`, `NOT_APPLICABLE` are distinct;
+- D4 receipt integrity is explicitly insufficient for runtime trust;
+- D3 binds receipt signing identity to the attested workload;
+- provider evidence is a separate dimension from runtime proof;
+- a bare `FULL`/`VERIFIED` label is forbidden;
+- every partial result can list exactly which dimensions are missing;
+- negative evidence causes failure, not silent downgrade;
+- the highest target customer profile is `CLIENT_TO_UPSTREAM_V1` (or an explicitly approved successor);
+- future code can represent the result structurally without relying on UI wording.
+
+After agreement, implementation work should use these profiles as acceptance truth until a versioned successor is approved.


### PR DESCRIPTION
## Goal

Freeze BurnCloud's product target before continuing broad page polish.

The north star is now explicit: **trust through independent verification**. BurnCloud should not ask a customer to believe a version string, screenshot, operator statement, or generic `VERIFIED` badge; it should expose the evidence needed to evaluate the software, request path, and upstream claim.

This PR is intentionally documentation-first and stacked on #420 (`agent/ui-product-flow-contract`). It does not implement the target trust features yet.

## Product Text Prototype v0.1

Adds `docs/ui/product-text-prototype.md`, defining the trust-first product hierarchy, customer-verifier path, software/request/upstream trust chain, strict proof vocabulary, release proof model, runtime-attestation boundary, Request Trust Receipt, provider evidence rules and text prototypes for Client startup, Overview, Requests, Request Trust Receipt and Verification.

A key rule is explicit: **a signed receipt does not by itself prove the server is running an official BurnCloud runtime**. Runtime proof stays separate and must remain `NOT ATTESTED` until accepted remote attestation exists.

## Machine-testable verification profiles

Adds `docs/ui/verification-profiles.md` and advances TODO **P0.4** from design-required to defined.

The standard separates proof dimensions such as:

- official client release provenance;
- official server release claim;
- remote runtime attestation;
- receipt integrity;
- local request/response binding;
- persisted routing decision evidence;
- provider-specific upstream evidence;
- financial evidence consistency;
- privacy-safe export.

It defines `PASS / FAIL / UNKNOWN / NOT_APPLICABLE` and versioned profiles including `RECEIPT_INTEGRITY_V1`, `ROUTE_EVIDENCE_V1`, `UPSTREAM_EVIDENCE_V1`, `RUNTIME_BOUND_REQUEST_V1`, `CLIENT_TO_UPSTREAM_V1`, and a target `BUSINESS_TRACE_V1`.

Bare `FULL` or bare `VERIFIED` is forbidden. Strong claims must name the profile, e.g. `CHAIN VERIFIED — CLIENT_TO_UPSTREAM_V1`.

## Goal → TODO → Verification plan

Adds `docs/ui/product-todo.md` with a source-audited baseline and explicit statuses.

The current router log model already provides useful primitives including `request_id`, `user_id`, `upstream_id`, model, HTTP/latency, detailed token/cost fields, `pricing_region`, `layer_decision`, `traffic_color`, `cost_status`, and `error_type`. These are foundations/partial evidence rather than a finished Trust Receipt.

The baseline audit did not locate a complete signed release manifest, release SHA-256 verification product feature, release signer verification, signed Trust Receipt, canonical request/response hashes, remote runtime attestation, or complete provider-specific upstream evidence profiles. Those remain backlog items rather than being presented as existing trust capabilities.

The plan organizes work around product goals instead of pages:

- **G0 Trust** — independently understandable, evidence-backed request chain;
- **G1 API Router** — successful real routed AI request;
- **G2 Routing Engine** — explainable candidate/decision/failover path;
- **G3 Business OS** — customer/credential/usage/cost/charge/settlement operations.

Each TODO has an acceptance test. A merged PR or green CI does not mean `VERIFIED DONE`.

## First real revalidation

PR #421 has already been revalidated using this model. Its CI is green and its Overview responsibility cleanup is useful, but it is now explicitly classified as **PARTIAL** because it does not yet expose signed release provenance, client/server verification, runtime attestation, Request Trust Receipt coverage, upstream evidence profiles, or a trust-chain conclusion.

This demonstrates the intended workflow: implementation evidence and goal completion are separate things.

## Near-term execution order

1. agree the product spine (#420);
2. agree this product prototype/TODO/profiles (#422);
3. design signed release manifest + signing key lifecycle (P1.1/P1.2);
4. implement official release SHA-256 + signatures (P1);
5. define/implement Request Trust Receipt canonical hashing/signature (P3);
6. implement the first provider-specific upstream evidence profile (P4);
7. build Client verification and Trust Receipt UX (P5);
8. revalidate Overview/current pages against G0-G3;
9. only then resume broad page migration and pixel polish.

Runtime attestation remains a separate harder architecture track. Until it exists, the correct product state is `NOT ATTESTED`, not a generic green verification claim.

## Scope

Documentation only:

- `docs/ui/product-text-prototype.md`
- `docs/ui/verification-profiles.md`
- `docs/ui/product-todo.md`
- `docs/ui/README.md`

No current runtime capability is changed or overclaimed by this PR.