### PR TITLE
docs(agent): enforce canonical engineering issue standard

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/engineering_task.yml
+++ b/.github/ISSUE_TEMPLATE/engineering_task.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         This form follows `docs/agent/ISSUE_STANDARD.md`.
-        One issue should deliver one primary observable capability.
+        A PLANNED issue is not implementation authorization. Codex should only implement issues that pass the READY Gate.
 
   - type: dropdown
     id: issue_type
@@ -36,7 +36,7 @@ body:
     id: goal
     attributes:
       label: 目标（Goal）
-      description: Describe one observable user/operator/system outcome.
+      description: Describe exactly one primary observable user/operator/system outcome.
       placeholder: What becomes possible or reliably true after this issue is complete?
     validations:
       required: true
@@ -45,10 +45,38 @@ body:
     id: current_evidence
     attributes:
       label: 当前事实与证据（Current Evidence）
-      description: Cite source/tests/runtime/docs and classify material claims as STATIC CONFIRMED / DYNAMIC / INFERRED / UNKNOWN / RUNTIME VERIFIED.
+      description: Cite current source/tests/runtime/accepted docs and classify claims as STATIC CONFIRMED / DYNAMIC / INFERRED / UNKNOWN / RUNTIME VERIFIED.
       placeholder: |
         STATIC CONFIRMED — crates/.../file.rs :: Symbol
-        UNKNOWN — runtime behavior has not yet been verified
+        RUNTIME VERIFIED — ...
+        UNKNOWN — behavior has not yet been established
+    validations:
+      required: true
+
+  - type: textarea
+    id: entry
+    attributes:
+      label: 入口 / 调查起点（Entry / Starting Point）
+      description: Give a real CLI, route, UI event, background trigger, source symbol, or other concrete place where Codex should begin investigation.
+      placeholder: |
+        CLI: burncloud node
+        Source: src/main.rs :: main
+    validations:
+      required: true
+
+  - type: textarea
+    id: reuse_targets
+    attributes:
+      label: 复用目标（Reuse Targets）
+      description: State existing components this issue should reuse and duplicate systems it must not recreate.
+      placeholder: |
+        Reuse:
+        - existing burncloud-server startup
+        - existing ModelRouter
+
+        Do not recreate:
+        - second HTTP server
+        - second router
     validations:
       required: true
 
@@ -56,7 +84,39 @@ body:
     id: expected_behavior
     attributes:
       label: 期望行为（Expected Behavior）
-      description: State the behavior or stable contract after the change.
+      description: State the observable behavior or stable internal semantics after the change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior_contract
+    attributes:
+      label: 行为合同（Behavior Contract）
+      description: Define semantic Inputs / Outputs / Ownership / Side effects. Write not-applicable only when there is genuinely no cross-component contract.
+      placeholder: |
+        Inputs:
+        - ...
+        Outputs:
+        - ...
+        Ownership:
+        - ...
+        Side effects:
+        - none
+    validations:
+      required: true
+
+  - type: textarea
+    id: failure_behavior
+    attributes:
+      label: 失败行为（Failure Behavior）
+      description: Define explicit failure semantics and forbidden silent fallbacks.
+      placeholder: |
+        On failure:
+        - return explicit structured error
+
+        Forbidden fallback:
+        - do not silently choose another provider
+        - do not hide the failure by widening scope
     validations:
       required: true
 
@@ -64,7 +124,7 @@ body:
     id: allowed_scope
     attributes:
       label: 允许范围（Allowed Scope）
-      description: Expected domains/components that may need changes.
+      description: Expected domains/components that may need changes. This is an authority boundary, not permission to edit everything listed.
       placeholder: |
         - crates/node
         - existing monitor interfaces needed by HardwareProfile
@@ -75,7 +135,7 @@ body:
     id: avoid_scope
     attributes:
       label: 禁止/避免范围（Avoid Scope）
-      description: Boundaries that must not be changed silently.
+      description: Boundaries that must not be crossed silently.
       placeholder: |
         - do not create a second router
         - do not change billing semantics
@@ -86,7 +146,7 @@ body:
     id: impact
     attributes:
       label: 影响面（Impact）
-      description: Explicitly mark each area as none or describe the impact.
+      description: Explicitly mark every area as none or describe the expected impact.
       placeholder: |
         persistence: none
         external_calls: none
@@ -114,22 +174,38 @@ body:
     id: dependencies
     attributes:
       label: 依赖与阻塞（Dependencies / Blockers）
-      description: List prerequisite issues, decisions, or external dependencies. Write none when independent.
+      description: List prerequisite issues, decisions, environments, or test assets. Hard dependencies must be DONE or explicitly waived before READY.
       placeholder: none
+    validations:
+      required: true
+
+  - type: textarea
+    id: stop_conditions
+    attributes:
+      label: 停止条件（Stop Conditions）
+      description: Conditions under which Codex must stop and report instead of widening scope or repairing unrelated modules.
+      placeholder: |
+        STOP IF:
+        - current source disproves a material issue assumption
+        - implementation requires changing an Avoid domain
+        - an undeclared architecture/invariant change is required
+        - a prerequisite is not actually available
     validations:
       required: true
 
   - type: textarea
     id: verification
     attributes:
-      label: 验证计划（Verification）
-      description: Define targeted, regression, and runtime/E2E verification where applicable.
+      label: 验证目标（Verification Targets）
+      description: Define targeted, regression, runtime/E2E, and protected-behavior verification where applicable. Exact commands may be finalized in the Task Contract.
       placeholder: |
         Targeted:
         - ...
         Regression:
         - ...
         Runtime/E2E:
+        - ...
+        Protected behavior:
         - ...
     validations:
       required: true
@@ -138,7 +214,7 @@ body:
     id: done_when
     attributes:
       label: 完成条件（Done When）
-      description: Use independently verifiable completion criteria.
+      description: Use independently verifiable acceptance conditions, not implementation steps.
       placeholder: |
         - observable condition 1
         - observable condition 2
@@ -149,19 +225,44 @@ body:
     id: plan_page
     attributes:
       label: 实施计划页面（Plan Page）
-      description: Link to the relevant BurnCloud Node implementation-plan child page when applicable.
+      description: Link to the relevant implementation-plan child page when applicable.
       placeholder: https://burncloud.github.io/burncloud-node/implementation-plan/...
 
-  - type: checkboxes
-    id: discipline
+  - type: dropdown
+    id: readiness
     attributes:
-      label: 边界确认
+      label: 当前状态（Readiness）
+      description: Select READY only after every READY Gate checkbox below is satisfied against current main.
       options:
-        - label: This issue has one primary outcome and is not a bundle of independent tasks.
+        - PLANNED
+        - READY
+        - BLOCKED
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: ready_gate
+    attributes:
+      label: READY Gate
+      description: All boxes are required before this issue may be marked READY and handed to Codex.
+      options:
+        - label: The issue has one primary outcome and is not a bundle of independent tasks.
           required: true
-        - label: Current behavior is evidence-backed or explicitly marked UNKNOWN.
+        - label: Hard dependencies are DONE or explicitly waived.
           required: true
-        - label: Architecture/invariant changes are explicit rather than hidden inside implementation work.
+        - label: Current Evidence has been checked against current main or marked UNKNOWN where evidence is genuinely missing.
+          required: true
+        - label: Entry / Starting Point and Reuse Targets are known.
+          required: true
+        - label: Allowed / Avoid boundaries and Impact are explicit.
+          required: true
+        - label: Behavior Contract and Failure Behavior are explicit where applicable.
+          required: true
+        - label: Relevant invariants and any architecture change are explicit.
+          required: true
+        - label: Verification Targets and Done When are independently verifiable.
+          required: true
+        - label: Stop Conditions are explicit; Codex must stop rather than silently widen scope.
           required: true
         - label: Implementation will be submitted through a Pull Request, not directly to main.
           required: true

--- a/.github/ISSUE_TEMPLATE/engineering_task.yml
+++ b/.github/ISSUE_TEMPLATE/engineering_task.yml
@@ -1,0 +1,167 @@
+name: Engineering Task
+about: Create a bounded, evidence-backed engineering issue
+title: "[domain] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form follows `docs/agent/ISSUE_STANDARD.md`.
+        One issue should deliver one primary observable capability.
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue 类型
+      options:
+        - Feature
+        - Bug
+        - Refactor
+        - Architecture
+        - Documentation
+        - Verification
+    validations:
+      required: true
+
+  - type: input
+    id: domain
+    attributes:
+      label: Domain
+      description: Primary ownership domain, for example node, router, billing, auth, provider.
+      placeholder: node
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: 目标（Goal）
+      description: Describe one observable user/operator/system outcome.
+      placeholder: What becomes possible or reliably true after this issue is complete?
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_evidence
+    attributes:
+      label: 当前事实与证据（Current Evidence）
+      description: Cite source/tests/runtime/docs and classify material claims as STATIC CONFIRMED / DYNAMIC / INFERRED / UNKNOWN / RUNTIME VERIFIED.
+      placeholder: |
+        STATIC CONFIRMED — crates/.../file.rs :: Symbol
+        UNKNOWN — runtime behavior has not yet been verified
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: 期望行为（Expected Behavior）
+      description: State the behavior or stable contract after the change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: allowed_scope
+    attributes:
+      label: 允许范围（Allowed Scope）
+      description: Expected domains/components that may need changes.
+      placeholder: |
+        - crates/node
+        - existing monitor interfaces needed by HardwareProfile
+    validations:
+      required: true
+
+  - type: textarea
+    id: avoid_scope
+    attributes:
+      label: 禁止/避免范围（Avoid Scope）
+      description: Boundaries that must not be changed silently.
+      placeholder: |
+        - do not create a second router
+        - do not change billing semantics
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: 影响面（Impact）
+      description: Explicitly mark each area as none or describe the impact.
+      placeholder: |
+        persistence: none
+        external_calls: none
+        billing_usage_quota: none
+        auth_authorization: none
+        routing_provider: none
+        concurrency_transactions: none
+        public_api_cli: none
+        process_runtime_lifecycle: describe
+    validations:
+      required: true
+
+  - type: textarea
+    id: invariants
+    attributes:
+      label: Invariants / Architecture
+      description: List relevant INV-* IDs. If a change is required, write ARCHITECTURE / INVARIANT CHANGE REQUIRED.
+      placeholder: |
+        - INV-...
+        - No invariant change expected
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: 依赖与阻塞（Dependencies / Blockers）
+      description: List prerequisite issues, decisions, or external dependencies. Write none when independent.
+      placeholder: none
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 验证计划（Verification）
+      description: Define targeted, regression, and runtime/E2E verification where applicable.
+      placeholder: |
+        Targeted:
+        - ...
+        Regression:
+        - ...
+        Runtime/E2E:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: done_when
+    attributes:
+      label: 完成条件（Done When）
+      description: Use independently verifiable completion criteria.
+      placeholder: |
+        - observable condition 1
+        - observable condition 2
+    validations:
+      required: true
+
+  - type: input
+    id: plan_page
+    attributes:
+      label: 实施计划页面（Plan Page）
+      description: Link to the relevant BurnCloud Node implementation-plan child page when applicable.
+      placeholder: https://burncloud.github.io/burncloud-node/implementation-plan/...
+
+  - type: checkboxes
+    id: discipline
+    attributes:
+      label: 边界确认
+      options:
+        - label: This issue has one primary outcome and is not a bundle of independent tasks.
+          required: true
+        - label: Current behavior is evidence-backed or explicitly marked UNKNOWN.
+          required: true
+        - label: Architecture/invariant changes are explicit rather than hidden inside implementation work.
+          required: true
+        - label: Implementation will be submitted through a Pull Request, not directly to main.
+          required: true

--- a/.github/ISSUE_TEMPLATE/engineering_task.yml
+++ b/.github/ISSUE_TEMPLATE/engineering_task.yml
@@ -1,5 +1,5 @@
 name: Engineering Task
-about: Create a bounded, evidence-backed implementation issue
+description: Create a bounded, evidence-backed implementation issue
 title: "[domain] "
 labels: []
 body:

--- a/.github/ISSUE_TEMPLATE/engineering_task.yml
+++ b/.github/ISSUE_TEMPLATE/engineering_task.yml
@@ -1,5 +1,5 @@
 name: Engineering Task
-about: Create a bounded, evidence-backed engineering issue
+about: Create a bounded, evidence-backed implementation issue
 title: "[domain] "
 labels: []
 body:
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         This form follows `docs/agent/ISSUE_STANDARD.md`.
-        A PLANNED issue is not implementation authorization. Codex should only implement issues that pass the READY Gate.
+        Long-term PLANNED work belongs in the Implementation Plan. Create an Engineering Issue only when the task is being prepared for implementation and can satisfy the READY Gate below.
 
   - type: dropdown
     id: issue_type
@@ -174,7 +174,7 @@ body:
     id: dependencies
     attributes:
       label: 依赖与阻塞（Dependencies / Blockers）
-      description: List prerequisite issues, decisions, environments, or test assets. Hard dependencies must be DONE or explicitly waived before READY.
+      description: List prerequisite issues, decisions, environments, or test assets. Hard dependencies must be DONE or explicitly waived before implementation.
       placeholder: none
     validations:
       required: true
@@ -228,23 +228,11 @@ body:
       description: Link to the relevant implementation-plan child page when applicable.
       placeholder: https://burncloud.github.io/burncloud-node/implementation-plan/...
 
-  - type: dropdown
-    id: readiness
-    attributes:
-      label: 当前状态（Readiness）
-      description: Select READY only after every READY Gate checkbox below is satisfied against current main.
-      options:
-        - PLANNED
-        - READY
-        - BLOCKED
-    validations:
-      required: true
-
   - type: checkboxes
     id: ready_gate
     attributes:
       label: READY Gate
-      description: All boxes are required before this issue may be marked READY and handed to Codex.
+      description: All boxes are required. Submitting this form means the issue is proposed as implementation-ready; Codex still performs Task Contract preflight against current main before editing.
       options:
         - label: The issue has one primary outcome and is not a bundle of independent tasks.
           required: true

--- a/docs/agent/ISSUE_STANDARD.md
+++ b/docs/agent/ISSUE_STANDARD.md
@@ -5,459 +5,59 @@ truth: normative
 status: active
 ---
 
-# BurnCloud Issue 标准
+# Engineering Issue Enforcement
 
-Issue 是进入 BurnCloud 工程执行系统的第一份**任务权限合同**。它不是简单描述“想做什么”，而是把一个需求压缩成 **单一、可验证、可审查、可停止、可转换成 Task Contract 的工程任务**。
+BurnCloud 的 Issue 语义标准不在本仓库重复定义。
 
-Issue 本身不是事实来源。当前行为必须由源码、测试、运行证据或已接受规范证明；证据不足时必须标记 `UNKNOWN`，不能把计划、聊天记录或 AI 推断写成当前事实。
+Canonical Standard：
 
-最重要的规则：
+https://burncloud.github.io/burncloud-node/implementation-plan/issue-standard/
 
-> **PLANNED 不等于可以编码。Codex 只能实现已经通过 READY Gate 的 Issue。**
+本文件只负责把 Canonical Standard 接入 `burncloud/burncloud` 的 Agent / Codex 执行流程，避免出现第二套 Source of Truth。
 
-## 1. 核心原则
+## Repository enforcement
 
-每个工程 Issue 必须满足：
+本仓库通过以下机制执行 Canonical Standard：
 
-1. **Single Outcome** — 一个 Issue 只交付一个主要可观察结果。
-2. **Evidence First** — 当前行为必须引用证据，不能依赖聊天记忆。
-3. **Known Entry** — 必须知道从哪个真实入口或源码起点开始调查。
-4. **Reuse Before Create** — 必须先声明应复用的现有组件，再允许新增抽象。
-5. **Bounded Scope** — 明确允许修改的领域，以及默认禁止跨越的边界。
-6. **Explicit Contract** — 对跨组件能力明确输入、输出和稳定语义，而不是让实现者自行命名和解释。
-7. **Explicit Failure** — 失败行为必须定义；不得用静默 fallback 掩盖失败。
-8. **Invariant Aware** — 列出会受到影响的不变量；如果不知道，先调查。
-9. **Stop Instead of Widen** — 一旦需要越权修改，停止并报告，不得为了完成 Issue 自动扩大范围。
-10. **Verifiable Done** — 完成条件必须可以通过测试、运行路径或明确检查验证。
-11. **No Hidden Architecture Change** — 架构或 invariant 变化必须独立暴露，不得伪装成普通功能实现。
-12. **No Bundle Issues** — 不把多个独立能力、多个 Phase 或“顺手重构”塞进同一个 Issue。
+- `.github/ISSUE_TEMPLATE/engineering_task.yml` — 收集 READY Engineering Issue 所需字段；
+- `docs/agent/TASK_CONTRACT.md` — Codex 修改代码前的 current-main preflight；
+- `AGENTS.md` / `START_HERE.md` / `TASK_ROUTER.md` — 将 Agent 路由到真实源码、测试和 Invariants；
+- CI / Review / Definition of Done — 验证 Candidate Patch 是否满足合同；
+- Pull Request — 所有实现进入 `main` 的唯一正常路径。
 
-## 2. 三层职责：Plan、Issue、Task Contract
-
-三层不能互相替代：
+## Execution rule
 
 ```text
-Implementation Plan
-“未来准备做什么”
-      ↓
+Implementation Plan (PLANNED)
+        ↓
 Evidence Audit
-      ↓
+        ↓
 READY Engineering Issue
-“批准实现什么、边界是什么、什么情况下必须停止”
-      ↓
-Task Contract
-“基于当前 main，具体从哪里改、真实执行路径和验证目标是什么”
-      ↓
+        ↓
+Task Contract against current main
+        ↓
 Codex / Coding Agent
-      ↓
+        ↓
 Candidate Patch
-      ↓
+        ↓
 Pull Request
-      ↓
+        ↓
 Verification / Review
-```
-
-### Implementation Plan
-
-可以包含长期目标、类别、依赖和 `PLANNED` 能力，但不能被当作当前实现事实，也不能直接授权 Codex 编码。
-
-### Engineering Issue
-
-定义任务目标、权限边界、稳定合同、失败语义、验证目标和停止条件。只有 `READY` Issue 才具有实现授权。
-
-### Task Contract
-
-Codex 在真正修改代码前，必须基于**当前 `main`**重新核实入口、执行路径、源码证据和测试位置。Issue 中的事实如果已经过期，必须停止或更新合同，而不是强行实现旧计划。
-
-## 3. Issue 必填结构
-
-每个非平凡工程 Issue 至少包含以下部分。
-
-### 3.1 标题
-
-格式：
-
-```text
-[domain] observable outcome
-```
-
-示例：
-
-```text
-[node] establish canonical HardwareProfile
-[node] detect NVIDIA GPU and VRAM
-[node] register READY local runtime as existing Channel
-```
-
-标题描述结果，不描述文件名，也不要使用 `misc`、`cleanup`、`improve` 等不可验证词语。
-
-### 3.2 目标（Goal）
-
-说明用户、运维人员或系统最终能够观察到什么。只允许一个主要结果。
-
-### 3.3 当前事实与证据（Current Evidence）
-
-必须引用当前源码、测试、运行路径或已接受规范。
-
-统一证据分类：
-
-- `STATIC CONFIRMED`
-- `DYNAMIC`
-- `INFERRED`
-- `UNKNOWN`
-- `RUNTIME VERIFIED`
-
-任何 `INFERRED` / `UNKNOWN` 都不能被写成锁定架构事实。
-
-### 3.4 入口 / 调查起点（Entry / Starting Point）
-
-必须给 Codex 一个真实起点，例如：
-
-```text
-CLI: burncloud node
-Route: POST /v1/chat/completions
-Source: src/main.rs :: main
-Source: crates/server/src/lib.rs :: start_server
-```
-
-这里的目的不是提前写死完整调用链，而是防止 Agent 从全仓库漫游并自行发明入口。
-
-### 3.5 复用目标（Reuse Targets）
-
-明确本 Issue 应优先复用哪些现有能力，例如：
-
-```text
-Reuse:
-- existing burncloud-server startup
-- existing ModelRouter
-- existing DownloadManager
-
-Do not recreate:
-- second HTTP server
-- second router
-- second downloader
-```
-
-如果调查后发现现有组件不能承担职责，必须先报告原因；不得直接创建第二套实现。
-
-### 3.6 期望行为（Expected Behavior）
-
-描述完成后的外部行为或稳定内部合同。
-
-### 3.7 行为合同（Behavior Contract）
-
-对跨组件能力必须明确：
-
-```text
-Inputs
-Outputs
-Ownership
-Side effects
-```
-
-这里定义**语义**，不规定具体 Rust struct、函数名或文件布局，除非已有接受的合同已经锁定这些名称。
-
-例如 Model Resolver：
-
-```text
-Inputs:
-- canonical model identity
-- HardwareProfile
-- ModelManifest
-- RuntimeCapabilities
-
-Output semantics:
-- selected variant
-- runtime requirement
-- artifact reference
-- resource requirements
-- selection reason
-
-Side effects:
-- none
-```
-
-### 3.8 失败行为（Failure Behavior）
-
-必须明确失败时系统做什么，以及禁止做什么。
-
-例如：
-
-```text
-No compatible variant:
-- return explicit structured failure
-
-Forbidden fallback:
-- do not choose an arbitrary artifact
-- do not silently route to Provider
-- do not trigger download unless this Issue explicitly owns preparation
-```
-
-不得把“让流程继续跑”作为默认正确行为。
-
-### 3.9 范围（Scope）
-
-必须同时写：
-
-```text
-Allowed
-Avoid
-```
-
-`Allowed` 是预期权限边界，不代表可以任意修改列出的所有代码。
-
-`Avoid` 是默认不可跨越的领域。如果源码证据证明必须跨越，不得直接扩大 Diff；先触发 Stop Condition，再更新 Issue / Task Contract 或拆分新的 Issue。
-
-### 3.10 影响面（Impact）
-
-至少判断：
-
-- persistence
-- external calls
-- billing / usage / quota
-- auth / authorization
-- routing / provider
-- concurrency / transactions
-- public API / CLI
-- process / runtime lifecycle
-
-没有影响时明确写 `none`，不能省略。
-
-### 3.11 Invariants / Architecture
-
-列出相关 `INV-*`。
-
-如果 Issue 需要改变 invariant 或架构边界，必须写：
-
-```text
-ARCHITECTURE / INVARIANT CHANGE REQUIRED
-```
-
-这种变化不能被普通 Feature / Bug Issue 自行批准。
-
-### 3.12 依赖与阻塞（Dependencies / Blockers）
-
-列出前置 Issue、架构决策、外部环境或测试资产。
-
-进入 `READY` 前，硬依赖必须已经完成或被明确豁免；不能让 Codex 一边实现当前 Issue，一边顺手实现前置 Issue。
-
-### 3.13 停止条件（Stop Conditions）
-
-这是 Codex 的硬边界。至少考虑：
-
-```text
-STOP IF:
-- current source disproves a material Issue assumption
-- implementation requires changing an Avoid domain
-- implementation requires architecture / invariant change not declared by the Issue
-- implementation requires a new duplicate source of truth or duplicate subsystem
-- a required dependency is not actually available
-- required verification cannot be meaningfully performed
-```
-
-触发 Stop Condition 时：
-
-```text
-Do not widen scope.
-Do not repair unrelated modules.
-Do not rewrite the requirement to fit the patch.
-Report the conflict and the evidence.
-```
-
-### 3.14 验证目标（Verification Targets）
-
-至少定义：
-
-```text
-Targeted
-Regression
-Runtime / E2E (when applicable)
-Protected behavior
-```
-
-不能只写“tests pass”。
-
-规划阶段如果无法安全确定具体命令，可以先锁定验证目标；Task Contract 再根据当前仓库确定真实命令和测试路径。
-
-### 3.15 完成条件（Done When）
-
-必须使用独立可观察、可验证条件，例如：
-
-```text
-- HardwareProfile contains GPU model and VRAM on a supported NVIDIA host.
-- Existing CPU / RAM / Disk reporting remains unchanged.
-- Resolver consumes HardwareProfile rather than probing GPU independently.
-```
-
-`Done When` 不是实现步骤清单，而是验收合同。
-
-## 4. Issue 大小标准
-
-一个 Issue 应尽量满足：
-
-```text
-one primary capability
-one primary owner/domain
-one reviewable behavior change
-one independently verifiable completion point
-```
-
-出现以下情况应拆分：
-
-- 同时新增 API + 数据库迁移 + Runtime；
-- 同时实现两个相互独立的组件；
-- 一个 Issue 存在多个互不依赖的主要结果；
-- 完成一半后已经形成独立可验证价值；
-- 标题必须使用“以及 / and”才能描述两个主要能力；
-- Agent 必须获得第二个领域的架构权限才能把第一个能力做完。
-
-不要为了追求小 Issue 而按文件或函数机械拆分。拆分单位是**行为和责任边界**。
-
-## 5. Issue 状态与 READY Gate
-
-状态语义：
-
-```text
-PLANNED      已进入实施计划，但尚未获得实现授权
-READY        已通过 Evidence Audit 和 READY Gate，可交给 Codex
-IN PROGRESS  已有执行分支 / Candidate Patch / PR
-BLOCKED      被依赖、证据缺口或架构决策阻塞
-DONE         对应 PR 已合并且要求的验证完成
-SUPERSEDED   被新的 Issue / 决策替代
-```
-
-### READY Gate
-
-Issue 只有同时满足以下条件才能标记 `READY`：
-
-```text
-[ ] Single Outcome 明确
-[ ] 硬依赖已 DONE 或明确豁免
-[ ] Current Evidence 已按当前 main 核实
-[ ] Entry / Starting Point 已确定
-[ ] Reuse Targets 已确定
-[ ] Allowed / Avoid 已确定
-[ ] Behavior Contract 已确定（适用时）
-[ ] Failure Behavior 已确定
-[ ] Impact 已完整判断
-[ ] Relevant Invariants 已确定
-[ ] Verification Targets 已确定
-[ ] Done When 可独立验证
-[ ] Stop Conditions 已确定
-[ ] 未隐藏架构 / invariant 修改
-```
-
-任何一项不满足：
-
-```text
-PLANNED / BLOCKED
-```
-
-而不是交给 Codex 猜。
-
-## 6. Codex 执行授权
-
-Codex / Coding Agent 只能领取 `READY` Issue。
-
-拿到 Issue 后第一步不是写代码，而是生成或更新 Task Contract，并核实：
-
-1. Issue 的 Current Evidence 在当前 `main` 是否仍成立；
-2. Entry 是否对应真实入口；
-3. Reuse Targets 是否仍存在且职责匹配；
-4. 预计执行路径是否可以被源码证明；
-5. Scope 是否足以完成目标；
-6. Stop Conditions 是否已经触发；
-7. Verification Targets 对应的真实测试 / 命令在哪里。
-
-如果 Issue 与当前源码冲突，Codex 没有权限自行重写架构目标。
-
-正确结果是：
-
-```text
-SCOPE / ARCHITECTURE CONFLICT DETECTED
-No out-of-scope code changed.
-Evidence: ...
-Decision required: ...
-```
-
-## 7. Pull Request 规则
-
-所有实现 Issue 必须通过 Pull Request 进入 `main`。
-
-```text
-READY Issue
-  ↓
-feature/fix branch
-  ↓
-Task Contract
-  ↓
-Candidate Patch
-  ↓
-Pull Request
-  ↓
-Review + CI + Verification
-  ↓
+        ↓
 main
 ```
 
-禁止把实现代码直接提交到 `main` 后再补 Issue 或补 PR。
+Codex 不得直接实现 `PLANNED` 页面。
 
-PR 正文必须关联 Issue，并说明：
+GitHub Issue 必须满足 Canonical Standard 的 READY Gate；随后 Codex 仍必须通过 Task Contract 核实当前 `main`。
 
-- 实际改变了什么行为；
-- 实际修改范围是否超出预期；
-- Reuse Targets 是否被复用；
-- 是否改变 invariant / architecture / API；
-- Failure Behavior 是否与合同一致；
-- 执行了哪些验证；
-- 哪些验证无法执行；
-- 是否触发过 Stop Condition，以及如何处理。
+## Conflict rule
 
-## 8. BurnCloud Node Issue 额外规则
+如果本仓库的 Issue Form、Task Contract、Agent Rule 或 CI 与 Canonical Standard 发生语义冲突：
 
-BurnCloud Node 的所有实施 Issue 还必须遵守：
+1. 不得自行选择更宽松的解释；
+2. 不得为了完成任务扩大权限；
+3. 停止实现并报告冲突；
+4. 通过独立 Pull Request 修正执行层或 Canonical Standard。
 
-1. 优先复用现有 BurnCloud Server、Router、Database、Model Service、Download、Monitor 能力。
-2. 不得创建第二套 Gateway、Router、Downloader、Database 或模型系统，除非先通过独立 Architecture Issue 证明必要性。
-3. Local Model 必须通过现有 Router 的 Channel / Ability 体系进入数据面，不创建旁路路由。
-4. Resolver 负责选择，不负责下载和启动进程。
-5. Runtime 负责定义“如何运行”；Process Manager 负责实际进程生命周期。
-6. `Process Spawned != Model READY`；只有 readiness / health 成功后才能接入真实流量。
-7. 每个 Node Issue 必须链接 BurnCloud Node 实施计划中的对应子页面。
-8. BurnCloud Node 实施计划页面默认是 `PLANNED`；不得直接作为 Codex 实现授权。
-
-## 9. 不要把 Issue 写成实现脚本
-
-Issue 应锁定：
-
-```text
-WHAT
-WHY
-ENTRY
-REUSE
-BOUNDARY
-CONTRACT
-FAILURE
-STOP CONDITIONS
-VERIFICATION
-DONE
-```
-
-但通常不应提前锁定：
-
-```text
-具体文件改第几行
-必须创建哪个新 struct
-必须新增哪个函数名
-具体内部实现算法
-```
-
-除非这些内容已经是接受的公共合同或架构决定。
-
-目标是限制 AI 的**架构权限**，不是取消它根据当前源码选择最小实现方式的能力。
-
-## 10. Issue Form
-
-仓库 `.github/ISSUE_TEMPLATE/engineering_task.yml` 是本标准的交互式入口。
-
-Issue Form 负责收集最小结构；本文件定义语义。Issue Form 不能替代源码调查、Evidence Audit 或 Task Contract。
+本仓库的执行文件可以强化约束，但不能另行定义一套冲突的 Issue 语义。

--- a/docs/agent/ISSUE_STANDARD.md
+++ b/docs/agent/ISSUE_STANDARD.md
@@ -1,0 +1,232 @@
+---
+doc_id: agent.issue-standard
+doc_type: agent-protocol
+truth: normative
+status: active
+---
+
+# BurnCloud Issue 标准
+
+Issue 是进入 BurnCloud 工程执行系统的第一份边界合同。它的职责不是描述“想做什么”这么简单，而是把一个需求压缩成 **单一、可验证、可审查、可转换成 Task Contract 的工程任务**。
+
+Issue 本身不是事实来源。当前行为必须由源码、测试、运行证据或现有规范证明；如果证据不足，必须标记为 `UNKNOWN`，不能把猜测写成当前事实。
+
+## 1. 核心原则
+
+每个工程 Issue 必须满足：
+
+1. **Single Outcome** — 一个 Issue 只交付一个主要可观察结果。
+2. **Evidence First** — 当前行为必须引用证据，不能依赖聊天记忆。
+3. **Bounded Scope** — 明确允许修改的领域，以及默认禁止跨越的边界。
+4. **Invariant Aware** — 列出会受到影响的不变量；如果不知道，先调查。
+5. **Verifiable Done** — 完成条件必须可以通过测试、运行路径或明确检查验证。
+6. **No Hidden Architecture Change** — Issue 不得把架构变更伪装成普通实现任务。
+7. **No Bundle Issues** — 不把多个独立能力、多个 Phase 或“顺手重构”打包进同一个 Issue。
+
+## 2. Issue 与 Task Contract 的关系
+
+流程固定为：
+
+```text
+Implementation Plan
+      ↓
+Engineering Issue
+      ↓
+Task Contract
+      ↓
+Source / Tests / Invariants
+      ↓
+Implementation
+      ↓
+Pull Request
+      ↓
+Verification
+```
+
+Issue 定义 **任务边界和验收目标**；`TASK_CONTRACT.md` 在真正修改代码前，把 Issue 再转换成当前代码证据下的执行合同。
+
+如果代码调查发现 Issue 的假设不成立：
+
+- 不得为了“完成 Issue”强行修改系统；
+- 更新 Task Contract；
+- 必要时回到 Issue 重新修订目标或拆分任务。
+
+## 3. 必填结构
+
+每个非平凡工程 Issue 至少包含以下部分。
+
+### 3.1 标题
+
+格式：
+
+```text
+[domain] observable outcome
+```
+
+BurnCloud Node 示例：
+
+```text
+[node] establish canonical HardwareProfile
+[node] detect NVIDIA GPU and VRAM
+[node] register READY local runtime as existing Channel
+```
+
+标题描述结果，不描述文件名，也不要使用 `misc`、`cleanup`、`improve` 这类不可验证词语。
+
+### 3.2 目标（Goal）
+
+说明用户、运维人员或系统最终能够观察到什么。
+
+### 3.3 当前事实（Current Evidence）
+
+必须引用当前源码、测试、运行路径或规范。
+
+证据使用统一分类：
+
+- `STATIC CONFIRMED`
+- `DYNAMIC`
+- `INFERRED`
+- `UNKNOWN`
+- `RUNTIME VERIFIED`
+
+### 3.4 期望行为（Expected Behavior）
+
+描述完成后的外部行为或稳定内部合同。
+
+### 3.5 范围（Scope）
+
+必须同时写：
+
+```text
+Allowed
+Avoid
+```
+
+`Allowed` 表示预期工作边界，不等于可以任意修改其中所有代码。
+
+`Avoid` 表示默认不可跨越的边界。如果调查证明根因必须跨越，应先更新 Task Contract，而不是静默扩张 Diff。
+
+### 3.6 影响面（Impact）
+
+至少判断：
+
+- persistence
+- external calls
+- billing / usage / quota
+- auth / authorization
+- routing / provider
+- concurrency / transactions
+- public API / CLI
+- process / runtime lifecycle
+
+没有影响时明确写 `none`。
+
+### 3.7 Invariants
+
+列出相关 `INV-*`；如果 Issue 提议改变 invariant，必须明确标记：
+
+```text
+ARCHITECTURE / INVARIANT CHANGE REQUIRED
+```
+
+这种 Issue 不得作为普通功能 Issue 静默实现。
+
+### 3.8 验证（Verification）
+
+至少定义：
+
+- targeted test
+- regression check
+- runtime / E2E check（适用时）
+
+不能只写“测试通过”。
+
+### 3.9 完成条件（Done When）
+
+使用可观察条件，例如：
+
+```text
+- HardwareProfile contains GPU model and VRAM on a supported NVIDIA host.
+- Existing CPU / RAM / Disk reporting remains unchanged.
+- Resolver consumes HardwareProfile rather than probing GPU independently.
+```
+
+## 4. Issue 大小标准
+
+一个 Issue 应当尽量满足：
+
+```text
+one primary capability
+one primary owner/domain
+one reviewable behavior change
+one independently verifiable completion point
+```
+
+出现以下情况应拆分：
+
+- 同时新增 API + 数据库迁移 + Runtime；
+- 同时实现两个相互独立的组件；
+- 一个 Issue 需要多个互不依赖的“Done When”；
+- 完成一半后系统已经形成独立可验证价值；
+- Issue 名称需要使用“以及 / and”连接两个主要能力。
+
+不要为了追求小 Issue 而按文件或函数机械拆分。拆分单位是 **行为与责任边界**。
+
+## 5. Issue 状态语义
+
+建议使用以下状态理解，而不是把 Issue 当事实：
+
+```text
+PLANNED      已进入实施计划，但尚未开始
+READY        目标、边界、依赖、验收条件足够明确
+IN PROGRESS  已有执行分支 / PR
+BLOCKED      被外部依赖或架构决策阻塞
+DONE         对应 PR 已合并且完成验证
+SUPERSEDED   被新的 Issue / 决策替代
+```
+
+`PLANNED` 不代表代码已经存在；`DONE` 才能转化为“已实现”的候选事实，并且仍应由代码/测试/运行证据确认。
+
+## 6. Pull Request 规则
+
+所有实现 Issue 必须通过 Pull Request 进入 `main`。
+
+```text
+Issue
+  ↓
+feature/fix branch
+  ↓
+Pull Request
+  ↓
+Review + CI + Verification
+  ↓
+main
+```
+
+禁止把实现代码直接提交到 `main` 后再补 Issue 或补 PR。
+
+PR 应在正文中关联 Issue，并说明：
+
+- 实际改变了什么行为；
+- 是否扩大了 Issue Scope；
+- 是否改变 invariant / architecture / API；
+- 执行了哪些验证；
+- 哪些验证无法执行。
+
+## 7. BurnCloud Node Issue 额外规则
+
+BurnCloud Node 的所有实施 Issue 还必须遵守：
+
+1. 优先复用现有 BurnCloud Server、Router、Database、Model Service、Download、Monitor 能力。
+2. 不得创建第二套 Gateway、Router、Downloader、Database 或模型系统，除非先通过独立架构 Issue 证明必要性。
+3. Local Model 必须通过现有 Router 的 Channel / Ability 体系进入数据面，不创建旁路路由。
+4. Resolver 负责选择，不负责下载和启动进程。
+5. Runtime 负责构造运行方式，Process Manager 负责实际进程生命周期。
+6. `Process Spawned != Model READY`；只有 readiness / health 成功后才能接入真实流量。
+7. 每个 Node Issue 必须链接 BurnCloud Node 实施计划中的对应子页面。
+
+## 8. Issue Form
+
+仓库 `.github/ISSUE_TEMPLATE/engineering_task.yml` 是本标准的交互式入口。
+
+Issue Form 负责强制收集最小信息；本文件负责定义语义。Issue Form 不能替代源码调查和 Task Contract。

--- a/docs/agent/ISSUE_STANDARD.md
+++ b/docs/agent/ISSUE_STANDARD.md
@@ -7,9 +7,13 @@ status: active
 
 # BurnCloud Issue 标准
 
-Issue 是进入 BurnCloud 工程执行系统的第一份边界合同。它的职责不是描述“想做什么”这么简单，而是把一个需求压缩成 **单一、可验证、可审查、可转换成 Task Contract 的工程任务**。
+Issue 是进入 BurnCloud 工程执行系统的第一份**任务权限合同**。它不是简单描述“想做什么”，而是把一个需求压缩成 **单一、可验证、可审查、可停止、可转换成 Task Contract 的工程任务**。
 
-Issue 本身不是事实来源。当前行为必须由源码、测试、运行证据或现有规范证明；如果证据不足，必须标记为 `UNKNOWN`，不能把猜测写成当前事实。
+Issue 本身不是事实来源。当前行为必须由源码、测试、运行证据或已接受规范证明；证据不足时必须标记 `UNKNOWN`，不能把计划、聊天记录或 AI 推断写成当前事实。
+
+最重要的规则：
+
+> **PLANNED 不等于可以编码。Codex 只能实现已经通过 READY Gate 的 Issue。**
 
 ## 1. 核心原则
 
@@ -17,41 +21,55 @@ Issue 本身不是事实来源。当前行为必须由源码、测试、运行�
 
 1. **Single Outcome** — 一个 Issue 只交付一个主要可观察结果。
 2. **Evidence First** — 当前行为必须引用证据，不能依赖聊天记忆。
-3. **Bounded Scope** — 明确允许修改的领域，以及默认禁止跨越的边界。
-4. **Invariant Aware** — 列出会受到影响的不变量；如果不知道，先调查。
-5. **Verifiable Done** — 完成条件必须可以通过测试、运行路径或明确检查验证。
-6. **No Hidden Architecture Change** — Issue 不得把架构变更伪装成普通实现任务。
-7. **No Bundle Issues** — 不把多个独立能力、多个 Phase 或“顺手重构”打包进同一个 Issue。
+3. **Known Entry** — 必须知道从哪个真实入口或源码起点开始调查。
+4. **Reuse Before Create** — 必须先声明应复用的现有组件，再允许新增抽象。
+5. **Bounded Scope** — 明确允许修改的领域，以及默认禁止跨越的边界。
+6. **Explicit Contract** — 对跨组件能力明确输入、输出和稳定语义，而不是让实现者自行命名和解释。
+7. **Explicit Failure** — 失败行为必须定义；不得用静默 fallback 掩盖失败。
+8. **Invariant Aware** — 列出会受到影响的不变量；如果不知道，先调查。
+9. **Stop Instead of Widen** — 一旦需要越权修改，停止并报告，不得为了完成 Issue 自动扩大范围。
+10. **Verifiable Done** — 完成条件必须可以通过测试、运行路径或明确检查验证。
+11. **No Hidden Architecture Change** — 架构或 invariant 变化必须独立暴露，不得伪装成普通功能实现。
+12. **No Bundle Issues** — 不把多个独立能力、多个 Phase 或“顺手重构”塞进同一个 Issue。
 
-## 2. Issue 与 Task Contract 的关系
+## 2. 三层职责：Plan、Issue、Task Contract
 
-流程固定为：
+三层不能互相替代：
 
 ```text
 Implementation Plan
+“未来准备做什么”
       ↓
-Engineering Issue
+Evidence Audit
+      ↓
+READY Engineering Issue
+“批准实现什么、边界是什么、什么情况下必须停止”
       ↓
 Task Contract
+“基于当前 main，具体从哪里改、真实执行路径和验证目标是什么”
       ↓
-Source / Tests / Invariants
+Codex / Coding Agent
       ↓
-Implementation
+Candidate Patch
       ↓
 Pull Request
       ↓
-Verification
+Verification / Review
 ```
 
-Issue 定义 **任务边界和验收目标**；`TASK_CONTRACT.md` 在真正修改代码前，把 Issue 再转换成当前代码证据下的执行合同。
+### Implementation Plan
 
-如果代码调查发现 Issue 的假设不成立：
+可以包含长期目标、类别、依赖和 `PLANNED` 能力，但不能被当作当前实现事实，也不能直接授权 Codex 编码。
 
-- 不得为了“完成 Issue”强行修改系统；
-- 更新 Task Contract；
-- 必要时回到 Issue 重新修订目标或拆分任务。
+### Engineering Issue
 
-## 3. 必填结构
+定义任务目标、权限边界、稳定合同、失败语义、验证目标和停止条件。只有 `READY` Issue 才具有实现授权。
+
+### Task Contract
+
+Codex 在真正修改代码前，必须基于**当前 `main`**重新核实入口、执行路径、源码证据和测试位置。Issue 中的事实如果已经过期，必须停止或更新合同，而不是强行实现旧计划。
+
+## 3. Issue 必填结构
 
 每个非平凡工程 Issue 至少包含以下部分。
 
@@ -63,7 +81,7 @@ Issue 定义 **任务边界和验收目标**；`TASK_CONTRACT.md` 在真正修�
 [domain] observable outcome
 ```
 
-BurnCloud Node 示例：
+示例：
 
 ```text
 [node] establish canonical HardwareProfile
@@ -71,17 +89,17 @@ BurnCloud Node 示例：
 [node] register READY local runtime as existing Channel
 ```
 
-标题描述结果，不描述文件名，也不要使用 `misc`、`cleanup`、`improve` 这类不可验证词语。
+标题描述结果，不描述文件名，也不要使用 `misc`、`cleanup`、`improve` 等不可验证词语。
 
 ### 3.2 目标（Goal）
 
-说明用户、运维人员或系统最终能够观察到什么。
+说明用户、运维人员或系统最终能够观察到什么。只允许一个主要结果。
 
-### 3.3 当前事实（Current Evidence）
+### 3.3 当前事实与证据（Current Evidence）
 
-必须引用当前源码、测试、运行路径或规范。
+必须引用当前源码、测试、运行路径或已接受规范。
 
-证据使用统一分类：
+统一证据分类：
 
 - `STATIC CONFIRMED`
 - `DYNAMIC`
@@ -89,11 +107,95 @@ BurnCloud Node 示例：
 - `UNKNOWN`
 - `RUNTIME VERIFIED`
 
-### 3.4 期望行为（Expected Behavior）
+任何 `INFERRED` / `UNKNOWN` 都不能被写成锁定架构事实。
+
+### 3.4 入口 / 调查起点（Entry / Starting Point）
+
+必须给 Codex 一个真实起点，例如：
+
+```text
+CLI: burncloud node
+Route: POST /v1/chat/completions
+Source: src/main.rs :: main
+Source: crates/server/src/lib.rs :: start_server
+```
+
+这里的目的不是提前写死完整调用链，而是防止 Agent 从全仓库漫游并自行发明入口。
+
+### 3.5 复用目标（Reuse Targets）
+
+明确本 Issue 应优先复用哪些现有能力，例如：
+
+```text
+Reuse:
+- existing burncloud-server startup
+- existing ModelRouter
+- existing DownloadManager
+
+Do not recreate:
+- second HTTP server
+- second router
+- second downloader
+```
+
+如果调查后发现现有组件不能承担职责，必须先报告原因；不得直接创建第二套实现。
+
+### 3.6 期望行为（Expected Behavior）
 
 描述完成后的外部行为或稳定内部合同。
 
-### 3.5 范围（Scope）
+### 3.7 行为合同（Behavior Contract）
+
+对跨组件能力必须明确：
+
+```text
+Inputs
+Outputs
+Ownership
+Side effects
+```
+
+这里定义**语义**，不规定具体 Rust struct、函数名或文件布局，除非已有接受的合同已经锁定这些名称。
+
+例如 Model Resolver：
+
+```text
+Inputs:
+- canonical model identity
+- HardwareProfile
+- ModelManifest
+- RuntimeCapabilities
+
+Output semantics:
+- selected variant
+- runtime requirement
+- artifact reference
+- resource requirements
+- selection reason
+
+Side effects:
+- none
+```
+
+### 3.8 失败行为（Failure Behavior）
+
+必须明确失败时系统做什么，以及禁止做什么。
+
+例如：
+
+```text
+No compatible variant:
+- return explicit structured failure
+
+Forbidden fallback:
+- do not choose an arbitrary artifact
+- do not silently route to Provider
+- do not trigger download unless this Issue explicitly owns preparation
+```
+
+不得把“让流程继续跑”作为默认正确行为。
+
+### 3.9 范围（Scope）
 
 必须同时写：
 
@@ -102,11 +204,11 @@ Allowed
 Avoid
 ```
 
-`Allowed` 表示预期工作边界，不等于可以任意修改其中所有代码。
+`Allowed` 是预期权限边界，不代表可以任意修改列出的所有代码。
 
-`Avoid` 表示默认不可跨越的边界。如果调查证明根因必须跨越，应先更新 Task Contract，而不是静默扩张 Diff。
+`Avoid` 是默认不可跨越的领域。如果源码证据证明必须跨越，不得直接扩大 Diff；先触发 Stop Condition，再更新 Issue / Task Contract 或拆分新的 Issue。
 
-### 3.6 影响面（Impact）
+### 3.10 影响面（Impact）
 
 至少判断：
 
@@ -119,31 +221,67 @@ Avoid
 - public API / CLI
 - process / runtime lifecycle
 
-没有影响时明确写 `none`。
+没有影响时明确写 `none`，不能省略。
 
-### 3.7 Invariants
+### 3.11 Invariants / Architecture
 
-列出相关 `INV-*`；如果 Issue 提议改变 invariant，必须明确标记：
+列出相关 `INV-*`。
+
+如果 Issue 需要改变 invariant 或架构边界，必须写：
 
 ```text
 ARCHITECTURE / INVARIANT CHANGE REQUIRED
 ```
 
-这种 Issue 不得作为普通功能 Issue 静默实现。
+这种变化不能被普通 Feature / Bug Issue 自行批准。
 
-### 3.8 验证（Verification）
+### 3.12 依赖与阻塞（Dependencies / Blockers）
+
+列出前置 Issue、架构决策、外部环境或测试资产。
+
+进入 `READY` 前，硬依赖必须已经完成或被明确豁免；不能让 Codex 一边实现当前 Issue，一边顺手实现前置 Issue。
+
+### 3.13 停止条件（Stop Conditions）
+
+这是 Codex 的硬边界。至少考虑：
+
+```text
+STOP IF:
+- current source disproves a material Issue assumption
+- implementation requires changing an Avoid domain
+- implementation requires architecture / invariant change not declared by the Issue
+- implementation requires a new duplicate source of truth or duplicate subsystem
+- a required dependency is not actually available
+- required verification cannot be meaningfully performed
+```
+
+触发 Stop Condition 时：
+
+```text
+Do not widen scope.
+Do not repair unrelated modules.
+Do not rewrite the requirement to fit the patch.
+Report the conflict and the evidence.
+```
+
+### 3.14 验证目标（Verification Targets）
 
 至少定义：
 
-- targeted test
-- regression check
-- runtime / E2E check（适用时）
+```text
+Targeted
+Regression
+Runtime / E2E (when applicable)
+Protected behavior
+```
 
-不能只写“测试通过”。
+不能只写“tests pass”。
 
-### 3.9 完成条件（Done When）
+规划阶段如果无法安全确定具体命令，可以先锁定验证目标；Task Contract 再根据当前仓库确定真实命令和测试路径。
 
-使用可观察条件，例如：
+### 3.15 完成条件（Done When）
+
+必须使用独立可观察、可验证条件，例如：
 
 ```text
 - HardwareProfile contains GPU model and VRAM on a supported NVIDIA host.
@@ -151,9 +289,11 @@ ARCHITECTURE / INVARIANT CHANGE REQUIRED
 - Resolver consumes HardwareProfile rather than probing GPU independently.
 ```
 
+`Done When` 不是实现步骤清单，而是验收合同。
+
 ## 4. Issue 大小标准
 
-一个 Issue 应当尽量满足：
+一个 Issue 应尽量满足：
 
 ```text
 one primary capability
@@ -166,35 +306,92 @@ one independently verifiable completion point
 
 - 同时新增 API + 数据库迁移 + Runtime；
 - 同时实现两个相互独立的组件；
-- 一个 Issue 需要多个互不依赖的“Done When”；
-- 完成一半后系统已经形成独立可验证价值；
-- Issue 名称需要使用“以及 / and”连接两个主要能力。
+- 一个 Issue 存在多个互不依赖的主要结果；
+- 完成一半后已经形成独立可验证价值；
+- 标题必须使用“以及 / and”才能描述两个主要能力；
+- Agent 必须获得第二个领域的架构权限才能把第一个能力做完。
 
-不要为了追求小 Issue 而按文件或函数机械拆分。拆分单位是 **行为与责任边界**。
+不要为了追求小 Issue 而按文件或函数机械拆分。拆分单位是**行为和责任边界**。
 
-## 5. Issue 状态语义
+## 5. Issue 状态与 READY Gate
 
-建议使用以下状态理解，而不是把 Issue 当事实：
+状态语义：
 
 ```text
-PLANNED      已进入实施计划，但尚未开始
-READY        目标、边界、依赖、验收条件足够明确
-IN PROGRESS  已有执行分支 / PR
-BLOCKED      被外部依赖或架构决策阻塞
-DONE         对应 PR 已合并且完成验证
+PLANNED      已进入实施计划，但尚未获得实现授权
+READY        已通过 Evidence Audit 和 READY Gate，可交给 Codex
+IN PROGRESS  已有执行分支 / Candidate Patch / PR
+BLOCKED      被依赖、证据缺口或架构决策阻塞
+DONE         对应 PR 已合并且要求的验证完成
 SUPERSEDED   被新的 Issue / 决策替代
 ```
 
-`PLANNED` 不代表代码已经存在；`DONE` 才能转化为“已实现”的候选事实，并且仍应由代码/测试/运行证据确认。
+### READY Gate
 
-## 6. Pull Request 规则
+Issue 只有同时满足以下条件才能标记 `READY`：
+
+```text
+[ ] Single Outcome 明确
+[ ] 硬依赖已 DONE 或明确豁免
+[ ] Current Evidence 已按当前 main 核实
+[ ] Entry / Starting Point 已确定
+[ ] Reuse Targets 已确定
+[ ] Allowed / Avoid 已确定
+[ ] Behavior Contract 已确定（适用时）
+[ ] Failure Behavior 已确定
+[ ] Impact 已完整判断
+[ ] Relevant Invariants 已确定
+[ ] Verification Targets 已确定
+[ ] Done When 可独立验证
+[ ] Stop Conditions 已确定
+[ ] 未隐藏架构 / invariant 修改
+```
+
+任何一项不满足：
+
+```text
+PLANNED / BLOCKED
+```
+
+而不是交给 Codex 猜。
+
+## 6. Codex 执行授权
+
+Codex / Coding Agent 只能领取 `READY` Issue。
+
+拿到 Issue 后第一步不是写代码，而是生成或更新 Task Contract，并核实：
+
+1. Issue 的 Current Evidence 在当前 `main` 是否仍成立；
+2. Entry 是否对应真实入口；
+3. Reuse Targets 是否仍存在且职责匹配；
+4. 预计执行路径是否可以被源码证明；
+5. Scope 是否足以完成目标；
+6. Stop Conditions 是否已经触发；
+7. Verification Targets 对应的真实测试 / 命令在哪里。
+
+如果 Issue 与当前源码冲突，Codex 没有权限自行重写架构目标。
+
+正确结果是：
+
+```text
+SCOPE / ARCHITECTURE CONFLICT DETECTED
+No out-of-scope code changed.
+Evidence: ...
+Decision required: ...
+```
+
+## 7. Pull Request 规则
 
 所有实现 Issue 必须通过 Pull Request 进入 `main`。
 
 ```text
-Issue
+READY Issue
   ↓
 feature/fix branch
+  ↓
+Task Contract
+  ↓
+Candidate Patch
   ↓
 Pull Request
   ↓
@@ -205,28 +402,62 @@ main
 
 禁止把实现代码直接提交到 `main` 后再补 Issue 或补 PR。
 
-PR 应在正文中关联 Issue，并说明：
+PR 正文必须关联 Issue，并说明：
 
 - 实际改变了什么行为；
-- 是否扩大了 Issue Scope；
+- 实际修改范围是否超出预期；
+- Reuse Targets 是否被复用；
 - 是否改变 invariant / architecture / API；
+- Failure Behavior 是否与合同一致；
 - 执行了哪些验证；
-- 哪些验证无法执行。
+- 哪些验证无法执行；
+- 是否触发过 Stop Condition，以及如何处理。
 
-## 7. BurnCloud Node Issue 额外规则
+## 8. BurnCloud Node Issue 额外规则
 
 BurnCloud Node 的所有实施 Issue 还必须遵守：
 
 1. 优先复用现有 BurnCloud Server、Router、Database、Model Service、Download、Monitor 能力。
-2. 不得创建第二套 Gateway、Router、Downloader、Database 或模型系统，除非先通过独立架构 Issue 证明必要性。
+2. 不得创建第二套 Gateway、Router、Downloader、Database 或模型系统，除非先通过独立 Architecture Issue 证明必要性。
 3. Local Model 必须通过现有 Router 的 Channel / Ability 体系进入数据面，不创建旁路路由。
 4. Resolver 负责选择，不负责下载和启动进程。
-5. Runtime 负责构造运行方式，Process Manager 负责实际进程生命周期。
+5. Runtime 负责定义“如何运行”；Process Manager 负责实际进程生命周期。
 6. `Process Spawned != Model READY`；只有 readiness / health 成功后才能接入真实流量。
 7. 每个 Node Issue 必须链接 BurnCloud Node 实施计划中的对应子页面。
+8. BurnCloud Node 实施计划页面默认是 `PLANNED`；不得直接作为 Codex 实现授权。
 
-## 8. Issue Form
+## 9. 不要把 Issue 写成实现脚本
+
+Issue 应锁定：
+
+```text
+WHAT
+WHY
+ENTRY
+REUSE
+BOUNDARY
+CONTRACT
+FAILURE
+STOP CONDITIONS
+VERIFICATION
+DONE
+```
+
+但通常不应提前锁定：
+
+```text
+具体文件改第几行
+必须创建哪个新 struct
+必须新增哪个函数名
+具体内部实现算法
+```
+
+除非这些内容已经是接受的公共合同或架构决定。
+
+目标是限制 AI 的**架构权限**，不是取消它根据当前源码选择最小实现方式的能力。
+
+## 10. Issue Form
 
 仓库 `.github/ISSUE_TEMPLATE/engineering_task.yml` 是本标准的交互式入口。
 
-Issue Form 负责强制收集最小信息；本文件负责定义语义。Issue Form 不能替代源码调查和 Task Contract。
+Issue Form 负责收集最小结构；本文件定义语义。Issue Form 不能替代源码调查、Evidence Audit 或 Task Contract。

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -14,7 +14,10 @@ They are not a repository encyclopedia. They are an execution system that routes
 ## Operating model
 
 ```text
-User Task
+Implementation Plan / User Task
+   |
+   v
+Engineering Issue
    |
    v
 Task Contract
@@ -55,7 +58,8 @@ Domain Contract       Runtime / Contract      Playbook
 - `AGENTS.md` — highest repository-level agent rules and document router.
 - `START_HERE.md` — required execution loop.
 - `TASK_ROUTER.md` — recurring behavior -> source/test starting points.
-- `TASK_CONTRACT.md` — minimum contract before non-trivial edits.
+- `ISSUE_STANDARD.md` — required structure and boundary rules for non-trivial engineering issues.
+- `TASK_CONTRACT.md` — minimum execution contract before non-trivial edits.
 
 ### 2. Domain contracts
 
@@ -97,9 +101,11 @@ Do not load the entire documentation tree by default.
 Use this path:
 
 ```text
-Task
+Issue / Task
  -> AGENTS.md
  -> START_HERE.md
+ -> ISSUE_STANDARD.md (when creating or validating an Issue)
+ -> TASK_CONTRACT.md (before non-trivial edits)
  -> TASK_ROUTER.md
  -> relevant domain/runtime/contract docs
  -> relevant invariants

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -17,7 +17,16 @@ They are not a repository encyclopedia. They are an execution system that routes
 Implementation Plan / User Task
    |
    v
-Engineering Issue
+Engineering Issue (PLANNED)
+   |
+   v
+Evidence Audit
+   |
+   v
+READY Gate
+   |
+   v
+Engineering Issue (READY)
    |
    v
 Task Contract
@@ -39,7 +48,7 @@ Domain Contract       Runtime / Contract      Playbook
                       Source Code
                           |
                           v
-                        Change
+                   Candidate Patch
                           |
                           v
                     Verification
@@ -49,7 +58,12 @@ Domain Contract       Runtime / Contract      Playbook
                           |
                           v
                     Evidence Report
+                          |
+                          v
+                    Pull Request
 ```
+
+A planning page does not authorize implementation. Codex / Coding Agents may implement only a `READY` Issue, or an explicit direct user task that is converted into an equivalent Task Contract before editing.
 
 ## Documentation layers
 
@@ -58,8 +72,8 @@ Domain Contract       Runtime / Contract      Playbook
 - `AGENTS.md` — highest repository-level agent rules and document router.
 - `START_HERE.md` — required execution loop.
 - `TASK_ROUTER.md` — recurring behavior -> source/test starting points.
-- `ISSUE_STANDARD.md` — required structure and boundary rules for non-trivial engineering issues.
-- `TASK_CONTRACT.md` — minimum execution contract before non-trivial edits.
+- `ISSUE_STANDARD.md` — issue authority, READY Gate, scope, contract, failure, stop, and verification rules.
+- `TASK_CONTRACT.md` — current-main execution contract before non-trivial edits.
 
 ### 2. Domain contracts
 
@@ -101,11 +115,14 @@ Do not load the entire documentation tree by default.
 Use this path:
 
 ```text
-Issue / Task
+Plan / User Task
+ -> ISSUE_STANDARD.md
+ -> Evidence Audit
+ -> READY Gate
+ -> READY Issue
  -> AGENTS.md
  -> START_HERE.md
- -> ISSUE_STANDARD.md (when creating or validating an Issue)
- -> TASK_CONTRACT.md (before non-trivial edits)
+ -> TASK_CONTRACT.md
  -> TASK_ROUTER.md
  -> relevant domain/runtime/contract docs
  -> relevant invariants
@@ -113,6 +130,21 @@ Issue / Task
 ```
 
 Only open additional documents when the current task crosses that boundary.
+
+## Agent authority model
+
+The execution agent owns implementation choices only inside the approved task boundary.
+
+It does **not** own the authority to:
+
+- promote a PLANNED item to implemented reality by assumption;
+- redefine architecture to make an Issue easier;
+- silently cross Avoid boundaries;
+- create duplicate sources of truth or parallel subsystems without approval;
+- change failure semantics merely to keep the happy path running;
+- weaken tests, invariants, or documentation to legitimize its patch.
+
+When current evidence conflicts with the Issue, the correct result is a conflict report, not broader code changes.
 
 ## Evidence vocabulary
 
@@ -157,6 +189,7 @@ Did a runtime path change?
 Did an invariant change?
 Did verification ownership change?
 Did a contract/architecture fact change?
+Did the Implementation Plan status need to change?
 ```
 
 Update only the documents whose declared truth changed. Avoid documentation churn for refactors that preserve all externally relevant truths.

--- a/docs/agent/TASK_CONTRACT.md
+++ b/docs/agent/TASK_CONTRACT.md
@@ -7,43 +7,76 @@ status: active
 
 # Task Contract
 
-A Task Contract converts a user request into an explicit engineering boundary before a non-trivial edit begins.
+A Task Contract converts a READY engineering issue or user task into an explicit execution boundary before a non-trivial edit begins.
 
-It exists to prevent three common agent failures:
+It exists to prevent four common agent failures:
 
 1. editing before understanding current behavior;
 2. expanding scope while solving the task;
-3. declaring completion without an explicit proof target.
+3. inventing new abstractions instead of reusing current ones;
+4. declaring completion without an explicit proof target.
+
+A Task Contract does not grant more authority than its parent Issue. It may narrow the implementation scope after source investigation, but it must not silently widen the approved architecture boundary.
 
 ## When required
 
-Use a Task Contract for any change that can affect runtime behavior, public/API behavior, persistence, routing, auth, billing, provider execution, concurrency, migrations, cross-crate APIs, or multiple files with coupled behavior.
+Use a Task Contract for any change that can affect runtime behavior, public/API behavior, persistence, routing, auth, billing, provider execution, concurrency, migrations, cross-crate APIs, process/runtime lifecycle, or multiple files with coupled behavior.
 
 A trivial typo or purely local documentation correction does not require a formal contract.
+
+If the task comes from a GitHub Issue, implementation must not begin unless that Issue is `READY` according to `ISSUE_STANDARD.md`.
 
 ## Minimum template
 
 ```yaml
+issue:
+  id: ISSUE-123 | none
+  status: READY | direct-user-task
+  plan_page: optional
+
 goal:
   Observable user/operator outcome.
 
 current_behavior:
   What current evidence proves today.
 
+entry:
+  Real route, CLI command, UI event, background trigger, source symbol, or other starting point.
+
+execution_path:
+  Smallest currently verified path relevant to the change.
+  Mark uncertain edges INFERRED / UNKNOWN instead of inventing them.
+
+reuse_targets:
+  - Existing components/contracts that should be reused.
+
+do_not_recreate:
+  - Duplicate subsystems or sources of truth forbidden by the Issue.
+
 expected_behavior:
   Observable behavior after the change.
 
-entry:
-  Route, CLI command, UI event, background trigger, or other real entrypoint.
+behavior_contract:
+  inputs:
+    - Semantic inputs.
+  outputs:
+    - Semantic outputs.
+  ownership:
+    - Which component owns the behavior/state.
+  side_effects:
+    - none | explicit side effects.
 
-execution_path:
-  Smallest verified path relevant to the change.
+failure_behavior:
+  on_failure:
+    - Explicit failure semantics.
+  forbidden_fallbacks:
+    - Silent fallback behaviors that would change system meaning.
 
 scope:
   allowed:
     - Intended files/domains/components.
   avoid:
-    - Boundaries that should not change unless new evidence requires it.
+    - Boundaries that must not change without a new decision.
 
 domains:
   - Relevant ownership domains.
@@ -55,28 +88,70 @@ impact:
   auth_authorization: none | describe
   routing_provider: none | describe
   concurrency_transactions: none | describe
+  public_api_cli: none | describe
+  process_runtime_lifecycle: none | describe
 
 invariants:
   - IDs from INVARIANTS.md, or explicit candidate invariants requiring review.
 
+dependencies:
+  - Required Issue / decision / environment / test asset, or none.
+
 evidence:
-  - path/to/file.rs :: SymbolName
-  - path/to/test.rs :: test_name
+  - STATIC CONFIRMED — path/to/file.rs :: SymbolName
+  - RUNTIME VERIFIED — runtime evidence
+
+stop_conditions:
+  - Conditions that require stopping instead of widening scope.
 
 verification:
-  - Targeted checks.
-  - Regression checks.
-  - Runtime/E2E checks when needed.
+  targeted:
+    - Concrete targeted checks/tests.
+  regression:
+    - Existing behaviors that must remain green.
+  runtime_e2e:
+    - Runtime/E2E checks when applicable.
+  protected_behavior:
+    - High-value semantics that must not be weakened.
 
 done_when:
   - Observable completion criteria.
 ```
 
+## Preflight rule
+
+Before editing, compare the parent Issue with current `main` and answer:
+
+1. Does the Issue evidence still hold?
+2. Is the stated Entry real?
+3. Do the Reuse Targets still exist and own the expected responsibility?
+4. Can the relevant execution path be proven far enough to make a bounded change?
+5. Are all hard dependencies actually available?
+6. Is the approved scope sufficient without crossing an Avoid boundary?
+7. Is any architecture/invariant change now required that the Issue did not authorize?
+8. Can the required verification be meaningfully executed?
+
+If the answer exposes a material conflict, stop before implementation.
+
 ## Scope discipline
 
-`allowed` is not permission to blindly edit every listed file. It describes the anticipated boundary.
+`allowed` is not permission to blindly edit every listed file. It describes the anticipated authority boundary.
 
-`avoid` is not an absolute prohibition. If source evidence proves the root cause crosses that boundary, update the task contract before expanding the change.
+`avoid` is not an invitation to cross the boundary after discovering inconvenience. If source evidence proves the requested outcome requires an Avoid-domain change, trigger a Stop Condition and report the conflict. Update or split the Issue before continuing.
+
+Do not use “repair by widening scope.”
+
+## Reuse discipline
+
+If an Issue names a Reuse Target, inspect it before creating a replacement abstraction.
+
+A new parallel subsystem, duplicate source of truth, duplicate router/gateway/downloader/state store, or equivalent architectural fork requires explicit evidence and architecture approval. Convenience is not sufficient justification.
+
+## Contract discipline
+
+The Task Contract locks semantic behavior, not arbitrary implementation details.
+
+Preserve the Issue's Inputs / Outputs / Ownership / Side Effects and Failure Behavior unless current evidence proves the Issue is invalid. In that case stop and report; do not silently rewrite the contract to match the patch.
 
 ## Evidence discipline
 
@@ -88,14 +163,53 @@ Classify material execution claims as:
 - UNKNOWN;
 - RUNTIME VERIFIED.
 
-Do not list an inferred call path as evidence without labeling the uncertain edge.
+Do not list an inferred call path as confirmed evidence. Do not convert planning documents or comments into higher-authority runtime facts.
+
+## Stop rule
+
+When any Stop Condition is triggered:
+
+```text
+SCOPE / ARCHITECTURE CONFLICT DETECTED
+No out-of-scope code changed.
+Evidence: ...
+Conflict: ...
+Decision required: ...
+```
+
+The agent must not:
+
+- widen scope on its own;
+- modify unrelated modules to make tests green;
+- create a duplicate subsystem to avoid an existing boundary;
+- weaken tests or failure semantics to fit the implementation;
+- modify architecture/invariant docs merely to legitimize the patch.
 
 ## Root-cause rule
 
 For bug fixes, the contract should contain the observed failure and the smallest evidence-backed root cause before implementation when the root cause can be established.
 
-Do not force a false root cause when evidence is incomplete. Mark it UNKNOWN and continue investigation.
+Do not force a false root cause when evidence is incomplete. Mark it `UNKNOWN` and continue investigation only within the approved authority boundary.
+
+## Verification rule
+
+Verification must distinguish:
+
+- **Targeted** — proves the new/change behavior;
+- **Regression** — proves relevant existing behavior is preserved;
+- **Runtime/E2E** — proves dynamic behavior where static tests are insufficient;
+- **Protected behavior** — proves important invariant semantics were not weakened.
+
+A patch author adding only new tests for its own new abstraction is not sufficient when existing behavior can regress.
 
 ## Completion rule
 
-The task contract is satisfied only when the final diff remains within the evidence-backed scope, required verification has been run or explicitly reported as unavailable, and the applicable Definition of Done is met.
+The Task Contract is satisfied only when:
+
+1. the final diff remains within the evidence-backed authority boundary;
+2. Reuse Targets were reused or an explicit approved decision explains why not;
+3. Behavior Contract and Failure Behavior are preserved;
+4. no Stop Condition remains unresolved;
+5. required verification has been run or explicitly reported as unavailable;
+6. applicable invariants and Definition of Done are satisfied;
+7. the change enters `main` only through a Pull Request.


### PR DESCRIPTION
## 目标

让 `burncloud/burncloud` 执行 BurnCloud Node 的 Canonical Issue Standard，而不是在主代码仓库维护第二套规范正文。

Canonical Standard 由文档仓库 PR #12 定义：

https://github.com/burncloud/burncloud.github.io/pull/12

发布后规范地址：

https://burncloud.github.io/burncloud-node/implementation-plan/issue-standard/

## Source of Truth

- `burncloud.github.io`：定义 Issue 的规范语义、READY Gate、Stop Conditions、Codex 授权模型。
- `burncloud/burncloud`：只负责执行规范。

本 PR 中 `docs/agent/ISSUE_STANDARD.md` 现在只是 Canonical Standard 的 repository enforcement adapter，不再重复维护完整规范。

## 本仓库执行机制

- `.github/ISSUE_TEMPLATE/engineering_task.yml`：结构化收集 READY Engineering Issue 所需字段
- `docs/agent/TASK_CONTRACT.md`：Codex 开工前基于 current main 重新核实真实执行路径
- Agent Docs：将 Codex 路由到源码、测试、Invariants
- PR / CI / Verification：验证 Candidate Patch

## 执行链

```text
Implementation Plan (PLANNED)
        ↓
Evidence Audit
        ↓
READY Engineering Issue
        ↓
Task Contract against current main
        ↓
Codex / Coding Agent
        ↓
Candidate Patch
        ↓
Pull Request
        ↓
Verification / Review
        ↓
main
```

## 关键约束

- PLANNED 页面不能直接授权 Codex 编码
- Codex 只实现 READY Issue
- Task Contract 不得获得比父 Issue 更大的架构权限
- 触发 Stop Condition 时必须停止并报告，禁止 repair-by-widening-scope
- 所有实现必须通过 branch + Pull Request 进入 `main`

## 合并顺序

建议先合并 `burncloud.github.io` PR #12，使 Canonical Standard 成为正式规范；随后再合并本 PR。